### PR TITLE
Rewrite outgoing links diff to not use `html_token`

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -24,7 +24,8 @@ DIFF_ROUTES = {
     "identical_bytes": web_monitoring.differs.identical_bytes,
     "pagefreezer": web_monitoring.differs.pagefreezer,
     "side_by_side_text": web_monitoring.differs.side_by_side_text,
-    "links": web_monitoring.links_diff.links_diff,
+    "links": web_monitoring.links_diff.links_diff_html,
+    "links_json": web_monitoring.links_diff.links_diff_json,
     # applying diff-match-patch (dmp) to strings (no tokenization)
     "html_text_dmp": web_monitoring.differs.html_text_diff,
     "html_source_dmp": web_monitoring.differs.html_source_diff,

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -321,6 +321,7 @@ def _table_row_for_link(soup, change_type, link):
 
     return row
 
+
 def _render_html_diff(raw_diff):
     """
     Create a Beautiful Soup document representing a diff.
@@ -331,13 +332,10 @@ def _render_html_diff(raw_diff):
         The basic diff as a sequence of opcodes and links.
     """
     result = _create_empty_soup()
-    links_table = result.new_tag('table')
-    links_table['class'] = 'links-list'
-    links_body = result.new_tag('tbody')
-    links_table.append(links_body)
-    result.body.append(links_table)
-
-    for code, link in raw_diff:
-        links_body.append(_table_row_for_link(result, code, link))
+    result.body.append(
+        _tag(result, 'table', {'class': 'links-list'},
+             _tag(result, 'tbody', {}, *(
+                  _table_row_for_link(result, code, link)
+                  for code, link in raw_diff))))
 
     return result

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -126,6 +126,16 @@ class Link:
     """
     Represents a link that was used on the page. Designed to be fed into
     SequenceMatcher for diffing.
+
+    Note that Link objects have a very loose sense of equality. That is:
+
+        link_a == link_b
+
+    only indicates that link_a and link_b may be sorta kinda be representing
+    the same thing, but that you should still compare them in a more nuanced
+    way. To check for strict equality, use their hashes:
+
+        hash(link_a) == hash(link_b)
     """
 
     @classmethod

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -33,10 +33,10 @@ def links_diff(a_text, b_text, a_headers=None, b_headers=None,
 
     a_links = sorted(
         set([Link.from_element(element) for element in _find_outgoing_links(a_soup)]),
-        key=lambda link: link.text.lower())
+        key=lambda link: link.text.lower() + f'({link.href})')
     b_links = sorted(
         set([Link.from_element(element) for element in _find_outgoing_links(b_soup)]),
-        key=lambda link: link.text.lower())
+        key=lambda link: link.text.lower() + f'({link.href})')
 
     matcher = SequenceMatcher(a=a_links, b=b_links)
     opcodes = matcher.get_opcodes()

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -40,10 +40,11 @@ def links_diff(a_text, b_text, a_headers=None, b_headers=None,
 
     matcher = SequenceMatcher(a=a_links, b=b_links)
     opcodes = matcher.get_opcodes()
+    diff = list(_assemble_diff(a_links, b_links, opcodes))
 
     return {
-        'change_count': _count_changes(opcodes),
-        'diff': _assemble_diff(a_links, b_links, opcodes),
+        'change_count': _count_changes(diff),
+        'diff': diff,
         'a_parsed': a_soup,
         'b_parsed': b_soup
     }
@@ -59,7 +60,7 @@ def links_diff_json(a_text, b_text, a_headers=None, b_headers=None,
                       content_type_options)
     return {
         'change_count': diff['change_count'],
-        'diff': list(diff['diff'])
+        'diff': diff['diff']
     }
 
 
@@ -239,7 +240,7 @@ def _get_link_text(link):
 
 
 def _count_changes(opcodes):
-    return len([operation for operation in opcodes if operation[0] != 'equal'])
+    return len([operation for operation in opcodes if operation[0] != 0])
 
 
 def _assemble_diff(a, b, opcodes):

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -89,19 +89,20 @@ def links_diff_html(a_text, b_text, a_headers=None, b_headers=None,
         }
         .links-list--item > td {
             border-bottom: 1px solid #fff;
+            opacity: 0.5;
             padding: 0.25em;
         }
         .links-list--href a {
             line-break: loose;
             word-break: break-all;
         }
-        [wm-has-deletions],
-        [wm-has-insertions] {
+        [wm-has-deletions] > td,
+        [wm-has-insertions] > td {
             background-color: #eee;
             opacity: 1;
         }
-        [wm-inserted] { background-color: #acf2bd; }
-        [wm-deleted]  { background-color: #fdb8c0; }
+        [wm-inserted] > td { background-color: #acf2bd; }
+        [wm-deleted] > td  { background-color: #fdb8c0; }
         ins { text-decoration: none; background-color: #acf2bd; }
         del { text-decoration: none; background-color: #fdb8c0; }"""
     soup.head.append(change_styles)

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -1,6 +1,5 @@
 from bs4 import BeautifulSoup
 from .content_type import raise_if_not_diffable_html
-from collections import Counter
 from .differs import compute_dmp_diff
 from difflib import SequenceMatcher
 from .html_diff_render import get_title, _html_for_dmp_operation

--- a/web_monitoring/tests/test_links_diff.py
+++ b/web_monitoring/tests/test_links_diff.py
@@ -16,7 +16,7 @@ def test_links_diff_only_includes_links():
              """
     result = links_diff(html_a, html_b)['diff']
     assert 'Here is some' not in result
-    assert '<li>go places' in result
+    assert 'go places' in result
 
 
 def test_links_diff_only_has_outgoing_links():

--- a/web_monitoring/tests/test_links_diff.py
+++ b/web_monitoring/tests/test_links_diff.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from pkg_resources import resource_filename
 import pytest
 from web_monitoring.diff_errors import UndiffableContentError
-from web_monitoring.links_diff import links_diff
+from web_monitoring.links_diff import links_diff, links_diff_html
 
 
 def test_links_diff_only_includes_links():
@@ -14,7 +14,7 @@ def test_links_diff_only_includes_links():
              Here is some HTML with <a href="http://ugh.com">some</a> links
              in it. Those links <a href="http://example.com">go places</a>.
              """
-    result = links_diff(html_a, html_b)['diff']
+    result = links_diff_html(html_a, html_b)['diff']
     assert 'Here is some' not in result
     assert 'go places' in result
 
@@ -28,7 +28,7 @@ def test_links_diff_only_has_outgoing_links():
              Here is some HTML with <a href="http://google.com">some links</a>
              in it. Those links <a href="#local">go places</a>.
              """
-    result = links_diff(html_a, html_b)['diff']
+    result = links_diff_html(html_a, html_b)['diff']
     assert result.count('<a') == 1
 
 
@@ -45,7 +45,7 @@ def test_links_diff_should_show_the_alt_text_for_images():
              Also an image with no alt text: <a href="/relative">
              <img src="whatever.jpg"></a>.
              """
-    result = links_diff(html_a, html_b)['diff']
+    result = links_diff_html(html_a, html_b)['diff']
     assert '[image: Alt text!]' in result
     assert '[image]' in result
 


### PR DESCRIPTION
It turns out the `html_token` diff was not as great a basis for this as I’d thought and it generated diffs that were not as clear as they could be for analysts.

Instead, rewrite the diff to generate a list of `Link` objects, which can then be run through `difflib.SequenceMatcher` for diffing. Then we format the output of that (as a bonus, we can easily get optional JSON formatting now).

I also added some extra fancy footwork by making this a two-stage model: `Link` objects compare as equal even if only their text or only their `href` attributes match. When we hit an “equal” link that wasn’t an *exact* match, we do a second pass with diff-match-patch to diff the text and `href` inside it.

![linksdiff](https://user-images.githubusercontent.com/74178/35366078-70556a4a-012c-11e8-9feb-91b33d05b693.png)

Rows have a light red BG if they only contain removals, a light green BG if only additions, and gray if they contain both.

Fixes #151