### PR TITLE
Add raw Internet Archive importing via CDX API

### DIFF
--- a/Data diff doc.ipynb
+++ b/Data diff doc.ipynb
@@ -22,8 +22,8 @@
    },
    "outputs": [],
    "source": [
-    "import internetarchive as ia\n",
-    "import pf_edgi as pfe"
+    "from web_monitoring import internetarchive as ia\n",
+    "from web_monitoring import pf_edgi as pfe"
    ]
   },
   {
@@ -34,8 +34,8 @@
    },
    "outputs": [],
    "source": [
-    "pairs = ia.list_versions('nasa.gov')\n",
-    "dt, uri = next(pairs)"
+    "versions = ia.list_versions('nasa.gov')\n",
+    "version = next(pairs)"
    ]
   },
   {
@@ -46,8 +46,7 @@
    },
    "outputs": [],
    "source": [
-    "ia_data = dt,uri\n",
-    "ia_data"
+    "version"
    ]
   },
   {

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -18,11 +18,11 @@ from web_monitoring import db
 
 def import_ia(url, agency, site):
     # Pulling on this generator does the work.
-    versions = (ia.timestamped_uri_to_version(dt, uri,
-                                              url=url,
+    versions = (ia.timestamped_uri_to_version(version.date, version.raw_url,
+                                              url=version.url,
                                               site=site,
                                               agency=agency)
-                for dt, uri in ia.list_versions(url))
+                for version in ia.list_versions(url))
     # Wrap it in a progress bar.
     versions = tqdm(versions, desc='importing', unit=' versions')
     return post_versions_batched(versions)

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -22,7 +22,8 @@ def import_ia(url, agency, site, from_date=None, to_date=None):
     versions = (ia.timestamped_uri_to_version(version.date, version.raw_url,
                                               url=version.url,
                                               site=site,
-                                              agency=agency)
+                                              agency=agency,
+                                              view_url=version.view_url)
                 for version in ia.list_versions(url,
                                                 from_date=from_date,
                                                 to_date=to_date))

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -255,6 +255,13 @@ def format_version(*, url, dt, uri, version_hash, title, agency, site, status,
         Any relevant HTTP headers from response
     view_url : string
         The archive.org URL for viewing the page (with rewritten links, etc.)
+    redirected_url : string
+        If getting `url` resulted in a redirect, this should be the URL
+        that was ultimately redirected to.
+    redirects : string
+        If getting `url` resulted in any redirects this should be a sequence
+        of all the URLs that were retrieved, starting with the originally
+        requested URL and ending with the value of the `redirected_url` arg.
 
     Returns
     -------

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -69,14 +69,20 @@ def search_cdx(params):
     Note that even URLs without wildcards may return results with different
     URLs. Search results are matched by url_key, which is a SURT-formatted,
     canonicalized URL:
-      - Does not differentiate between HTTP and HTTPS
-      - Is not case-sensitive
-      - Treats `www.` and `www*.` subdomains the same as no subdomain at all
+
+      * Does not differentiate between HTTP and HTTPS
+      * Is not case-sensitive
+      * Treats `www.` and `www*.` subdomains the same as no subdomain at all
 
     Parameters
     ----------
     params : dict
            Any options that the CDX API takes. Must at least include `url`.
+
+    Raises
+    ------
+    UnexpectedResponseFormat
+        If the CDX response was not parseable.
 
     References
     ----------
@@ -134,9 +140,10 @@ def list_versions(url, *, from_date=None, to_date=None, skip_repeats=True):
     Note that even URLs without wildcards may return results with multiple
     URLs. Search results are matched by url_key, which is a SURT-formatted,
     canonicalized URL:
-      - Does not differentiate between HTTP and HTTPS
-      - Is not case-sensitive
-      - Treats `www.` and `www*.` subdomains the same as no subdomain at all
+
+      * Does not differentiate between HTTP and HTTPS
+      * Is not case-sensitive
+      * Treats `www.` and `www*.` subdomains the same as no subdomain at all
 
     Parameters
     ----------
@@ -148,6 +155,13 @@ def list_versions(url, *, from_date=None, to_date=None, skip_repeats=True):
         Get versions captured before this date (optional).
     skip_repeats : boolean
         Don’t include consecutive captures of the same content (default: True).
+
+    Raises
+    ------
+    UnexpectedResponseFormat
+        If the CDX response was not parseable.
+    ValueError
+        If there were no versions of the given URL.
 
     Examples
     --------

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -126,7 +126,7 @@ def search_cdx(params):
 
 def list_versions(url, *, from_date=None, to_date=None, skip_repeats=True):
     """
-    Yield (version_datetime, version_uri) for all versions of a url.
+    Yield a CdxRecord object for each version of a url.
 
     This function provides a convenient, use-case-specific interface to
     archive.org's CDX API. For a more direct, low-level API, use search_cdx().
@@ -147,20 +147,20 @@ def list_versions(url, *, from_date=None, to_date=None, skip_repeats=True):
     to_date : datetime
         Get versions captured before this date (optional).
     skip_repeats : boolean
-        Don’t include consecutive captures of unchanged content (default: True).
+        Don’t include consecutive captures of the same content (default: True).
 
     Examples
     --------
     Grab the datetime and URL of the version nasa.gov snapshot.
-    >>> pairs = list_versions('nasa.gov')
-    >>> dt, url = next(pairs)
-    >>> dt
+    >>> versions = list_versions('nasa.gov')
+    >>> version = next(versions)
+    >>> version.date
     datetime.datetime(1996, 12, 31, 23, 58, 47)
-    >>> url
-    'http://web.archive.org/web/19961231235847/http://www.nasa.gov:80/'
+    >>> version.raw_url
+    'http://web.archive.org/web/19961231235847id_/http://www.nasa.gov:80/'
 
     Loop through all the snapshots.
-    >>> for dt, url in list_versions('nasa.gov'):
+    >>> for version in list_versions('nasa.gov'):
     ...     # do something
     """
     params = {'url': url, 'collapse': 'digest'}
@@ -177,7 +177,7 @@ def list_versions(url, *, from_date=None, to_date=None, skip_repeats=True):
             has_versions = True
             last_hashes[version.url] = version.digest
             # TODO: yield the whole version
-            yield version.date, version.raw_url
+            yield version
 
     if not has_versions:
         raise ValueError("Internet archive does not have archived "

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -66,6 +66,13 @@ def search_cdx(params):
     Returns an iterator of CdxRecord objects. The StopIteration value is the
     total count of found captures.
 
+    Note that even URLs without wildcards may return results with different
+    URLs. Search results are matched by url_key, which is a SURT-formatted,
+    canonicalized URL:
+      - Does not differentiate between HTTP and HTTPS
+      - Is not case-sensitive
+      - Treats `www.` and `www*.` subdomains the same as no subdomain at all
+
     Parameters
     ----------
     params : dict
@@ -123,6 +130,13 @@ def list_versions(url, *, from_date=None, to_date=None, skip_repeats=True):
 
     This function provides a convenient, use-case-specific interface to
     archive.org's CDX API. For a more direct, low-level API, use search_cdx().
+
+    Note that even URLs without wildcards may return results with multiple
+    URLs. Search results are matched by url_key, which is a SURT-formatted,
+    canonicalized URL:
+      - Does not differentiate between HTTP and HTTPS
+      - Is not case-sensitive
+      - Treats `www.` and `www*.` subdomains the same as no subdomain at all
 
     Parameters
     ----------

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -81,7 +81,7 @@ def original_url_for_memento(memento_url):
 def cdx_hash(content):
     if isinstance(content, str):
         content = content.encode()
-    return b32encode(hashlib.sha1(content).digest())
+    return b32encode(hashlib.sha1(content).digest()).decode()
 
 
 def search_cdx(params):
@@ -135,7 +135,6 @@ def search_cdx(params):
 
         try:
             data = CdxRecord(*text.split(' '), None, '', '')
-            encoded_url = urllib.parse.quote(data.url, safe='')
             capture_time = datetime.strptime(data.timestamp, URL_DATE_FORMAT)
         except:
             raise UnexpectedResponseFormat(text)
@@ -146,9 +145,9 @@ def search_cdx(params):
         data = data._replace(
             date=capture_time,
             raw_url=ARCHIVE_RAW_URL_TEMPLATE.format(
-                timestamp=data.timestamp, url=encoded_url),
+                timestamp=data.timestamp, url=data.url),
             view_url=ARCHIVE_VIEW_URL_TEMPLATE.format(
-                timestamp=data.timestamp, url=encoded_url)
+                timestamp=data.timestamp, url=data.url)
         )
         count += 1
         yield data

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -181,7 +181,7 @@ def list_versions(url, *, from_date=None, to_date=None, skip_repeats=True):
     if from_date:
         params['from'] = from_date.strftime(URL_DATE_FORMAT)
     if to_date:
-        params['to'] = from_date.strftime(URL_DATE_FORMAT)
+        params['to'] = to_date.strftime(URL_DATE_FORMAT)
 
     has_versions = False
     last_hashes = {}

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -266,7 +266,13 @@ def timestamped_uri_to_version(dt, uri, *, url, site, agency, view_url=None):
     Obtain hash and title and return a Version.
     """
     res = requests.get(uri)
-    assert res.ok
+
+    # IA's memento server responds with the status of the original request, so
+    # use the presence of the 'Memento-Datetime' header to determine if we
+    # should use the response or there was an actual error.
+    if not res.ok and not res.headers.get('memento-datetime'):
+        res.raise_for_status()
+
     version_hash = utils.hash_content(res.content)
     title = utils.extract_title(res.content)
     content_type = (res.headers['content-type'] or '').split(';', 1)

--- a/web_monitoring/tests/test_ia.py
+++ b/web_monitoring/tests/test_ia.py
@@ -3,18 +3,18 @@ from web_monitoring.internetarchive import list_versions
 
 
 def test_list_versions():
-    pairs = list_versions('nasa.gov')
-    dt, url = next(pairs)
-    assert dt == datetime(1996, 12, 31, 23, 58, 47)
+    versions = list_versions('nasa.gov')
+    version = next(versions)
+    assert version.date == datetime(1996, 12, 31, 23, 58, 47)
 
-    # Exhaust the generator and make sure not entries trigger errors.
-    list(pairs)
+    # Exhaust the generator and make sure no entries trigger errors.
+    list(versions)
 
 
-def test_list_versions_multipage(): 
+def test_list_versions_multipage():
     # cnn.com has enough 'mementos' to span multiple pages and exercise the
     # multi-page code path.
-    pairs = list_versions('cnn.com')
+    versions = list_versions('cnn.com')
 
-    # Exhaust the generator and make sure not entries trigger errors.
-    list(pairs)
+    # Exhaust the generator and make sure no entries trigger errors.
+    list(versions)

--- a/web_monitoring/tests/test_ia.py
+++ b/web_monitoring/tests/test_ia.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from web_monitoring.internetarchive import list_versions
+from web_monitoring.internetarchive import (list_versions,
+                                            original_url_for_memento)
 
 
 def test_list_versions():
@@ -18,3 +19,20 @@ def test_list_versions_multipage():
 
     # Exhaust the generator and make sure no entries trigger errors.
     list(versions)
+
+
+class TestOriginalUrlForMemento:
+    def test_extracts_url(self):
+        url = original_url_for_memento('http://web.archive.org/web/20170813195036/https://arpa-e.energy.gov/?q=engage/events-workshops')
+        assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
+
+        url = original_url_for_memento('http://web.archive.org/web/20170813195036id_/https://arpa-e.energy.gov/?q=engage/events-workshops')
+        assert url == 'https://arpa-e.energy.gov/?q=engage/events-workshops'
+
+    def test_decodes_url(self):
+        url = original_url_for_memento('http://web.archive.org/web/20150930233055id_/http%3A%2F%2Fwww.epa.gov%2Fenvironmentaljustice%2Fgrants%2Fej-smgrants.html%3Futm')
+        assert url == 'http://www.epa.gov/environmentaljustice/grants/ej-smgrants.html?utm'
+
+    def test_does_not_decode_query(self):
+        url = original_url_for_memento('http://web.archive.org/web/20170813195036/https://arpa-e.energy.gov/?q=engage%2Fevents-workshops')
+        assert url == 'https://arpa-e.energy.gov/?q=engage%2Fevents-workshops'


### PR DESCRIPTION
This fixes #3 and fixes #46, and is the beginnings of work towards edgi-govdata-archiving/web-monitoring#23.

I’ve replaced `list_versions()` with an implementation that uses the CDX API and also split the work into two functions:

1. `search_cdx()` is a simple wrapper around the CDX API and iterates through and parses each line of each page of the CDX response.
2. `list_versions()` is a slightly higher-level interface to the same results that adds business logic like de-duping, resolving metadata, and raising meaningful errors.

The parsed CDX responses now also include `.raw_url` and `.view_url` attributes, which are URL from which to retrieve the raw content of the version and the viewable content (with URLs rewritten to point to resources from the archive) of the version, respectively.

Things I’m still planning to try and do here:

- [x] Pull more metadata from either the CDX record or the headers that we get when requesting the content (hard because of the `warc/revisit` problem)
- [x] Add CLI options to limit the timeframe of captures (the implementation is already there in `list_versions`)
- ~Add CLI option to limit results to a list of pages or to pages that are already in the DB~ (Moved this to #86)
- [x] Fix all the `.ipynb` files I probably broke
- ~Validate downloaded version content using the hash from the CDX result (I already added a method to calculate the CDX hash, which is a base 32 encoded SHA-1 digest of just the response body; no headers)~