### PR TITLE
Ignore test cache/output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ __pycache__/
 # sphinx docs
 docs/build/*
 docs/source/generated/*
+
+# test caches (not sure if ignoring these is right, but useful for now)
+diff_output_*
+.cache
+.coverage


### PR DESCRIPTION
These were turning into a lot of noise in my local checkout. Seems like they should be ignored.