### PR TITLE
Use minimal HTML in html_diff_render when there is no content

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -173,6 +173,14 @@ SEPARATABLE_TAGS = ('blockquote', 'section', 'article', 'header', 'footer',
                     'pre', 'ul', 'ol', 'li', 'table', 'p')
 # SEPARATABLE_TAGS = block_level_tags
 
+# A simplistic, empty HTML document to use in place of totally empty content
+EMPTY_HTML = '''<html>
+    <head></head>
+    <body>
+        <p style="text-align: center;">[No Content]</p>
+    </body>
+</html>'''
+
 
 def html_diff_render(a_text, b_text, include='combined'):
     """
@@ -201,8 +209,8 @@ def html_diff_render(a_text, b_text, include='combined'):
     text2 = '<!DOCTYPE html><html><head></head><body><h1>Header</h1></body></html>'
     test_diff_render = html_diff_render(text1,text2)
     """
-    soup_old = BeautifulSoup(a_text, 'lxml')
-    soup_new = BeautifulSoup(b_text, 'lxml')
+    soup_old = BeautifulSoup(a_text.strip() or EMPTY_HTML, 'lxml')
+    soup_new = BeautifulSoup(b_text.strip() or EMPTY_HTML, 'lxml')
 
     # Remove comment nodes since they generally don't affect display.
     # NOTE: This could affect display if the removed are conditional comments,

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -80,3 +80,10 @@ def test_html_diff_render_should_count_changes():
     assert isinstance(results['insertions_count'], int)
     assert isinstance(results['deletions_count'], int)
     assert results['change_count'] == results['insertions_count'] + results['deletions_count']
+
+
+def test_html_diff_render_should_not_break_with_empty_content():
+    results = html_diff_render(
+        ' \n ',
+        'Here is some actual content!')
+    assert results


### PR DESCRIPTION
When there is no content (or just whitespace) for a given version, BeautifulSoup winds up creating no structure in the document at all (in all other situations, with any content present, it will create a root `<html>` element even if one was not actually in the source code it parsed). Later on, we break when it turns out there is no root element to work with. Instead, this detects situations where there is just whitespace and substitutes an extremly simple HTML document for diffing.

This has an added bonus: we can add a little bit of text explaining there there was no content so analysts aren't confused about whether something is still loading, silently broken, or if there really was just no content.

<img width="1009" alt="screen shot 2018-02-11 at 10 25 57 pm" src="https://user-images.githubusercontent.com/74178/36085695-763e03c8-0f7c-11e8-90c1-9f6573945924.png">

Fixes #157.