### PR TITLE
WIP: Visual diff workarounds/hacks/fixes

### DIFF
--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -296,8 +296,8 @@ def _htmldiff(old, new):
     """
     old_tokens = tokenize(old)
     new_tokens = tokenize(new)
-    old_tokens = [customize_token(token) for token in old_tokens]
-    new_tokens = [customize_token(token) for token in new_tokens]
+    old_tokens = [_customize_token(token) for token in old_tokens]
+    new_tokens = [_customize_token(token) for token in new_tokens]
     result = htmldiff_tokens(old_tokens, new_tokens)
     result = ''.join(result).strip()
     return fixup_ins_del_tags(result)
@@ -315,7 +315,7 @@ class MinimalHrefToken(href_token):
         return ''
 
 
-def customize_token(token):
+def _customize_token(token):
     """
     Replace existing diffing tokens with customized ones for better output.
     """

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -1,10 +1,7 @@
 from bs4 import BeautifulSoup, Comment
-import copy
 from diff_match_patch import diff, diff_bytes
 from htmldiffer.diff import HTMLDiffer
 import htmltreediff
-from lxml.html.diff import (tokenize, htmldiff_tokens, fixup_ins_del_tags,
-                            href_token)
 import re
 import sys
 import web_monitoring.pagefreezer
@@ -17,6 +14,7 @@ sys.setrecursionlimit(10000)
 diff_codes = {'=': 0, '-': -1, '+': 1}
 
 REPEATED_BLANK_LINES = re.compile(r'([^\S\n]*\n\s*){2,}')
+
 
 def compare_length(a_body, b_body):
     "Compute difference in response body lengths. (Does not compare contents.)"
@@ -66,6 +64,7 @@ def pagefreezer(a_url, b_url):
     obj = web_monitoring.pagefreezer.PageFreezer(a_url, b_url)
     return obj.query_result
 
+
 def compute_dmp_diff(a_text, b_text, timelimit=4):
 
     if (isinstance(a_text, str) and isinstance(b_text, str)):
@@ -109,209 +108,6 @@ def html_source_diff(a_text, b_text):
     """
     TIMELIMIT = 2 #seconds
     return compute_dmp_diff(a_text, b_text, timelimit=TIMELIMIT)
