### PR TITLE
Argument order was changed during dev and now password leaks as url.

### DIFF
--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -155,7 +155,7 @@ variables:
    WEB_MONITORING_DB_PASSWORD
 
 Alternatively, you can instaniate Client(user, password) directly.""")
-        return cls(url, email, password)
+        return cls(email=email, password=password, url=url)
 
     ### PAGES ###
 


### PR DESCRIPTION
I made `url` optional (and therefore moved it last) but forgot
to update the corresponding call. Now keyword arguments are used,
so this can't happened again.