### PR TITLE
Handle versions with different numbers of nodes in HTML diffs

### DIFF
--- a/diff_config.json
+++ b/diff_config.json
@@ -3,5 +3,6 @@
  "pagefreezer": ["web_monitoring.differs", "pagefreezer"],
  "side_by_side_text": ["web_monitoring.differs", "side_by_side_text"],
  "html_text_diff": ["web_monitoring.differs", "html_text_diff"],
- "html_source_diff": ["web_monitoring.differs", "html_source_diff"]
+ "html_source_diff": ["web_monitoring.differs", "html_source_diff"],
+ "html_visual_diff": ["web_monitoring.differs", "html_diff_render"]
 }

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -4,7 +4,6 @@ from lxml.html.diff import htmldiff
 import re
 import web_monitoring.pagefreezer
 import sys
-import os
 import copy
 
 # BeautifulSoup can sometimes exceed the default Python recursion limit (1000).

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -5,6 +5,7 @@ import re
 import web_monitoring.pagefreezer
 import sys
 import os
+import copy
 
 # BeautifulSoup can sometimes exceed the default Python recursion limit (1000).
 sys.setrecursionlimit(10000)
@@ -101,9 +102,15 @@ def html_source_diff(a_text, b_text):
     TIMELIMIT = 2 #seconds
     return compute_dmp_diff(a_text, b_text, timelimit=TIMELIMIT)
 
+
 def html_diff_render(a_text, b_text):
     """
-    HTML Diff for rendering
+    HTML Diff for rendering.
+
+    Please note that the result of this should not be displayed as-is in a
+    browser -- because this contains added and removed sections of the
+    document’s <head>, it may cause a browser to load two different CSS or JS
+    files that are in conflict with each other.
 
     Example
     -------
@@ -114,24 +121,28 @@ def html_diff_render(a_text, b_text):
     soup_old = BeautifulSoup(a_text, 'lxml')
     soup_new = BeautifulSoup(b_text, 'lxml')
 
+    # Remove comment nodes since they generally don't affect display.
+    # NOTE: This could affect display if the removed are conditional comments,
+    # but it's unclear how we'd meaningfully visualize those anyway.
     [element.extract() for element in
      soup_old.find_all(string=lambda text:isinstance(text, Comment))]
     [element.extract() for element in
      soup_new.find_all(string=lambda text:isinstance(text, Comment))]
 
-    old_content = [str(child) for child in soup_old.html.children]
-    new_content = [str(child) for child in soup_new.html.children]
-
-    parent_tags = [content[:content.find('>')+1] for content in new_content]
-    parent_tag_names = [tag[1:tag.find(' ')] + '>' if (tag.find(' ') != -1) else tag[1:] for tag in parent_tags]
-
-    diff_list = []
-    for index in range(len(new_content)):
-        diff_list.append(htmldiff(old_content[index], new_content[index]))
-
-    diff_list = [os.linesep.join([s for s in text.splitlines() if s]) for text in diff_list]
-
-    append_list = [parent_tags[index]+diff_list[index]+'</'+parent_tag_names[index] for index in range(len(new_content))]
+    # htmldiff will normally extract the <body> and return only a diff of its
+    # contents (without any of the surround code like a doctype, <html>, or
+    # <head>). Because we want something a little more like a structured diff
+    # of the whole page, we work around the standard behavior by finding each
+    # part of the <html> element and diffing it individually.
+    old_content = _find_meaningful_nodes(soup_old)
+    new_content = _find_meaningful_nodes(soup_new)
+    diffs = [
+        htmldiff(old_content['pre_head'], new_content['pre_head']),
+        _diff_elements(old_content['head'], new_content['head']),
+        htmldiff(old_content['pre_body'], new_content['pre_body']),
+        _diff_elements(old_content['body'], new_content['body']),
+        htmldiff(old_content['post_body'], new_content['post_body'])
+    ]
 
     soup_new.html.clear()
 
@@ -140,9 +151,64 @@ def html_diff_render(a_text, b_text):
                         del {text-decoration : none; background-color: #fbb6c2;}"""
     soup_new.html.append(new_tag)
 