-
-
-def html_diff_render(a_text, b_text):
-    """
-    HTML Diff for rendering. This is focused on visually highlighting portions
-    of a page’s text that have been changed. It does not do much to show how
-    node types or attributes have been modified (save for link or image URLs).
-
-    The overall page returned primarily represents the structure of the "new"
-    or "B" version. However, it contains some useful metadata in the `<head>`:
-
-    1. A `<template id="wm-diff-old-head">` contains the contents of the "old"
-       or "A" version’s `<head>`.
-    2. A `<style id="wm-diff-style">` contains styling diff-specific styling.
-    3. A `<meta name="wm-diff-title" content="[diff]">` contains a renderable
-       HTML diff of the page’s `<title>`. For example:
-
-        `The <del>old</del><ins>new</ins> title`
-
-    NOTE: you may want to be careful with rendering this response as-is;
-    inline `<script>` and `<style>` elements may be included twice if they had
-    changes, which could have undesirable runtime effects.
-
-    Example
-    -------
-    text1 = '<!DOCTYPE html><html><head></head><body><p>Paragraph</p></body></html>'
-    text2 = '<!DOCTYPE html><html><head></head><body><h1>Header</h1></body></html>'
-    test_diff_render = html_diff_render(text1,text2)
-    """
-    soup_old = BeautifulSoup(a_text, 'lxml')
-    soup_new = BeautifulSoup(b_text, 'lxml')
-
-    # Remove comment nodes since they generally don't affect display.
-    # NOTE: This could affect display if the removed are conditional comments,
-    # but it's unclear how we'd meaningfully visualize those anyway.
-    [element.extract() for element in
-     soup_old.find_all(string=lambda text:isinstance(text, Comment))]
-    [element.extract() for element in
-     soup_new.find_all(string=lambda text:isinstance(text, Comment))]
-
-    # Ensure the new soup (which we will modify and return) has a `<head>`
-    if not soup_new.head:
-        head = soup_new.new_tag('head')
-        soup_new.html.insert(0, head)
-
-    # htmldiff will unfortunately try to diff the content of elements like
-    # <script> or <style> that embed foreign cnontent that shouldn't be parsed
-    # as part of the DOM. We work around this by replacing those elements
-    # with placeholders, but a better upstream fix would be to have
-    # `flatten_el()` handle these cases by creating a special token, e.g:
-    #
-    #  class undiffable_tag(token):
-    #    def __new__(cls, html_repr, **kwargs):
-    #      # Make the value this represents for diffing an empty string
-    #      obj = token.__new__(cls, '', **kwargs)
-    #      # But keep the actual source around for serializing when done
-    #      obj.html_repr = html_repr
-    #
-    #    def html(obj):
-    #      return self.html_repr
-    soup_old, replacements_old = _remove_undiffable_content(soup_old, 'old')
-    soup_new, replacements_new = _remove_undiffable_content(soup_new, 'new')
-
-    # htmldiff primarily diffs just *readable text*, so it doesn't really
-    # diff parts of the page outside the `<body>` (e.g. `<head>`). We don't
-    # have a great way to visualize metadata changes anyway.
-    soup_new.body.replace_with(_diff_elements(soup_old.body, soup_new.body))
-
-    # The `name` keyword sets the node name, not the `name` attribute
-    title_meta = soup_new.new_tag(
-        'meta',
-        content=_diff_title(soup_old, soup_new))
-    title_meta.attrs['name'] = 'wm-diff-title'
-    soup_new.head.append(title_meta)
-
-    old_head = soup_new.new_tag('template', id='wm-diff-old-head')
-    if soup_old.head:
-        for node in soup_old.head.contents.copy():
-            old_head.append(node)
-    soup_new.head.append(old_head)
-
-    change_styles = soup_new.new_tag(
-        "style",
-        type="text/css",
-        id='wm-diff-style')
-    change_styles.string = """ins {text-decoration : none; background-color: #d4fcbc;}
-                        del {text-decoration : none; background-color: #fbb6c2;}"""
-    soup_new.head.append(change_styles)
-
-    # The method we use above to append HTML strings (the diffs) to the soup
-    # results in a non-navigable soup. So we serialize and re-parse :(
-    # (Note we use no formatter for this because proper encoding escape the
-    # tags our differ generated.)
-    soup_new = BeautifulSoup(soup_new.prettify(formatter=None), 'lxml')
-    replacements_new.update(replacements_old)
-    soup_new = _add_undiffable_content(soup_new, replacements_new)
-
-    return soup_new.prettify(formatter='minimal')
-
-
-def _remove_undiffable_content(soup, prefix=''):
-    """
-    Find nodes that cannot be diffed (e.g. <script>, <style>) and replace them
-    with an empty node that has the attribute `wm-diff-replacement="some ID"`
-
-    Returns a tuple of the cleaned-up soup and a dict of replacements.
-    """
-    replacements = {}
-
-    # NOTE: we may want to consider treating <object> and <canvas> similarly.
-    # (They are "transparent" -- containing DOM, but only as a fallback.)
-    for index, element in enumerate(soup.find_all(['script', 'style'])):
-        replacement_id = f'{prefix}-{index}'
-        replacements[replacement_id] = element
-        replacement = soup.new_tag(element.name, **{
-            'wm-diff-replacement': replacement_id
-        })
-        # The replacement has to have text if we want to ensure both old and
-        # new versions of a script are included. Use a single word (so it
-        # can't be broken up) that is unlikely to appear in text.
-        replacement.append(f'$[{replacement_id}]$')
-        element.replace_with(replacement)
-
-    return (soup, replacements)
-
-
-def _add_undiffable_content(soup, replacements):
-    """
-    This is the opposite operation of `_remove_undiffable_content()`. It
-    takes a soup and a replacement dict and replaces nodes in the soup that
-    have the attribute `wm-diff-replacement"some ID"` with the original content
-    from the replacements dict.
-    """
-    for element in soup.select('[wm-diff-replacement]'):
-        replacement = replacements[element['wm-diff-replacement']]
-        if replacement:
-            element.replace_with(replacement)
-
-    return soup
-
-
-def _get_title(soup):
-    return soup.title and soup.title.string or ''
-
-
-def _diff_title(old, new):
-    return ''.join(map(
-        lambda change: ((change[0] == -1 and '<del>{}</del>')
-                        or (change[0] == 1 and '<ins>{}</ins>')
-                        or '{}').format(change[1]),
-        compute_dmp_diff(_get_title(old), _get_title(new))))
-
-
-def _diff_elements(old, new):
-    """
-    Diff the contents of two Beatiful Soup elements. Note that this returns
-    the "new" element with its content replaced by the diff.
-    """
-    if not old or not new:
-        return ''
-    result_element = copy.copy(new)
-    result_element.clear()
-    result_element.append(_htmldiff(str(old), str(new)))
-    return result_element
-
-
-def _htmldiff(old, new):
-    """
-    A slightly customized version of htmldiff that uses different tokens.
-    """
-    old_tokens = tokenize(old)
-    new_tokens = tokenize(new)
-    old_tokens = [_customize_token(token) for token in old_tokens]
-    new_tokens = [_customize_token(token) for token in new_tokens]
-    result = htmldiff_tokens(old_tokens, new_tokens)
-    result = ''.join(result).strip()
-    return fixup_ins_del_tags(result)
-
-
-class MinimalHrefToken(href_token):
-    """
-    A diffable token representing the URL of an <a> element. This allows the
-    URL of a link to be diffed. However, we don't actually want to *render*
-    the URL in the output (it's quite noisy in practice).
-
-    Future revisions may change this for more complex, useful output.
-    """
-    def html(self):
-        return ''
-
-
-def _customize_token(token):
-    """
-    Replace existing diffing tokens with customized ones for better output.
-    """
-    if isinstance(token, href_token):
-        return MinimalHrefToken(
-            str(token),
-            pre_tags=token.pre_tags,
-            post_tags=token.post_tags,
-            trailing_whitespace=token.trailing_whitespace)
-    else:
-        return token
 
 
 def insert_style(html, css):

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -8,6 +8,7 @@ import tornado.ioloop
 import tornado.web
 import web_monitoring
 import web_monitoring.differs
