### PR TITLE
Limit coverage reporting to our own code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source =
+    web_monitoring
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*
+    # ignore _version.py and versioneer.py
+    .*version.*
+    *_version.py
+
+exclude_lines =
+    if __name__ == '__main__':

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   override:
-    - coverage run run_tests.py -v web_monitoring/tests/
+    - coverage run --source web_monitoring run_tests.py -v web_monitoring/tests/
     - pyflakes web_monitoring
     - coverage report -m
     - cd docs && make html

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   override:
-    - coverage run --source web_monitoring run_tests.py -v web_monitoring/tests/
+    - coverage run run_tests.py -v web_monitoring/tests/
     - pyflakes web_monitoring
     - coverage report -m
     - cd docs && make html


### PR DESCRIPTION
Checking coverage locally or in CI gets kinda crazy because our coverage reports are including all our dependencies. This is just a simple switch to limit coverage to code in the `web_monitoring` directory. Not sure if I should also be excluding `web_monitoring/tests`.