### PR TITLE
Simplify config scheme by removing a layer of indirection.

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -73,7 +73,7 @@ $ python setup.py install
 Now, test that your installation actually works by running the diffing server on port 8000:
 
 ```sh
-$ wm-diffing-server diff_config.json --port 8000
+$ wm-diffing-server --port 8000
 ```
 
 Open a web browser and try browsing to: `http://[IP address for your server]:8000/html_text_diff`
@@ -107,25 +107,25 @@ The content of this file should look like:
 ; To take advantage of multiple cores, you'll need multiple processes.
 
 [program:wm-diffing-server-8000]
-command=/opt/conda/bin/wm-diffing-server /var/www/web-monitoring-processing/diff_config.json --port 8000
+command=/opt/conda/bin/wm-diffing-server --port 8000
 stderr_logfile = /var/log/supervisor/tornado-stderr.log
 stdout_logfile = /var/log/supervisor/tornado-stdout.log
 environment=PAGE_FREEZER_API_KEY=<page_freezer_key>
 
 [program:wm-diffing-server-8001]
-command=/opt/conda/bin/wm-diffing-server /var/www/web-monitoring-processing/diff_config.json --port 8001
+command=/opt/conda/bin/wm-diffing-server --port 8001
 stderr_logfile = /var/log/supervisor/tornado-stderr.log
 stdout_logfile = /var/log/supervisor/tornado-stdout.log
 environment=PAGE_FREEZER_API_KEY=<page_freezer_key>
 
 [program:wm-diffing-server-8002]
-command=/opt/conda/bin/wm-diffing-server /var/www/web-monitoring-processing/diff_config.json --port 8002
+command=/opt/conda/bin/wm-diffing-server --port 8002
 stderr_logfile = /var/log/supervisor/tornado-stderr.log
 stdout_logfile = /var/log/supervisor/tornado-stdout.log
 environment=PAGE_FREEZER_API_KEY=<page_freezer_key>
 
 [program:wm-diffing-server-8003]
-command=/opt/conda/bin/wm-diffing-server /var/www/web-monitoring-processing/diff_config.json --port 8003
+command=/opt/conda/bin/wm-diffing-server --port 8003
 stderr_logfile = /var/log/supervisor/tornado-stderr.log
 stdout_logfile = /var/log/supervisor/tornado-stdout.log
 environment=PAGE_FREEZER_API_KEY=<page_freezer_key>

--- a/diff_config.json
+++ b/diff_config.json
@@ -1,8 +1,0 @@
-{"length": ["web_monitoring.differs", "compare_length"],
- "identical_bytes": ["web_monitoring.differs", "identical_bytes"],
- "pagefreezer": ["web_monitoring.differs", "pagefreezer"],
- "side_by_side_text": ["web_monitoring.differs", "side_by_side_text"],
- "html_text_diff": ["web_monitoring.differs", "html_text_diff"],
- "html_source_diff": ["web_monitoring.differs", "html_source_diff"],
- "html_visual_diff": ["web_monitoring.differs", "html_diff_render"]
-}

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -3,12 +3,24 @@ from docopt import docopt
 import hashlib
 from importlib import import_module
 import inspect
-import json
 import tornado.gen
 import tornado.httpclient
 import tornado.ioloop
 import tornado.web
 import web_monitoring
+
+
+# MAP tokens in the REST API to functions in modules.
+# The modules do not have to be part of the web_monitoring package.
+CONFIG = {
+    "length": ["web_monitoring.differs", "compare_length"],
+    "identical_bytes": ["web_monitoring.differs", "identical_bytes"],
+    "pagefreezer": ["web_monitoring.differs", "pagefreezer"],
+    "side_by_side_text": ["web_monitoring.differs", "side_by_side_text"],
+    "html_text_diff": ["web_monitoring.differs", "html_text_diff"],
+    "html_source_diff": ["web_monitoring.differs", "html_source_diff"],
+    "html_visual_diff": ["web_monitoring.differs", "html_diff_render"]
+}
 
 
 def load_config(config):
@@ -132,18 +144,27 @@ def caller(func, a, b, **query_params):
                                "".format(func.__name__, name))
     return func(**kwargs)
 
+class IndexHandler(tornado.web.RequestHandler):
 
-def make_app(config):
+    @tornado.gen.coroutine
+    def get(self):
+        # Return a list of the differs.
+        # TODO Show swagger API instead.
+        self.write(repr(list(CONFIG)))
+
+
+def make_app():
 
     class BoundDiffHandler(DiffHandler):
-        differs = load_config(config)
+        differs = load_config(CONFIG)
 
     return tornado.web.Application([
         (r"/([A-Za-z0-9_]+)", BoundDiffHandler),
+        (r"/", IndexHandler),
     ])
 
-def start_app(config, port):
-    app = make_app(config)
+def start_app(port):
+    app = make_app()
     app.listen(port)
     print(f'Starting server on port {port}')
     tornado.ioloop.IOLoop.current().start()
@@ -153,7 +174,7 @@ def cli():
     doc = """Start a diffing server.
 
 Usage:
-wm-diffing-server <config_file> [--port <port>]
+wm-diffing-server [--port <port>]
 
 Options:
 -h --help     Show this screen.
@@ -161,7 +182,5 @@ Options:
 --port        Port. [default: 8888]
 """
     arguments = docopt(doc, version='0.0.1')
-    with open(arguments['<config_file>']) as f:
-        config = json.load(f)
     port = int(arguments['<port>'] or 8888)
-    start_app(config, port)
+    start_app(port)


### PR DESCRIPTION
The purpose of having a 'config' is to make it easy to plug in diffing functions
from external libraries that might be maintained separately from the library where
the server lives. This PR simplifies things by moving that config from a JSON
file to a module global.