### PR TITLE
Fully fork lxml.html.diff; fix the foreign/undiffable content problem

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -18,12 +18,17 @@ For now, you can mentally divide this module into two sections:
 from bs4 import BeautifulSoup, Comment
 from collections import Counter, namedtuple
 import copy
+import difflib
 import html
 import logging
-from lxml.html.diff import (tokenize, href_token, tag_token, expand_tokens,
-                            InsensitiveSequenceMatcher)
-from lxml.html.diff import token as DiffToken
+import re
 from .differs import compute_dmp_diff
+
+# Imports only used in forked tokenization code; may be ripe for removal:
+from lxml import etree
+from lxml.html import fragment_fromstring
+from html import escape as html_escape
+
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +97,8 @@ block_level_tags = (
     'slot',
 )
 
-empty_tags = (
+# "void" in the HTML sense -- these tags do not having a closing tag
+void_tags = (
     'area',
     'base',
     'basefont',
@@ -100,7 +106,6 @@ empty_tags = (
     'col',
     'embed',
     'img',
-    'iframe',  # TODO: make sure we treat these right -- they need closing tags
     'input',
     'link',
     'meta',
@@ -109,6 +114,9 @@ empty_tags = (
     'track',
     'wbr'
 )
+
+# Tags that do not allow content or whose content can be ignored
+empty_tags = (*void_tags, 'iframe')
 
 # Should be treated as a single unit for diffing purposes -- their content is not HTML
 # TODO: fork the tokenization part of lxml.html.diff and use this list!
@@ -435,6 +443,289 @@ def _count_changes(opcodes):
     }
 
 
+# --------------------- lxml.html.diff Tokenization --------------------------
+# The following tokenization-related code is more-or-less copied from
+# lxml.html.diff. We plan to change it significantly.
+
+def expand_tokens(tokens, equal=False):
+    """Given a list of tokens, return a generator of the chunks of
+    text for the data in the tokens.
+    """
+    for token in tokens:
+        for pre in token.pre_tags:
+            yield pre
+        if not equal or not token.hide_when_equal:
+            if token.trailing_whitespace:
+                yield token.html() + token.trailing_whitespace
+            else:
+                yield token.html()
+        for post in token.post_tags:
+            yield post
+
+
+class DiffToken(str):
+    """ Represents a diffable token, generally a word that is displayed to
+    the user.  Opening tags are attached to this token when they are
+    adjacent (pre_tags) and closing tags that follow the word
+    (post_tags).  Some exceptions occur when there are empty tags
+    adjacent to a word, so there may be close tags in pre_tags, or
+    open tags in post_tags.
+
+    We also keep track of whether the word was originally followed by
+    whitespace, even though we do not want to treat the word as
+    equivalent to a similar word that does not have a trailing
+    space."""
+
+    # When this is true, the token will be eliminated from the
+    # displayed diff if no change has occurred:
+    hide_when_equal = False
+
+    def __new__(cls, text, pre_tags=None, post_tags=None, trailing_whitespace=""):
+        obj = str.__new__(cls, text)
+
+        if pre_tags is not None:
+            obj.pre_tags = pre_tags
+        else:
+            obj.pre_tags = []
+
+        if post_tags is not None:
+            obj.post_tags = post_tags
+        else:
+            obj.post_tags = []
+
+        obj.trailing_whitespace = trailing_whitespace
+
+        return obj
+
+    def __repr__(self):
+        return 'DiffToken(%s, %r, %r, %r)' % (str.__repr__(self), self.pre_tags,
+                                              self.post_tags, self.trailing_whitespace)
+
+    def html(self):
+        return str(self)
+
+
+class tag_token(DiffToken):
+
+    """ Represents a token that is actually a tag.  Currently this is just
+    the <img> tag, which takes up visible space just like a word but
+    is only represented in a document by a tag.  """
+
+    def __new__(cls, tag, data, html_repr, pre_tags=None,
+                post_tags=None, trailing_whitespace=""):
+        obj = DiffToken.__new__(cls, "%s: %s" % (type, data),
+                            pre_tags=pre_tags,
+                            post_tags=post_tags,
+                            trailing_whitespace=trailing_whitespace)
+        obj.tag = tag
+        obj.data = data
+        obj.html_repr = html_repr
+        return obj
+
+    def __repr__(self):
+        return 'tag_token(%s, %s, html_repr=%s, post_tags=%r, pre_tags=%r, trailing_whitespace=%r)' % (
+            self.tag,
+            self.data,
+            self.html_repr,
+            self.pre_tags,
+            self.post_tags,
+            self.trailing_whitespace)
+    def html(self):
+        return self.html_repr
+
+class href_token(DiffToken):
+    """ Represents the href in an anchor tag.  Unlike other words, we only
+    show the href when it changes.  """
+
+    hide_when_equal = True
+
+    def html(self):
+        return ' Link: %s' % self
+
+def tokenize(html, include_hrefs=True):
+    """
+    Parse the given HTML and returns token objects (words with attached tags).
+
+    This parses only the content of a page; anything in the head is
+    ignored, and the <head> and <body> elements are themselves
+    optional.  The content is then parsed by lxml, which ensures the
+    validity of the resulting parsed document (though lxml may make
+    incorrect guesses when the markup is particular bad).
+
+    <ins> and <del> tags are also eliminated from the document, as
+    that gets confusing.
+
+    If include_hrefs is true, then the href attribute of <a> tags is
+    included as a special kind of diffable token."""
+    if etree.iselement(html):
+        body_el = html
+    else:
+        body_el = parse_html(html, cleanup=True)
+    # Then we split the document into text chunks for each tag, word, and end tag:
+    chunks = flatten_el(body_el, skip_tag=True, include_hrefs=include_hrefs)
+    # Finally re-joining them into token objects:
+    return fixup_chunks(chunks)
+
+def parse_html(html, cleanup=True):
+    """
+    Parses an HTML fragment, returning an lxml element.  Note that the HTML will be
+    wrapped in a <div> tag that was not in the original document.
+
+    If cleanup is true, make sure there's no <head> or <body>, and get
+    rid of any <ins> and <del> tags.
+    """
+    if cleanup:
+        # This removes any extra markup or structure like <head>:
+        html = cleanup_html(html)
+    return fragment_fromstring(html, create_parent=True)
+
+_body_re = re.compile(r'<body.*?>', re.I|re.S)
+_end_body_re = re.compile(r'</body.*?>', re.I|re.S)
+_ins_del_re = re.compile(r'</?(ins|del).*?>', re.I|re.S)
+
+def cleanup_html(html):
+    """ This 'cleans' the HTML, meaning that any page structure is removed
+    (only the contents of <body> are used, if there is any <body).
+    Also <ins> and <del> tags are removed.  """
+    match = _body_re.search(html)
+    if match:
+        html = html[match.end():]
+    match = _end_body_re.search(html)
+    if match:
+        html = html[:match.start()]
+    html = _ins_del_re.sub('', html)
+    return html
+
+def split_trailing_whitespace(word):
+    """
+    This function takes a word, such as 'test\n\n' and returns ('test','\n\n')
+    """
+    stripped_length = len(word.rstrip())
+    return word[0:stripped_length], word[stripped_length:]
+
+
+def fixup_chunks(chunks):
+    """
+    This function takes a list of chunks and produces a list of tokens.
+    """
+    tag_accum = []
+    cur_word = None
+    result = []
+    for chunk in chunks:
+        if isinstance(chunk, tuple):
+            if chunk[0] == 'img':
+                src = chunk[1]
+                tag, trailing_whitespace = split_trailing_whitespace(chunk[2])
+                cur_word = tag_token('img', src, html_repr=tag,
+                                     pre_tags=tag_accum,
+                                     trailing_whitespace=trailing_whitespace)
+                tag_accum = []
+                result.append(cur_word)
+
+            elif chunk[0] == 'href':
+                href = chunk[1]
+                cur_word = href_token(href, pre_tags=tag_accum, trailing_whitespace=" ")
+                tag_accum = []
+                result.append(cur_word)
+            continue
+
+        if is_word(chunk):
+            chunk, trailing_whitespace = split_trailing_whitespace(chunk)
+            cur_word = DiffToken(chunk, pre_tags=tag_accum, trailing_whitespace=trailing_whitespace)
+            tag_accum = []
+            result.append(cur_word)
+
+        elif is_start_tag(chunk):
+            tag_accum.append(chunk)
+
+        elif is_end_tag(chunk):
+            if tag_accum:
+                tag_accum.append(chunk)
+            else:
+                assert cur_word, (
+                    "Weird state, cur_word=%r, result=%r, chunks=%r of %r"
+                    % (cur_word, result, chunk, chunks))
+                cur_word.post_tags.append(chunk)
+        else:
+            assert(0)
+
+    if not result:
+        return [DiffToken('', pre_tags=tag_accum)]
+    else:
+        result[-1].post_tags.extend(tag_accum)
+
+    return result
+
+def flatten_el(el, include_hrefs, skip_tag=False):
+    """ Takes an lxml element el, and generates all the text chunks for
+    that tag.  Each start tag is a chunk, each word is a chunk, and each
+    end tag is a chunk.
+
+    If skip_tag is true, then the outermost container tag is
+    not returned (just its contents)."""
+    if not skip_tag:
+        if el.tag == 'img':
+            yield ('img', el.get('src'), start_tag(el))
+        else:
+            yield start_tag(el)
+    if el.tag in void_tags and not el.text and not len(el) and not el.tail:
+        return
+    start_words = split_words(el.text)
+    for word in start_words:
+        yield html_escape(word)
+    for child in el:
+        for item in flatten_el(child, include_hrefs=include_hrefs):
+            yield item
+    if el.tag == 'a' and el.get('href') and include_hrefs:
+        yield ('href', el.get('href'))
+    if not skip_tag:
+        yield end_tag(el)
+        end_words = split_words(el.tail)
+        for word in end_words:
+            yield html_escape(word)
+
+split_words_re = re.compile(r'\S+(?:\s+|$)', re.U)
+
+def split_words(text):
+    """ Splits some text into words. Includes trailing whitespace
+    on each word when appropriate.  """
+    if not text or not text.strip():
+        return []
+
+    words = split_words_re.findall(text)
+    return words
+
+start_whitespace_re = re.compile(r'^[ \t\n\r]')
+
+def start_tag(el):
+    """
+    The text representation of the start tag for a tag.
+    """
+    return '<%s%s>' % (
+        el.tag, ''.join([' %s="%s"' % (name, html_escape(value, True))
+                         for name, value in el.attrib.items()]))
+
+def end_tag(el):
+    """ The text representation of an end tag for a tag.  Includes
+    trailing whitespace when appropriate.  """
+    if el.tail and start_whitespace_re.search(el.tail):
+        extra = ' '
+    else:
+        extra = ''
+    return '</%s>%s' % (el.tag, extra)
+
+def is_word(tok):
+    return not tok.startswith('<')
+
+def is_end_tag(tok):
+    return tok.startswith('</')
+
+def is_start_tag(tok):
+    return tok.startswith('<') and not tok.startswith('</')
+
+# ------------------ END lxml.html.diff Tokenization ------------------------
+
+
 class MinimalHrefToken(href_token):
     """
     A diffable token representing the URL of an <a> element. This allows the
@@ -468,7 +759,7 @@ class MinimalHrefToken(href_token):
 # unchanged areas in the diff, but not render that crap to the final result.
 class SpacerToken(DiffToken):
     # def __new__(cls, text, pre_tags=None, post_tags=None, trailing_whitespace=""):
-    #     obj = _unicode.__new__(cls, text)
+    #     obj = str.__new__(cls, text)
 
     #     if pre_tags is not None:
     #         obj.pre_tags = pre_tags
@@ -1321,6 +1612,23 @@ def flatten_groups(groups, include_non_groups=True):
             flat.append(item)
 
     return flat
+
+
+class InsensitiveSequenceMatcher(difflib.SequenceMatcher):
+    """
+    Acts like SequenceMatcher, but tries not to find very small equal
+    blocks amidst large spans of changes
+    """
+
+    threshold = 2
+
+    def get_matching_blocks(self):
+        size = min(len(self.b), len(self.b))
+        threshold = min(self.threshold, size / 4)
+        actual = difflib.SequenceMatcher.get_matching_blocks(self)
+        return [item for item in actual
+                if item[2] > threshold
+                or not item[2]]
 
 
 UPDATE_CONTRAST_SCRIPT = """

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -1008,7 +1008,7 @@ def merge_changes(change_chunks, doc, tag_type='ins'):
         if chunk[0] == '<':
             # NOTE: split first by `>` because we could have undiffable items
             # with content here, i.e. more than one tag.
-            name = chunk.split('>')[0].split()[0].strip('<>/')
+            name = chunk.split('>', 1)[0].split(None, 1)[0].strip('<>/')
             # Also treat `a` tags as block in this context, because they *can*
             # contain block elements, like `h1`, etc.
             is_block = name in block_level_tags or name == 'a'
@@ -1069,7 +1069,9 @@ def merge_changes(change_chunks, doc, tag_type='ins'):
         # Note the undiffable_content_tags check here. We assume tokens for
         # those tags represent a whole element, not just a start or end tag,
         # so we don't consider them "open" as part of `current_content`.
-        if inline_tag and inline_tag_name not in undiffable_content_tags and inline_tag_name not in empty_tags:
+        if (inline_tag and
+                (inline_tag_name not in undiffable_content_tags) and
+                (inline_tag_name not in empty_tags)):
             # FIXME: track the original start tag for when we need to break
             # these elements around boundaries.
             current_content.insert(0, inline_tag_name)
@@ -1266,7 +1268,7 @@ def merge_change_groups(change_chunks, doc, tag_type=None):
         if chunk[0] == '<':
             # NOTE: split first by `>` because we could have undiffable items
             # with content here, i.e. more than one tag.
-            name = chunk.split('>')[0].split()[0].strip('<>/')
+            name = chunk.split('>', 1)[0].split(None, 1)[0].strip('<>/')
             # Also treat `a` tags as block in this context, because they *can*
             # contain block elements, like `h1`, etc.
             is_block = name in block_level_tags or name == 'a'
@@ -1343,7 +1345,9 @@ def merge_change_groups(change_chunks, doc, tag_type=None):
         # Note the undiffable_content_tags check here. We assume tokens for
         # those tags represent a whole element, not just a start or end tag,
         # so we don't consider them "open" as part of `current_content`.
-        if inline_tag and inline_tag_name not in empty_tags and inline_tag_name not in undiffable_content_tags:
+        if (inline_tag and
+                (inline_tag_name not in undiffable_content_tags) and
+                (inline_tag_name not in empty_tags)):
             # FIXME: track the original start tag for when we need to break
             # these elements around boundaries.
             current_content.insert(0, inline_tag_name)
@@ -1576,7 +1580,7 @@ class InsensitiveSequenceMatcher(difflib.SequenceMatcher):
     threshold = 2
 
     def get_matching_blocks(self):
-        size = min(len(self.b), len(self.b))
+        size = min(len(self.a), len(self.b))
         threshold = min(self.threshold, size / 4)
         actual = difflib.SequenceMatcher.get_matching_blocks(self)
         return [item for item in actual


### PR DESCRIPTION
This finally fully forks `lxml.html.diff` (#145); we no longer utilize any parts of it (thought we do have large chunks of its tokenization routine now sitting in our module—but we will probably change those). 

This also fixes #146, where we always show SVG, MathML, styles, scripts, and other non-HTML content as changing, even if it didn’t. That was because of my earlier clever-but-horrible hack to remove that content before diffing (because the tokenizer would always try to tokenize the contents of those elements) and put it back in after. Now, because we own the tokenizing routine instead of using lxml’s, we can prevent the contents of those elements from being tokenized so they *actually get diffed,* but as single, complete tokens that never get broken up.