### PR TITLE
Remove repeat blank lines from text diffs

### DIFF
--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -12,6 +12,8 @@ sys.setrecursionlimit(10000)
 # Dictionary mapping which maps from diff-match-patch tags to the ones we use
 diff_codes = {'=': 0, '-': -1, '+': 1}
 
+REPEATED_BLANK_LINES = re.compile(r'([^\S\n]*\n\s*){2,}')
+
 def compare_length(a_body, b_body):
     "Compute difference in response body lengths. (Does not compare contents.)"
     return len(b_body) - len(a_body)
@@ -42,7 +44,8 @@ def _is_visible(element):
 
 
 def _get_visible_text(html):
-    return list(filter(_is_visible, _get_text(html)))
+    text = ' '.join(filter(_is_visible, _get_text(html)))
+    return REPEATED_BLANK_LINES.sub('\n\n', text).strip()
 
 
 def side_by_side_text(a_text, b_text):
@@ -82,8 +85,8 @@ def html_text_diff(a_text, b_text):
     [[-1, 'Delet'], [1, 'Add'], [0, 'ed Unchanged']]
     """
 
-    t1 = ' '.join(_get_visible_text(a_text))
-    t2 = ' '.join(_get_visible_text(b_text))
+    t1 = _get_visible_text(a_text)
+    t2 = _get_visible_text(b_text)
 
     TIMELIMIT = 2 #seconds
     return compute_dmp_diff(t1, t2, timelimit=TIMELIMIT)

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -4,7 +4,7 @@ import web_monitoring.differs as wd
 def test_side_by_side_text():
     actual = wd.side_by_side_text(a_text='<html><body>hi</body></html>',
                                   b_text='<html><body>bye</body></html>')
-    expected = {'a_text': ['hi'], 'b_text': ['bye']}
+    expected = {'a_text': 'hi', 'b_text': 'bye'}
     assert actual == expected
 
 
@@ -32,6 +32,20 @@ def test_text_diff():
                 (0, 'ed Unchanged')]
     assert actual == expected
 
+def test_text_diff_omits_more_than_two_consecutive_blank_lines():
+    actual = wd.html_text_diff('''<p>Deleted</p>
+                                  <script>whatever</script>
+                                  <img src='something.jpg'>
+                                  <p>Unchanged</p>''',
+                               '''<p>Added</p>
+                                  <script>some script</script>
+                                  <img src='something.jpg'>
+                                  <p>Unchanged</p>''')
+    expected = [(-1, 'Delet'),
+                (1, 'Add'),
+                (0, 'ed\n\nUnchanged')]
+    assert actual == expected
+
 
 def test_html_diff():
     actual = wd.html_source_diff('<p>Deleted</p><p>Unchanged</p>',
@@ -54,9 +68,7 @@ def test_pagefreezer():
 def test_get_visible_text():
     html = '<!--First comment--><h1>First Heading</h1><p>First paragraph.</p>'
     actual = wd._get_visible_text(html)
-    expected = ['First Heading',
-                'First paragraph.']
-    assert actual == expected
+    assert actual == 'First Heading First paragraph.'
 
 
 def test_html_diff_render():


### PR DESCRIPTION
Up to two repeat blank lines are allowed (which helps to get some differentiation between parts of the page), but anything more is collapsed. This also changes the output of side-by-side text to be two text strings rather than a list of text strings (since we need to collapse *across* strings).

So now we have diffs that look like:

<img width="459" alt="screen shot 2017-10-02 at 12 53 15 am" src="https://user-images.githubusercontent.com/74178/31068285-2ecb3ed0-a70c-11e7-9c34-f4d1f9d1d4da.png">

rather than:

<img width="572" alt="screen shot 2017-10-02 at 1 00 59 am" src="https://user-images.githubusercontent.com/74178/31068520-3ea3c7a4-a70d-11e7-9430-f755087cd9bd.png">

I also went way overboard and made an implementation of something approximating HTML’s whitespace algorithm (collapse all types of whitespace including line feeds into a single space; newlines are triggered by `<br>` and block elements), but it rarely looked better and often looked worse on most actual pages I tried it with. (It turns out that the way people write markup, various nav links and sections of the page tend to clump up meaningfully when we naively collapse blank lines, but get spaced out confusingly uniformly when we follow HTML whitespace). We could definitely get that to be something really good, but it would require a lot of work to get over the hump to be better than the naive approach in this PR, so I tabled it for now.

Fixes #98.