### PR TITLE
HOTFIX: Diff HTML pages without a `<head>`

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -204,7 +204,10 @@ def html_diff_render(a_text, b_text, include='combined'):
     [element.extract() for element in
      soup_new.find_all(string=lambda text:isinstance(text, Comment))]
 
-    # Ensure the new soup (which we will modify and return) has a `<head>`
+    # Ensure the soups (which we will modify and return) each have a `<head>`
+    if not soup_old.head:
+        head = soup_old.new_tag('head')
+        soup_old.html.insert(0, head)
     if not soup_new.head:
         head = soup_new.new_tag('head')
         soup_new.html.insert(0, head)

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -15,6 +15,13 @@ from web_monitoring.html_diff_render import html_diff_render
 # `test_html_diff.py`. Most of these are written generically enough they could
 # feasibly work with any visual HTML diff routine.
 
+def test_html_diff_render_works_on_pages_with_no_head():
+    result = html_diff_render('<html><body>Hello</body></html>',
+                              '<html><body>Goodbye</body></html>',
+                              include='deletions')
+    assert result
+
+
 def test_html_diff_render_does_not_encode_embedded_content():
     html = '<script>console.log("uhoh");</script> ok ' \
            '<style>body {font-family: "arial";}</style>'


### PR DESCRIPTION
Inside the `html_token` diff, the “combined” and “additions” diffs support documents with no `<head>`, but the “deletions” diff did not. Ooooooops. This follows the procedure for the “additions” diff and explicitly inserts a `<head>` for manipulating if one is not present.

Note that, in the page that caused this issue, we have some other problems where the styling is still getting stripped. That’s because of how `lxml.html.diff` does tokenization, which we’ve been meaning to fork and improve as well, but haven’t had the time to get to yet. It’s *much* more involved, so this hotfix just solves the immediate issue of the differ raising an exception and stopping.

Fixes #143. 
