### PR TITLE
ENH: Minimal plugable diffing server.

### DIFF
--- a/diff_config.json
+++ b/diff_config.json
@@ -1,6 +1,7 @@
 {"length": ["web_monitoring.differs", "compare_length"],
  "identical_bytes": ["web_monitoring.differs", "identical_bytes"],
  "pagefreezer": ["web_monitoring.differs", "pagefreezer"],
- "pagefreezer_direct": ["web_monitoring.differs", "pagefreezer_direct"],
- "side_by_side_text": ["web_monitoring.differs", "side_by_side_text"]
+ "side_by_side_text": ["web_monitoring.differs", "side_by_side_text"],
+ "html_text_diff": ["web_monitoring.differs", "html_text_diff"],
+ "html_source_diff": ["web_monitoring.differs", "html_source_diff"]
 }

--- a/diff_config.json
+++ b/diff_config.json
@@ -1,0 +1,4 @@
+{"dummy": ["web_monitoring.differs", "dummy"],
+ "length": ["web_monitoring.differs", "compare_length"],
+ "identical_bytes": ["web_monitoring.differs", "identical_bytes"]
+}

--- a/diff_config.json
+++ b/diff_config.json
@@ -1,4 +1,6 @@
-{"dummy": ["web_monitoring.differs", "dummy"],
- "length": ["web_monitoring.differs", "compare_length"],
- "identical_bytes": ["web_monitoring.differs", "identical_bytes"]
+{"length": ["web_monitoring.differs", "compare_length"],
+ "identical_bytes": ["web_monitoring.differs", "identical_bytes"],
+ "pagefreezer": ["web_monitoring.differs", "pagefreezer"],
+ "pagefreezer_direct": ["web_monitoring.differs", "pagefreezer_direct"],
+ "side_by_side_text": ["web_monitoring.differs", "side_by_side_text"]
 }

--- a/diff_config.json.example
+++ b/diff_config.json.example
@@ -1,2 +1,0 @@
-{"dummy": ["web_monitoring.differs", "dummy"],
- "length": ["web_monitoring.differs", "compare_length"]}

--- a/diff_config.json.example
+++ b/diff_config.json.example
@@ -1,0 +1,2 @@
+{"dummy": ["web_monitoring.differs", "dummy"],
+ "length": ["web_monitoring.differs", "compare_length"]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ lxml
 pandas
 requests
 toolz
+tornado
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bs4
+diff-match-patch
 docopt
 lxml
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bs4
 docopt
 lxml
 pandas

--- a/scripts/wm-diffing-server
+++ b/scripts/wm-diffing-server
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import sys
+from web_monitoring.diffing_server import cli
+
+
+if __name__ == '__main__':
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from distutils.core import setup
+import glob
 import os
 import setuptools
 import sys
@@ -17,7 +18,7 @@ def read(fname):
 
 setup(name='web_monitoring',
       packages=['web_monitoring'],
-      scripts=['scripts/wm'],
+      scripts=glob.glob('scripts/*'),
       install_requires=read('requirements.txt').split(),
       long_description=read('README.md'),
      )

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -5,3 +5,7 @@ def dummy(a, b, **options):
 
 def compare_length(a, b):
     return len(b) - len(a)
+
+
+def identical_bytes(a, b):
+    return a == b

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -1,4 +1,5 @@
 from bs4 import BeautifulSoup
+import diff_match_patch
 import re
 import web_monitoring.pagefreezer
 import sys
@@ -57,3 +58,35 @@ def pagefreezer_direct(a_text, b_text):
     "Dispatch to PageFreezer, the slow way."
     # Send PF the full body.
     return web_monitoring.pagefreezer.compare(a_text, b_text)
+
+
+d = diff_match_patch.diff_match_patch()
+
+def _diff(a_text, b_text):
+    return d.diff_compute(a_text, b_text, False, DEADLINE)
+
+
+def html_text_diff(a_text, b_text):
+    """
+    Example
+    ------
+    >>> text_diff('<p>Deleted</p><p>Unchanged</p>',
+    ...           '<p>Added</p><p>Unchanged</p>')
+    [(0, '<p>'), (-1, 'Delet'), (1, 'Add'), (0, 'ed</p><p>Unchanged</p>')]
+    """
+    t1 = ' '.join(_get_visible_text(a_text))
+    t2 = ' '.join(_get_visible_text(b_text))
+    DEADLINE = 2  # seconds
+    return d.diff_compute(t1, t2, checklines=False, deadline=DEADLINE)
+
+
+def html_source_diff(a_text, b_text):
+    """
+    Example
+    ------
+    >>> text_diff('<p>Deleted</p><p>Unchanged</p>',
+    ...           '<p>Added</p><p>Unchanged</p>')
+    [(-1, '<p>Deleted</p>'), (1, '<p>Added</p>'), (0, '<p>Unchanged</p>')]
+    """
+    DEADLINE = 2  # seconds
+    return d.diff_compute(a_text, b_text, checklines=False, deadline=DEADLINE)

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -59,10 +59,12 @@ d = diff_match_patch.diff_match_patch()
 
 def html_text_diff(a_text, b_text):
     """
+    Diff the visible textual content of an HTML document.
+
     Example
     ------
-    >>> text_diff('<p>Deleted</p><p>Unchanged</p>',
-    ...           '<p>Added</p><p>Unchanged</p>')
+    >>> html_text_diff('<p>Deleted</p><p>Unchanged</p>',
+    ...                '<p>Added</p><p>Unchanged</p>')
     [(0, '<p>'), (-1, 'Delet'), (1, 'Add'), (0, 'ed</p><p>Unchanged</p>')]
     """
     t1 = ' '.join(_get_visible_text(a_text))
@@ -73,11 +75,13 @@ def html_text_diff(a_text, b_text):
 
 def html_source_diff(a_text, b_text):
     """
+    Diff the full source code of an HTML document.
+
     Example
     ------
-    >>> text_diff('<p>Deleted</p><p>Unchanged</p>',
-    ...           '<p>Added</p><p>Unchanged</p>')
-    [(-1, '<p>Deleted</p>'), (1, '<p>Added</p>'), (0, '<p>Unchanged</p>')]
+    >>> html_source_diff('<p>Deleted</p><p>Unchanged</p>',
+    ...                  '<p>Added</p><p>Unchanged</p>')
+    [(0, '<p>'), (-1, 'Delet'), (1, 'Add'), (0, 'ed</p><p>Unchanged</p>')]
     """
     DEADLINE = 2  # seconds
     return d.diff_compute(a_text, b_text, checklines=False, deadline=DEADLINE)

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -54,12 +54,6 @@ def pagefreezer(a_url, b_url):
     return web_monitoring.pagefreezer.compare(a_url, b_url)
 
 
-def pagefreezer_direct(a_text, b_text):
-    "Dispatch to PageFreezer, the slow way."
-    # Send PF the full body.
-    return web_monitoring.pagefreezer.compare(a_text, b_text)
-
-
 d = diff_match_patch.diff_match_patch()
 
 def _diff(a_text, b_text):

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -1,11 +1,59 @@
-def dummy(a, b, **options):
-    # dummy example illustrating how query parameters pass through
-    return options
+from bs4 import BeautifulSoup
+import re
+import web_monitoring.pagefreezer
+import sys
 
 
-def compare_length(a, b):
-    return len(b) - len(a)
+# BeautifulSoup can sometimes exceed the default Python recursion limit (1000).
+sys.setrecursionlimit(10000)
 
 
-def identical_bytes(a, b):
-    return a == b
+def compare_length(a_body, b_body):
+    "Compute difference in response body lengths. (Does not compare contents.)"
+    return len(b_body) - len(a_body)
+
+
+def identical_bytes(a_body, b_body):
+    "Compute whether response bodies are exactly identical."
+    return a_body == b_body
+
+
+def _get_text(html):
+    "Extract textual content from HTML."
+    soup = BeautifulSoup(html, 'html.parser')
+    return soup.findAll(text=True)
+
+
+def _is_visible(element):
+    "A best-effort guess at whether an HTML element is visible on the page."
+    # adapted from https://www.quora.com/How-can-I-extract-only-text-data-from-HTML-pages
+    INVISIBLE_TAGS = ('style', 'script', '[document]', 'head', 'title')
+    if element.parent.name in INVISIBLE_TAGS:
+        return False
+    elif re.match('<!--.*-->', str(element.encode('utf-8'))):
+        return False
+    return True
+
+
+def _get_visible_text(html):
+    return list(filter(_is_visible, _get_text(html)))
+
+
+def side_by_side_text(a_text, b_text):
+    "Extract the visible text from both response bodies."
+    return {'a_text': _get_visible_text(a_text),
+            'b_text': _get_visible_text(b_text)}
+
+
+def pagefreezer(a_url, b_url):
+    "Dispatch to PageFreezer."
+    # Just send PF the urls, not the whole body.
+    # It is still useful that we downloaded the body because we are able to
+    # validate it against the expected hash.
+    return web_monitoring.pagefreezer.compare(a_url, b_url)
+
+
+def pagefreezer_direct(a_text, b_text):
+    "Dispatch to PageFreezer, the slow way."
+    # Send PF the full body.
+    return web_monitoring.pagefreezer.compare(a_text, b_text)

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -1,0 +1,7 @@
+def dummy(a, b, **options):
+    # dummy example illustrating how query parameters pass through
+    return options
+
+
+def compare_length(a, b):
+    return len(b) - len(a)

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -56,9 +56,6 @@ def pagefreezer(a_url, b_url):
 
 d = diff_match_patch.diff_match_patch()
 
-def _diff(a_text, b_text):
-    return d.diff_compute(a_text, b_text, False, DEADLINE)
-
 
 def html_text_diff(a_text, b_text):
     """

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -61,7 +61,8 @@ class DiffHandler(tornado.web.RequestHandler):
             else:
                 actual_hash = hashlib.sha256(res.body).hexdigest()
                 if actual_hash != expected_hash:
-                    self.send_error(500)
+                    self.send_error(
+                        500, reason="Fetched content does not match hash.")
                     return
 
         # TODO Add caching of fetched URIs.

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -84,6 +84,7 @@ wm-diffing-server <config_file> [--port <port>]
 Options:
 -h --help     Show this screen.
 --version     Show version.
+--port        Port. [default: 8888]
 """
     arguments = docopt(doc, version='0.0.1')
     with open(arguments['<config_file>']) as f:

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -1,0 +1,92 @@
+import concurrent.futures
+from docopt import docopt
+from importlib import import_module
+import json
+import tornado.gen
+import tornado.httpclient
+import tornado.ioloop
+import tornado.web
+
+
+def load_config(config):
+    """
+
+    Example
+    -------
+
+    >>> load_config({'foo', ('mypackage.mymodule', 'foofunc')})
+    """
+    d = {}
+    for name, spec in config.items():
+        modname, funcname = spec
+        mod = import_module(modname)
+        func = getattr(mod, funcname)
+        d[name] = func
+    return d
+
+
+client = tornado.httpclient.AsyncHTTPClient()
+executor = concurrent.futures.ProcessPoolExecutor()
+
+
+class DiffHandler(tornado.web.RequestHandler):
+    # subclass must define `differs` attribute
+
+    @tornado.gen.coroutine
+    def get(self, differ):
+        # Find the diffing function registered with the name given by `differ`.
+        try:
+            func = self.differs[differ]
+        except KeyError:
+            self.send_error(404)
+            return
+
+        # If params repeat, take last one. Decode bytes into unicode strings.
+        query_params = {k: v[-1].decode() for k, v in
+                        self.request.arguments.items()}
+        a = query_params.pop('a')
+        b = query_params.pop('b')
+
+        # Fetch server response for URLs a and b.
+        res_a, res_b = yield [client.fetch(a), client.fetch(b)]
+        # TODO Add caching of fetched URIs.
+
+        # TODO Validate the bytes against the hash, if provided.
+
+        # Pass the bytes and any remaining args to the diffing function.
+        res = yield executor.submit(func, res_a.body, res_b.body,
+                                    **query_params)
+        self.write(json.dumps({'diff': res}))
+
+
+def make_app(config):
+
+    class BoundDiffHandler(DiffHandler):
+        differs = load_config(config)
+
+    return tornado.web.Application([
+        (r"/([A-Za-z0-9_]+)", BoundDiffHandler),
+    ])
+
+def start_app(config, port):
+    app = make_app(config)
+    app.listen(port)
+    print(f'Starting server on port {port}')
+    tornado.ioloop.IOLoop.current().start()
+
+
+def cli():
+    doc = """Start a diffing server.
+
+Usage:
+wm-diffing-server <config_file> [--port <port>]
+
+Options:
+-h --help     Show this screen.
+--version     Show version.
+"""
+    arguments = docopt(doc, version='0.0.1')
+    with open(arguments['<config_file>']) as f:
+        config = json.load(f)
+    port = int(arguments['<port>'] or 8888)
+    start_app(config, port)

--- a/web_monitoring/pagefreezer.py
+++ b/web_monitoring/pagefreezer.py
@@ -36,9 +36,9 @@ def compare(url_1, url_2):
     """
     response = requests.post(COMPARE_ENDPOINT,
                              data=json.dumps({"url1": url_1, "url2": url_2}),
-                             headers= {"Accept": "application/json",
-                                       "Content-Type": "application/json",
-                                       "x-api-key": _settings['api_key']})
+                             headers={"Accept": "application/json",
+                                      "Content-Type": "application/json",
+                                      "x-api-key": _settings['api_key']})
     assert response.ok
     return response.json()
 

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -1,0 +1,24 @@
+import web_monitoring.differs as wd
+
+
+def test_side_by_side_text():
+    actual = wd.side_by_side_text(a_text='<html><body>hi</body></html>',
+                                  b_text='<html><body>bye</body></html>')
+    expected = {'a_text': ['hi'], 'b_text': ['bye']}
+    assert actual == expected
+
+
+def test_compare_length():
+    actual = wd.compare_length(a_body=b'asdf', b_body=b'asd')
+    expected = -1
+    assert actual == expected
+
+
+def test_identical_bytes():
+    actual = wd.identical_bytes(a_body=b'asdf', b_body=b'asdf')
+    expected = True
+    assert actual == expected
+
+    actual = wd.identical_bytes(a_body=b'asdf', b_body=b'Asdf')
+    expected = False
+    assert actual == expected

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -22,3 +22,23 @@ def test_identical_bytes():
     actual = wd.identical_bytes(a_body=b'asdf', b_body=b'Asdf')
     expected = False
     assert actual == expected
+
+
+def test_text_diff():
+    actual = wd.html_text_diff('<p>Deleted</p><p>Unchanged</p>',
+                               '<p>Added</p><p>Unchanged</p>')
+    expected = [
+                (-1, 'Delet'),
+                (1, 'Add'),
+                (0, 'ed Unchanged')]
+    assert actual == expected
+
+
+def test_html_diff():
+    actual = wd.html_source_diff('<p>Deleted</p><p>Unchanged</p>',
+                                 '<p>Added</p><p>Unchanged</p>')
+    expected = [(0, '<p>'),
+                (-1, 'Delet'),
+                (1, 'Add'),
+                (0, 'ed</p><p>Unchanged</p>')]
+    assert actual == expected


### PR DESCRIPTION
**This description is now out of date -- see recap in my last comment.**

Short Version: You write a Python function `f(a, b)` where `a` and `b` are HTML. (To be precise, they are generic bytestrings of response body content.) You register your function with the server by adding a line to a config file. Boom! Your function is now a diffing service.

Long Version:

This PR provides a generic, plugable "diffing server" that makes it easy to deploy diffing utilities without re-implementing network code. Specifically, the server handles incoming requests, fetches Version content, and dispatches to a registry of differs. (In the future, content validation and caching can be handled as well.) All a differ needs to do is compare the bytes of the response bodies.

A differ can be expressed as a Python function that takes two positional arguments -- the bytestrings to be diffed. It might also accept additional options specific to the differ, given as keyword arguments that may be required or optional. Here's a differ that returns the difference in the lengths of the two bytestrings.

```python
def compare_length(a, b):
    return len(b) - len(a)
```

The actual processing code in the diffing fucntion may in Python directly, as in this example, or it may just be called from Python by executing a shell command in a subprocess or making a network request.

To plug this a differ into the server, add it to the config file.

This example ,`compare_length` happens to be defined in the module `web_monitoring.differs`. (It could just as well be defined is some other user module, `my_favorite_differs`.) The example config file, `diff_config.json.example`, specifies differ names, each mapped to a list with two elements: the module where the function can be imported from and the name of the function. The differ name may be the same as the function name, but it doesn't have to be.

```json
# diff_config.json.example
{"dummy": ["web_monitoring.differs", "dummy"],
"length": ["web_monitoring.differs", "compare_length"]}
```

Start the diffing server and provide the path to the config file as an argument.

```bash
$ wm-diffing-server diff_config.json.example
```

Example usage with curl:

```bash
$ curl "localhost:8888/length?a=https://google.com&b=https://yahoo.com"
{"diff": 721891}
```

Query parameters other than a and b are passed through to the function as keyword arguments. The `dummy` differ illustrates this:

```python
def dummy(a, b, **options):
    # dummy example illustrating how query parameters pass through
    return options
```

```bash
$ curl "localhost:8888/dummy?a=https://google.com&b=https://yahoo.com&c=cat&d=dog"
{"diff": {"c": "cat", "d": "dog"}}
```

TODO:

- [x] Documentation
- [ ] Basic caching of fetched Version content
- [x] Use optional `a_hash` and `b_hash` parameters to validate downloaded Version content.
- [x] Integrate more differs: PageFreezer and plain text to start