-    for index in range(len(append_list)):
-        soup_new.html.append(append_list[index])
+    for index in range(len(diffs)):
+        soup_new.html.append(diffs[index])
 
     render = soup_new.prettify(formatter=None)
 
     return render
+
+
+def _find_meaningful_nodes(soup):
+    """
+    Find meaningful content chunks from a Beautiful Soup document. Namely, this
+    is a dict of:
+    {
+        pre_head: string,
+        head: node,
+        pre_body: string,
+        body: node,
+        post_body: string
+    }
+    """
+    pre_head = []
+    head = None
+    pre_body = []
+    body = None
+    post_body = []
+    for node in soup.html.children:
+        if not head and not body:
+            if hasattr(node, 'name') and node.name == 'head':
+                head = node
+            elif hasattr(node, 'name') and node.name == 'body':
+                body = node
+            else:
+                pre_head.append(str(node))
+        elif not body:
+            if hasattr(node, 'name') and node.name == 'body':
+                body = node
+            else:
+                pre_body.append(str(node))
+        else:
+            post_body.append(str(node))
+
+    return {
+        'pre_head': '\n'.join(pre_head),
+        'head': head,
+        'pre_body': '\n'.join(pre_body),
+        'body': body,
+        'post_body': '\n'.join(post_body)
+    }
+
+
+def _diff_elements(old, new):
+    """
+    Diff the contents of two Beatiful Soup elements. Note that this returns
+    the "new" element with its content replaced by the diff.
+    """
+    if not old or not new:
+        return ''
+    result_element = copy.copy(new)
+    result_element.clear()
+    result_element.append(htmldiff(str(old), str(new)))
+    return result_element

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -145,14 +145,17 @@ def html_diff_render(a_text, b_text):
     ]
 
     soup_new.html.clear()
-
-    new_tag = soup_new.new_tag("style", type="text/css")
-    new_tag.string = """ins {text-decoration : none; background-color: #d4fcbc;}
-                        del {text-decoration : none; background-color: #fbb6c2;}"""
-    soup_new.html.append(new_tag)
-
     for index in range(len(diffs)):
         soup_new.html.append(diffs[index])
+
+    if not soup_new.head:
+        head = soup_new.new_tag('head')
+        soup_new.html.insert(0, head)
+
+    change_styles = soup_new.new_tag("style", type="text/css")
+    change_styles.string = """ins {text-decoration : none; background-color: #d4fcbc;}
+                        del {text-decoration : none; background-color: #fbb6c2;}"""
+    soup_new.head.append(change_styles)
 
     render = soup_new.prettify(formatter=None)
 

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -69,10 +69,10 @@ def test_html_diff_render():
                  ('<html><head><title>HTML Diff Render</title></head><body><h1>Heading</h1></body></html>',
                   '<html><head><title>HTML Difference Render</title></head><body><h1>Head</h1></body></html>')]
 
