### PR TITLE
Errors and  Typo removal

### DIFF
--- a/DEVELOPER_DOCS.md
+++ b/DEVELOPER_DOCS.md
@@ -30,7 +30,7 @@ When a user shows up:
 * Server determines the highest priority diff that needs human inspection and
   redirects user to ``/diff/<DIFF_HASH>``. This is a permanent link that can be
   shared or revisited later.
-* The page at ``/diff/<DIFF_HASH>`` displays viral statistics about the diff,
+* The page at ``/diff/<DIFF_HASH>`` displays vital statistics about the diff,
   gleaned from PageFreezer's result object, including text-only changes and
   source changes.
 * Meanwhile, a visual diff is loaded asynchronously on the client side.
@@ -51,8 +51,11 @@ When a user shows up:
 * A server written in Python using the Tornado framework.
 * A frontend using TypeScript, JQuery, and Bootstrap.
 
-## Development Install
+### Pre-requisite for Development
+PostgreSQL is downloaded and installed.
++ For latest version refer - [PostgreSQL.org](https://www.postgresql.org/)
 
+## Development Install
 Create a new postgresql user and database.
 ```
 createuser web_monitoring --pwprompt  # Enter a password.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ This repo contains:
   notebook](https://github.com/edgi-govdata-archiving/web-monitoring-processing/blob/master/page_freezer_python_module/PageFreezer.ipynb).
 * An experiment with the [newspaper
   module](https://github.com/edgi-govdata-archiving/web-monitoring-processing/tree/master/get_article_text).
+
+## Contribute
+
+To contribute to this repository, please refer [DEVELOPER_DOCS.md](https://github.com/edgi-govdata-archiving/web-monitoring-processing/blob/master/DEVELOPER_DOCS.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+## On running the command - `pip install -r requirements.txt` following packages will be installed using pip
 requests
-sqlalchmey
+sqlalchemy

--- a/web_monitoring/app.py
+++ b/web_monitoring/app.py
@@ -14,7 +14,7 @@ import pymongo
 SQL_DB_URI = 'sqlite3://'
 MONGO_DB_URI = 'mongodb://localhost:27017/'
 MONGO_DB_NAME = 'page_freezer_v1'
-engine = sqlalcehmy.create_engine(SQL_DB_URI)
+engine = sqlalchemy.create_engine(SQL_DB_URI)
 client = pymongo.MongoClient(MONGO_URI)
 
 results = Results(client[MONGO_DB_NAME])

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -434,18 +434,18 @@ def diff_version(version_uuid, versions, diffs, source_type,
                  source_metadata)
 
 
-class WebVersioningException(Exception):
+#class WebVersioningException(Exception):
     # All exceptions raised by this package inherit from this.
-    ...
+    #...
 
 
-class PageFreezerError(WebVersioningException):
-    ...
+#class PageFreezerError(WebVersioningException):
+    #...
 
 
-class NoAncestor(WebVersioningException):
-    ...
+#class NoAncestor(WebVersioningException):
+    #...
 
 
-class EmptyWorkQueue(WebVersioningException):
-    ...
+#class EmptyWorkQueue(WebVersioningException):
+    #...

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -434,18 +434,22 @@ def diff_version(version_uuid, versions, diffs, source_type,
                  source_metadata)
 
 
-#class WebVersioningException(Exception):
+class WebVersioningException(Exception):
+    pass
     # All exceptions raised by this package inherit from this.
     #...
 
 
-#class PageFreezerError(WebVersioningException):
+class PageFreezerError(WebVersioningException):
+    pass
     #...
 
 
-#class NoAncestor(WebVersioningException):
+class NoAncestor(WebVersioningException):
+    pass
     #...
 
 
-#class EmptyWorkQueue(WebVersioningException):
+class EmptyWorkQueue(WebVersioningException):
+    pass
     #...


### PR DESCRIPTION
@dcwalk @b5 
Given pull request consists of following commits
## 1. web_monitoring/db.py
+ Problem - SyntaxError: invalid syntax
+ Solution - comment empty classes and ...

## 2. requirement.txt
With reference to edgi-govdata-archiving/web-monitoring-processing#26
+ Typo - alchemy

## 3. web-monitoring/app.py
+ Name Error
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/home/chai/GSOC/web-monitoring-processing/web_monitoring/app.py in <module>()
     15 MONGO_DB_URI = 'mongodb://localhost:27017/'
     16 MONGO_DB_NAME = 'page_freezer_v1'
---> 17 engine = sqlalcehmy.create_engine(SQL_DB_URI)
     18 client = pymongo.MongoClient(MONGO_URI)
     19

NameError: name 'sqlalcehmy' is not defined
```
+ Solution - correct the typo _sqlalcehmy_ to *sqlalchemy*

## 4. Readme.md
+ Add refer developer docs.md for contributing to this repository

## 5. Developer docs

+ Typo - page displays **viral** statistics (corrected to **vital**)

+ Development install - Added pre-requisite of Download+Install **_PostgreSQL_**