+import web_monitoring.html_diff_render
 
 
 # Map tokens in the REST API to functions in modules.
@@ -20,7 +21,7 @@ DIFF_ROUTES = {
     "html_text_diff": web_monitoring.differs.html_text_diff,
     "html_source_diff": web_monitoring.differs.html_source_diff,
     # three different approaches to the same goal:
-    "html_visual_diff": web_monitoring.differs.html_diff_render,
+    "html_visual_diff": web_monitoring.html_diff_render.html_diff_render,
     "html_tree_diff": web_monitoring.differs.html_tree_diff,
     "html_differ": web_monitoring.differs.html_differ,
 }

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -50,7 +50,7 @@ def html_diff_render(a_text, b_text):
         soup_new.html.insert(0, head)
 
     # htmldiff will unfortunately try to diff the content of elements like
-    # <script> or <style> that embed foreign cnontent that shouldn't be parsed
+    # <script> or <style> that embed foreign content that shouldn't be parsed
     # as part of the DOM. We work around this by replacing those elements
     # with placeholders, but a better upstream fix would be to have
     # `flatten_el()` handle these cases by creating a special token, e.g:

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -139,8 +139,17 @@ def _add_undiffable_content(soup, replacements):
     from the replacements dict.
     """
     for element in soup.select('[wm-diff-replacement]'):
-        replacement = replacements[element['wm-diff-replacement']]
+        replacement_id = element['wm-diff-replacement']
+        replacement = replacements[replacement_id]
         if replacement:
+            if replacement_id.startswith('old-'):
+                replacement['class'] = 'wm-diff-deleted-active'
+                wrapper = soup.new_tag('template')
+                wrapper['class'] = 'wm-diff-deleted-inert'
+                wrapper.append(replacement)
+                replacement = wrapper
+            else:
+                replacement['class'] = 'wm-diff-inserted-active'
             element.replace_with(replacement)
 
     return soup

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -1,0 +1,209 @@
+from bs4 import BeautifulSoup, Comment
+import copy
+from lxml.html.diff import (tokenize, htmldiff_tokens, fixup_ins_del_tags,
+                            href_token)
+from .differs import compute_dmp_diff
+
+
+def html_diff_render(a_text, b_text):
+    """
+    HTML Diff for rendering. This is focused on visually highlighting portions
+    of a page’s text that have been changed. It does not do much to show how
+    node types or attributes have been modified (save for link or image URLs).
+
+    The overall page returned primarily represents the structure of the "new"
+    or "B" version. However, it contains some useful metadata in the `<head>`:
+
+    1. A `<template id="wm-diff-old-head">` contains the contents of the "old"
+       or "A" version’s `<head>`.
+    2. A `<style id="wm-diff-style">` contains styling diff-specific styling.
+    3. A `<meta name="wm-diff-title" content="[diff]">` contains a renderable
+       HTML diff of the page’s `<title>`. For example:
+
+        `The <del>old</del><ins>new</ins> title`
+
+    NOTE: you may want to be careful with rendering this response as-is;
+    inline `<script>` and `<style>` elements may be included twice if they had
+    changes, which could have undesirable runtime effects.
+
+    Example
+    -------
+    text1 = '<!DOCTYPE html><html><head></head><body><p>Paragraph</p></body></html>'
+    text2 = '<!DOCTYPE html><html><head></head><body><h1>Header</h1></body></html>'
+    test_diff_render = html_diff_render(text1,text2)
+    """
+    soup_old = BeautifulSoup(a_text, 'lxml')
+    soup_new = BeautifulSoup(b_text, 'lxml')
+
+    # Remove comment nodes since they generally don't affect display.
+    # NOTE: This could affect display if the removed are conditional comments,
+    # but it's unclear how we'd meaningfully visualize those anyway.
+    [element.extract() for element in
+     soup_old.find_all(string=lambda text:isinstance(text, Comment))]
+    [element.extract() for element in
+     soup_new.find_all(string=lambda text:isinstance(text, Comment))]
+
+    # Ensure the new soup (which we will modify and return) has a `<head>`
+    if not soup_new.head:
+        head = soup_new.new_tag('head')
+        soup_new.html.insert(0, head)
+
+    # htmldiff will unfortunately try to diff the content of elements like
+    # <script> or <style> that embed foreign cnontent that shouldn't be parsed
+    # as part of the DOM. We work around this by replacing those elements
+    # with placeholders, but a better upstream fix would be to have
+    # `flatten_el()` handle these cases by creating a special token, e.g:
+    #
+    #  class undiffable_tag(token):
+    #    def __new__(cls, html_repr, **kwargs):
+    #      # Make the value this represents for diffing an empty string
+    #      obj = token.__new__(cls, '', **kwargs)
+    #      # But keep the actual source around for serializing when done
+    #      obj.html_repr = html_repr
+    #
+    #    def html(obj):
+    #      return self.html_repr
+    soup_old, replacements_old = _remove_undiffable_content(soup_old, 'old')
+    soup_new, replacements_new = _remove_undiffable_content(soup_new, 'new')
+
+    # htmldiff primarily diffs just *readable text*, so it doesn't really
+    # diff parts of the page outside the `<body>` (e.g. `<head>`). We don't
+    # have a great way to visualize metadata changes anyway.
+    soup_new.body.replace_with(_diff_elements(soup_old.body, soup_new.body))
+
+    # The `name` keyword sets the node name, not the `name` attribute
+    title_meta = soup_new.new_tag(
+        'meta',
+        content=_diff_title(soup_old, soup_new))
+    title_meta.attrs['name'] = 'wm-diff-title'
+    soup_new.head.append(title_meta)
+
+    old_head = soup_new.new_tag('template', id='wm-diff-old-head')
+    if soup_old.head:
+        for node in soup_old.head.contents.copy():
+            old_head.append(node)
+    soup_new.head.append(old_head)
+
+    change_styles = soup_new.new_tag(
+        "style",
+        type="text/css",
+        id='wm-diff-style')
+    change_styles.string = """
+        ins {text-decoration: none; background-color: #d4fcbc;}
+        del {text-decoration: none; background-color: #fbb6c2;}"""
+    soup_new.head.append(change_styles)
+
+    # The method we use above to append HTML strings (the diffs) to the soup
+    # results in a non-navigable soup. So we serialize and re-parse :(
+    # (Note we use no formatter for this because proper encoding escape the
+    # tags our differ generated.)
+    soup_new = BeautifulSoup(soup_new.prettify(formatter=None), 'lxml')
+    replacements_new.update(replacements_old)
+    soup_new = _add_undiffable_content(soup_new, replacements_new)
+
+    return soup_new.prettify(formatter='minimal')
+
+
+def _remove_undiffable_content(soup, prefix=''):
+    """
+    Find nodes that cannot be diffed (e.g. <script>, <style>) and replace them
+    with an empty node that has the attribute `wm-diff-replacement="some ID"`
+
+    Returns a tuple of the cleaned-up soup and a dict of replacements.
+    """
+    replacements = {}
+
+    # NOTE: we may want to consider treating <object> and <canvas> similarly.
+    # (They are "transparent" -- containing DOM, but only as a fallback.)
+    for index, element in enumerate(soup.find_all(['script', 'style'])):
+        replacement_id = f'{prefix}-{index}'
+        replacements[replacement_id] = element
+        replacement = soup.new_tag(element.name, **{
+            'wm-diff-replacement': replacement_id
+        })
+        # The replacement has to have text if we want to ensure both old and
+        # new versions of a script are included. Use a single word (so it
+        # can't be broken up) that is unlikely to appear in text.
+        replacement.append(f'$[{replacement_id}]$')
+        element.replace_with(replacement)
+
+    return (soup, replacements)
+
+
+def _add_undiffable_content(soup, replacements):
+    """
+    This is the opposite operation of `_remove_undiffable_content()`. It
+    takes a soup and a replacement dict and replaces nodes in the soup that
+    have the attribute `wm-diff-replacement"some ID"` with the original content
+    from the replacements dict.
+    """
+    for element in soup.select('[wm-diff-replacement]'):
+        replacement = replacements[element['wm-diff-replacement']]
+        if replacement:
+            element.replace_with(replacement)
+
+    return soup
+
+
+def _get_title(soup):
+    return soup.title and soup.title.string or ''
+
+
+def _diff_title(old, new):
+    return ''.join(map(
+        lambda change: ((change[0] == -1 and '<del>{}</del>')
+                        or (change[0] == 1 and '<ins>{}</ins>')
+                        or '{}').format(change[1]),
+        compute_dmp_diff(_get_title(old), _get_title(new))))
+
+
+def _diff_elements(old, new):
+    """
+    Diff the contents of two Beatiful Soup elements. Note that this returns
+    the "new" element with its content replaced by the diff.
+    """
+    if not old or not new:
+        return ''
+    result_element = copy.copy(new)
+    result_element.clear()
+    result_element.append(_htmldiff(str(old), str(new)))
+    return result_element
+
+
+def _htmldiff(old, new):
+    """
+    A slightly customized version of htmldiff that uses different tokens.
+    """
+    old_tokens = tokenize(old)
+    new_tokens = tokenize(new)
+    old_tokens = [_customize_token(token) for token in old_tokens]
+    new_tokens = [_customize_token(token) for token in new_tokens]
+    result = htmldiff_tokens(old_tokens, new_tokens)
+    result = ''.join(result).strip()
+    return fixup_ins_del_tags(result)
+
+
+class MinimalHrefToken(href_token):
+    """
+    A diffable token representing the URL of an <a> element. This allows the
+    URL of a link to be diffed. However, we don't actually want to *render*
+    the URL in the output (it's quite noisy in practice).
+
+    Future revisions may change this for more complex, useful output.
+    """
+    def html(self):
+        return ''
+
+
+def _customize_token(token):
+    """
+    Replace existing diffing tokens with customized ones for better output.
+    """
+    if isinstance(token, href_token):
+        return MinimalHrefToken(
+            str(token),
+            pre_tags=token.pre_tags,
+            post_tags=token.post_tags,
+            trailing_whitespace=token.trailing_whitespace)
+    else:
+        return token

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -1,5 +1,7 @@
 import pytest
+import re
 import web_monitoring.differs as wd
+
 
 def test_side_by_side_text():
     actual = wd.side_by_side_text(a_text='<html><body>hi</body></html>',
@@ -23,6 +25,7 @@ def test_identical_bytes():
     expected = False
     assert actual == expected
 
+
 def test_text_diff():
     actual = wd.html_text_diff('<p>Deleted</p><p>Unchanged</p>',
                                '<p>Added</p><p>Unchanged</p>')
@@ -31,6 +34,7 @@ def test_text_diff():
                 (1, 'Add'),
                 (0, 'ed Unchanged')]
     assert actual == expected
+
 
 def test_text_diff_omits_more_than_two_consecutive_blank_lines():
     actual = wd.html_text_diff('''<p>Deleted</p>
@@ -60,3 +64,54 @@ def test_get_visible_text():
     html = '<!--First comment--><h1>First Heading</h1><p>First paragraph.</p>'
     actual = wd._get_visible_text(html)
     assert actual == 'First Heading First paragraph.'
+
+
+# TODO: extend this to other html differs
+# Should these move to `test_html_diff.py`? I kept them out of there because
+# that file is mostly concerned with creating evaluatable output, not testing
+# for correctness/validity like these are. These can actual FAIL.
+def test_html_diff_render_does_not_encode_embedded_content():
+    html = '<script>console.log("uhoh");</script> ok ' \
+           '<style>body {font-family: "arial";}</style>'
+    result = wd.html_diff_render(f'Hi! {html}', f'Bye {html}')
+    assert '&quot;' not in result
+
+
+def test_html_diff_render_doesnt_move_script_content_into_page_text():
+    '''
+    If the differ is actually diffing text across nodes and doesn't treat
+    scripts specially, having a new script tag added after the original one
+    (when the original one has changed content) can cause that start tag of the
+    added script to get inserted inside the first script. Because it's embedded
+    content, the close tag of the added script winds up closing the first
+    script, and any deletions from the original script wind up being placed
+    afterward, where they are no longer treated as script content.
+
+    Confusing, I know. See test code below for example.
+
+    Note this can occur with tag that embeds foreign content that is not parsed
+    as part of the DOM (e.g. `<style>`).
+    '''
+    a = '''<div><script>var x = {json: 'old data};</script></div>'''
+    b = '''<div><script>var x = {new: 'updated'};</script>
+<script>var what = "totally new!";</script></div>'''
+
+    # If this is broken, the output will look like:
+    #   <div>
+    #     <script>var x = <ins>{new: &#x27;updated&#x27;};<script>var what = &quot;totally new!&quot;;</script>
+    #     <del>{json: 'old data};</del>
+    #   </div>
+    # Note how the deleted script code got extracted out into page text.
+    result = wd.html_diff_render(a, b)
+
+    # if we remove scripts from the result we should have an empty <div>
+    body = re.search(r'(?s)<body>(.*)</body>', result)[1]
+    without_script = re.sub(r'(?s)<script>.*?</script>', '', body).strip()
+    assert re.match(r'<div>\s*</div>', without_script) is not None
+
+
+@pytest.mark.skip(reason='lxml parser does not support CDATA in html')
+def test_html_diff_render_preserves_cdata_content():
+    html = '<foo>A CDATA section: <![CDATA[ <hi>yes</hi> ]]> {}.</foo>'
+    result = wd.html_diff_render(html.format('old'), html.format('new'))
+    assert re.match(r'(&lt;hi&gt;)|(<!\[CDATA\[\s*<hi>)', result) is not None

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -1,5 +1,4 @@
 import pytest
-import re
 import web_monitoring.differs as wd
 
 
@@ -64,55 +63,3 @@ def test_get_visible_text():
     html = '<!--First comment--><h1>First Heading</h1><p>First paragraph.</p>'
     actual = wd._get_visible_text(html)
     assert actual == 'First Heading First paragraph.'
-
-
-# TODO: extend this to other html differs
-# Should these move to `test_html_diff.py`? I kept them out of there because
-# that file is mostly concerned with creating evaluatable output, not testing
-# for correctness/validity like these are. These can actual FAIL.
-def test_html_diff_render_does_not_encode_embedded_content():
-    html = '<script>console.log("uhoh");</script> ok ' \
-           '<style>body {font-family: "arial";}</style>'
-    result = wd.html_diff_render(f'Hi! {html}', f'Bye {html}')
-    assert '&quot;' not in result
-
-
-def test_html_diff_render_doesnt_move_script_content_into_page_text():
-    '''
-    If the differ is actually diffing text across nodes and doesn't treat
-    scripts specially, having a new script tag added after the original one
-    (when the original one has changed content) can cause that start tag of the
-    added script to get inserted inside the first script. Because it's embedded
-    content, the close tag of the added script winds up closing the first
-    script, and any deletions from the original script wind up being placed
-    afterward, where they are no longer treated as script content.
-
-    Confusing, I know. See test code below for example.
-
-    Note this can occur with tag that embeds foreign content that is not parsed
-    as part of the DOM (e.g. `<style>`).
-    '''
-    a = '''<div><script>var x = {json: 'old data};</script></div>'''
-    b = '''<div><script>var x = {new: 'updated'};</script>
-<script>var what = "totally new!";</script></div>'''
-
-    # If this is broken, the output will look like:
-    #   <div>
-    #     <script>var x = <ins>{new: &#x27;updated&#x27;};<script>var what = &quot;totally new!&quot;;</script>
-    #     <del>{json: 'old data};</del>
-    #   </div>
-    # Note how the deleted script code got extracted out into page text.
-    result = wd.html_diff_render(a, b)
-
-    # if we remove scripts from the result we should have an empty <div>
-    body = re.search(r'(?s)<body>(.*)</body>', result)[1]
-    without_script = re.sub(r'(?s)<script>.*?</script>', '', body)
-    text_only = re.sub(r'<[^>]+>', '', without_script).strip()
-    assert text_only == ''
-
-
-@pytest.mark.skip(reason='lxml parser does not support CDATA in html')
-def test_html_diff_render_preserves_cdata_content():
-    html = '<foo>A CDATA section: <![CDATA[ <hi>yes</hi> ]]> {}.</foo>'
-    result = wd.html_diff_render(html.format('old'), html.format('new'))
-    assert re.match(r'(&lt;hi&gt;)|(<!\[CDATA\[\s*<hi>)', result) is not None

--- a/web_monitoring/tests/test_differs.py
+++ b/web_monitoring/tests/test_differs.py
@@ -106,8 +106,9 @@ def test_html_diff_render_doesnt_move_script_content_into_page_text():
 
     # if we remove scripts from the result we should have an empty <div>
     body = re.search(r'(?s)<body>(.*)</body>', result)[1]
-    without_script = re.sub(r'(?s)<script>.*?</script>', '', body).strip()
-    assert re.match(r'<div>\s*</div>', without_script) is not None
+    without_script = re.sub(r'(?s)<script>.*?</script>', '', body)
+    text_only = re.sub(r'<[^>]+>', '', without_script).strip()
+    assert text_only == ''
 
 
 @pytest.mark.skip(reason='lxml parser does not support CDATA in html')

--- a/web_monitoring/tests/test_html_diff.py
+++ b/web_monitoring/tests/test_html_diff.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from pkg_resources import resource_filename
 import pytest
 from web_monitoring.db import Client
-from web_monitoring.differs import (html_diff_render, html_tree_diff,
-                                    html_differ)
+from web_monitoring.differs import html_tree_diff, html_differ
+from web_monitoring.html_diff_render import html_diff_render
 
 
 def lookup_pair(fn):

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -1,7 +1,7 @@
 """
 This module hosts tests for visual HTML diffs that check validity -- that is,
 they focus on whether the diff will render properly or outputs correct/working
-markup. Unlike the tests in `test-html_diff.py`, these tests can actually fail
+markup. Unlike the tests in `test_html_diff.py`, these tests can actually fail
 in the sense that the diff is “wrong” as opposed to just testing that the diff
 doesn’t break or throw exceptions.
 """

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -51,7 +51,7 @@ def test_html_diff_render_doesnt_move_script_content_into_page_text():
 
     # if we remove scripts from the result we should have an empty <div>
     body = re.search(r'(?s)<body>(.*)</body>', result)[1]
-    without_script = re.sub(r'(?s)<script>.*?</script>', '', body)
+    without_script = re.sub(r'(?s)<script[^>]*>.*?</script>', '', body)
     text_only = re.sub(r'<[^>]+>', '', without_script).strip()
     assert text_only == ''
 

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -1,0 +1,63 @@
+"""
+This module hosts tests for visual HTML diffs that check validity -- that is,
+they focus on whether the diff will render properly or outputs correct/working
+markup. Unlike the tests in `test-html_diff.py`, these tests can actually fail
+in the sense that the diff is “wrong” as opposed to just testing that the diff
+doesn’t break or throw exceptions.
+"""
+
+import pytest
+import re
+from web_monitoring.html_diff_render import html_diff_render
+
+
+# TODO: extend these to other html differs via parameterization, a la
+# `test_html_diff.py`. Most of these are written generically enough they could
+# feasibly work with any visual HTML diff routine.
+
+def test_html_diff_render_does_not_encode_embedded_content():
+    html = '<script>console.log("uhoh");</script> ok ' \
+           '<style>body {font-family: "arial";}</style>'
+    result = html_diff_render(f'Hi! {html}', f'Bye {html}')
+    assert '&quot;' not in result
+
+
+def test_html_diff_render_doesnt_move_script_content_into_page_text():
+    '''
+    If the differ is actually diffing text across nodes and doesn't treat
+    scripts specially, having a new script tag added after the original one
+    (when the original one has changed content) can cause that start tag of the
+    added script to get inserted inside the first script. Because it's embedded
+    content, the close tag of the added script winds up closing the first
+    script, and any deletions from the original script wind up being placed
+    afterward, where they are no longer treated as script content.
+
+    Confusing, I know. See test code below for example.
+
+    Note this can occur with tag that embeds foreign content that is not parsed
+    as part of the DOM (e.g. `<style>`).
+    '''
+    a = '''<div><script>var x = {json: 'old data};</script></div>'''
+    b = '''<div><script>var x = {new: 'updated'};</script>
+<script>var what = "totally new!";</script></div>'''
+
+    # If this is broken, the output will look like:
+    #   <div>
+    #     <script>var x = <ins>{new: &#x27;updated&#x27;};<script>var what = &quot;totally new!&quot;;</script>
+    #     <del>{json: 'old data};</del>
+    #   </div>
+    # Note how the deleted script code got extracted out into page text.
+    result = html_diff_render(a, b)
+
+    # if we remove scripts from the result we should have an empty <div>
+    body = re.search(r'(?s)<body>(.*)</body>', result)[1]
+    without_script = re.sub(r'(?s)<script>.*?</script>', '', body)
+    text_only = re.sub(r'<[^>]+>', '', without_script).strip()
+    assert text_only == ''
+
+
+@pytest.mark.skip(reason='lxml parser does not support CDATA in html')
+def test_html_diff_render_preserves_cdata_content():
+    html = '<foo>A CDATA section: <![CDATA[ <hi>yes</hi> ]]> {}.</foo>'
+    result = html_diff_render(html.format('old'), html.format('new'))
+    assert re.match(r'(&lt;hi&gt;)|(<!\[CDATA\[\s*<hi>)', result) is not None


### PR DESCRIPTION
**Work in Progress; Do Not Merge**

These are a few quick-and-dirty fixes and hacks for the `html_diff_render` visual diff so that it works better in real-world scenarios where we hit lots of problems. This will be a little bit of a grab-bag, but I intend to keep this relatively small so it can be merged by the end of the week and then iterated on.

- [x] Handle `<script>` and `<style>` elements well (#94 plus more)
- [x] Don’t diff stuff in the `<head>` (except may be `<title>`); just use the new version (maybe keep old stuff in a `<template>`, which is inert).
- [x] Remove the “Link: [url]” text after changed links (ideally, still include it as title text or something a script can turn into useful display)
- [x] See if there’s an obvious fix for #124 (list of links). Only address here if it’s easy.
- [ ] Look into character encoding issues @trinberg mentioned.
- [x] ¿Split this differ and all its associated support functions into a separate module? (There is a lot of code involved in cleaning up and working around its issues.)