-    test_results = ['<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <head>\n </head> <body>\n  <h1><ins>Heading</ins></h1> <p><del>Paragraph</del></p>\n </body>\n</html>',
-                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <body>\n  <h1><ins>Heading</ins></h1> <p>Paragraph</p>\n </body>\n</html>',
-                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <body>\n  <h3>Paragraph</h3>\n </body>\n</html>',
-                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <head>\n  <title>HTML <ins>Difference</ins> <del>Diff</del> Render</title>\n </head> <body>\n  <h1><ins>Head</ins></h1> <h1><del>Heading</del></h1>\n </body>\n</html>']
+    test_results = ['<html>\n <head>\n  <style type="text/css">\n   ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n  </style>\n </head> <body>\n  <h1><ins>Heading</ins></h1> <p><del>Paragraph</del></p>\n </body>\n</html>',
+                    '<html>\n <head>\n  <style type="text/css">\n   ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n  </style>\n </head> <body>\n  <h1><ins>Heading</ins></h1> <p>Paragraph</p>\n </body>\n</html>',
+                    '<html>\n <head>\n  <style type="text/css">\n   ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n  </style>\n </head> <body>\n  <h3>Paragraph</h3>\n </body>\n</html>',
+                    '<html>\n <head>\n  <title>HTML <ins>Difference</ins> <del>Diff</del> Render</title>\n  <style type="text/css">\n   ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n  </style>\n </head> <body>\n  <h1><ins>Head</ins></h1> <h1><del>Heading</del></h1>\n </body>\n</html>']
 
     for index in range(len(test_data)):
         diff = wd.html_diff_render(test_data[index][0], test_data[index][1])
@@ -83,6 +83,6 @@ def test_html_diff_render_handles_differing_numbers_of_nodes():
     test_data = ('<html><head></head><body><p>Paragraph</p></body></html>',
                  '<html><head></head>\n<body><h1>Heading</h1></body></html>')
 
-    expected = '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <head>\n </head> <body>\n  <h1><ins>Heading</ins></h1> <p><del>Paragraph</del></p>\n </body>\n</html>'
+    expected = '<html>\n <head>\n  <style type="text/css">\n   ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n  </style>\n </head> <body>\n  <h1><ins>Heading</ins></h1> <p><del>Paragraph</del></p>\n </body>\n</html>'
     diff = wd.html_diff_render(test_data[0], test_data[1])
     assert expected == diff

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -50,12 +50,14 @@ def test_pagefreezer():
     # 2. Ensure that the resulting output is properly passed through
     pass
 
+
 def test_get_visible_text():
     html = '<!--First comment--><h1>First Heading</h1><p>First paragraph.</p>'
     actual = wd._get_visible_text(html)
     expected = ['First Heading',
                 'First paragraph.']
     assert actual == expected
+
 
 def test_html_diff_render():
     test_data = [('<html><head></head><body><p>Paragraph</p></body></html>',
@@ -67,15 +69,20 @@ def test_html_diff_render():
                  ('<html><head><title>HTML Diff Render</title></head><body><h1>Heading</h1></body></html>',
                   '<html><head><title>HTML Difference Render</title></head><body><h1>Head</h1></body></html>')]
 
-    test_results = ['<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style>\n <head></head>\n <body><h1><ins>Heading</ins></h1> <p><del>Paragraph</del></p></body>\n</html>',
-                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style>\n <body><h1><ins>Heading</ins></h1> <p>Paragraph</p></body>\n</html>',
-                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style>\n <body><h3>Paragraph</h3></body>\n</html>',
-                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style>\n <head><title>HTML <ins>Difference</ins> <del>Diff</del> Render</title></head>\n <body><h1><ins>Head</ins></h1> <h1><del>Heading</del></h1></body>\n</html>']
-
-    test_check = []
+    test_results = ['<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <head>\n </head> <body>\n  <h1><ins>Heading</ins></h1> <p><del>Paragraph</del></p>\n </body>\n</html>',
+                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <body>\n  <h1><ins>Heading</ins></h1> <p>Paragraph</p>\n </body>\n</html>',
+                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <body>\n  <h3>Paragraph</h3>\n </body>\n</html>',
+                    '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <head>\n  <title>HTML <ins>Difference</ins> <del>Diff</del> Render</title>\n </head> <body>\n  <h1><ins>Head</ins></h1> <h1><del>Heading</del></h1>\n </body>\n</html>']
 
     for index in range(len(test_data)):
-        test_check.append(wd.html_diff_render(test_data[index][0],
-                                              test_data[index][1]) == test_results[index])
+        diff = wd.html_diff_render(test_data[index][0], test_data[index][1])
+        assert (f'{index}: ' + test_results[index]) == (f'{index}: ' + diff)
 
-    assert False not in test_check
+
+def test_html_diff_render_handles_differing_numbers_of_nodes():
+    test_data = ('<html><head></head><body><p>Paragraph</p></body></html>',
+                 '<html><head></head>\n<body><h1>Heading</h1></body></html>')
+
+    expected = '<html>\n <style type="text/css">\n  ins {text-decoration : none; background-color: #d4fcbc;}\n                        del {text-decoration : none; background-color: #fbb6c2;}\n </style> <head>\n </head> <body>\n  <h1><ins>Heading</ins></h1> <p><del>Paragraph</del></p>\n </body>\n</html>'
+    diff = wd.html_diff_render(test_data[0], test_data[1])
+    assert expected == diff


### PR DESCRIPTION
This fixes #91. It also adds a bunch of comments to clarify why we are bending over backwards to do some strange transformations here.

While I was here, I also took the opportunity to clean up how the inserted CSS styling was clobbering character encoding on lots of pages.