### PR TITLE
Add command to import known page URLs from IA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,10 @@ export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
 
 # Set how many diffs can be run in parallel.
 # export DIFFER_PARALLELISM=10
+
+# Uncomment to enable logging. Set the level as any normal level.
+# https://docs.python.org/3.6/library/logging.html#logging-levels
+# LOG_LEVEL=INFO
+
+# Enable logging for third-party subcomponents (e.g. urllib3)
+# LOG_LEVEL_SUBCOMPONENT=ERROR

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,3 @@ export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
 # Uncomment to enable logging. Set the level as any normal level.
 # https://docs.python.org/3.6/library/logging.html#logging-levels
 # LOG_LEVEL=INFO
-
-# Enable logging for third-party subcomponents (e.g. urllib3)
-# LOG_LEVEL_SUBCOMPONENT=ERROR

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ env:
         - secure: "CvGiseLGfgrT3KN++1Zir4GBQO3KXOSxGTYplgX1yREHgqdixRPeEEv2z0RBc3pc8e1QWNRh9cSkXDcmny8KNwmRnrTgfqJfbvzErX9WEoNSSs+zSXrjUYmarfrcckRR/guKv/yM4zTatzQ23EUrT3wlp5JBtjudb8msuwzlPXkfyMZPjK6NTwmvuA0JwHyCfjg559wVnMUXvVj7CLSVTH/bxvNIfWwfqnfOnk1mM9Zuj6B+HQxUreU367I/S7d1FK5Rs+Ov9scy2DvnbsuN5NHg7/KmbaD31xiKoZMmcFKIMBjv3Bubd7BLFmjAQ5KW0ZuOD76k+8yq7AREV2dUlWLdsOxfHb79+9xQuJGocN7mmLqF1WcHDBIkJLiBiB9GwE9brKMwdsnzI+CfXOi+aH+B1Q6ZvztJ+eDTjoGi0fiHXaXC82pCvBhLoV8H/tHNZB7ojUZvDhigN/NtfEBcBMmer/6gXbFmDZWOM3z1rh+pgZOppvVxDUWLTgo7i1XNMjMlKgDl4lc+JYY6/d3r8B8oGuaPGiDD6pM1aNu2Nd5DmNOH7HCwL1MlVIvNT/c/4yuzdbxvH6aKxGHRfQlTovpLyIFMlnuQVWYqd6d+AYzDl8dvPiwQrHvMK7uxdEheYRbOOX39w8I2AAdYhAus+ENsEfoSKJXcdGdNfjv3MmE="
 matrix:
   include:
-    - python: 3.6
-    # - python: 3.7  # not yet supported by Travis (2018-09-14)
+    - python: 3.7
 
 install:
     - pip install -r requirements.txt

--- a/scripts/ia_healthcheck
+++ b/scripts/ia_healthcheck
@@ -53,9 +53,9 @@ def wayback_has_captures(url, from_date=None):
     list of JSON
     """
     try:
-        wayback = internetarchive.WaybackClient()
-        versions = wayback.list_versions(url, from_date=from_date)
-        next(versions)
+        with internetarchive.WaybackClient() as wayback:
+            versions = wayback.list_versions(url, from_date=from_date)
+            next(versions)
     except ValueError:
         return False
     else:

--- a/scripts/ia_healthcheck
+++ b/scripts/ia_healthcheck
@@ -30,7 +30,7 @@ def sample_monitored_urls(sample_size):
     list of string
     """
     client = db.Client.from_env()
-    page = client.list_pages(chunk=1, chunk_size=1, active=True)
+    page = client.list_pages(chunk=1, chunk_size=1, active=True, include_total=True)
     url_count = page['meta']['total_results']
     return (get_page_url(client, index)
             for index in random.sample(range(url_count), sample_size))

--- a/web_monitoring/__init__.py
+++ b/web_monitoring/__init__.py
@@ -7,8 +7,3 @@ del get_versions
 
 if os.environ.get('LOG_LEVEL'):
     logging.basicConfig(level=os.environ['LOG_LEVEL'].upper())
-    # Urllib3 logs a warning every time a retry happens. Way too noisy.
-    # TODO: is this the best way to configure? We should probably revisit this.
-    # Maybe the right answer is filtering when *reading* the output.
-    subcomponent_level = os.environ.get('LOG_LEVEL_SUBCOMPONENT', 'ERROR')
-    logging.getLogger('urllib3.connectionpool').setLevel(subcomponent_level)

--- a/web_monitoring/__init__.py
+++ b/web_monitoring/__init__.py
@@ -7,3 +7,8 @@ del get_versions
 
 if os.environ.get('LOG_LEVEL'):
     logging.basicConfig(level=os.environ['LOG_LEVEL'].upper())
+    # Urllib3 logs a warning every time a retry happens. Way too noisy.
+    # TODO: is this the best way to configure? We should probably revisit this.
+    # Maybe the right answer is filtering when *reading* the output.
+    subcomponent_level = os.environ.get('LOG_LEVEL_SUBCOMPONENT', 'ERROR')
+    logging.getLogger('urllib3.connectionpool').setLevel(subcomponent_level)

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -1,51 +1,436 @@
 # Command Line Interface
 # See scripts/ directory for associated executable(s). All of the interesting
 # functionality is implemented in this module to make it easier to test.
+from collections import defaultdict
+from datetime import datetime, timedelta
 from docopt import docopt
+import json
+import logging
+from os.path import splitext
 import pandas
+from pathlib import Path
+import re
+import requests
+import signal
+import sys
+import threading
 from tqdm import tqdm
+from urllib.parse import urlparse
 from web_monitoring import db
 from web_monitoring import internetarchive as ia
+from web_monitoring import utils
+
+import queue
+import asyncio
+import concurrent
+
+
+logger = logging.getLogger(__name__)
+
+# Number of memento requests to make at once. Can be overridden via CLI args.
+PARALLEL_REQUESTS = 10
+
+# Matches the host segment of a URL.
+HOST_EXPRESSION = re.compile(r'^[^:]+://([^/]+)')
+# Matches URLs for "index" pages that are likely to be the same as a URL ending
+# with a slash. e.g. matches the `index.html` in `https://epa.gov/index.html`.
+# Used to group URLs representing the same logical page.
+INDEX_PAGE_EXPRESSION = re.compile(r'index(\.\w+)?$')
+# MIME types that we always consider to be subresources and never "pages".
+SUBRESOURCE_MIME_TYPES = (
+    'text/css',
+    'text/javascript',
+    'application/javascript',
+    'image/jpeg',
+    'image/webp',
+    'image/png',
+    'image/gif',
+    'image/bmp',
+    'image/tiff',
+    'image/x-icon',
+)
+# Extensions that we always consider to be subresources and never "pages".
+SUBRESOURCE_EXTENSIONS = (
+    '.css',
+    '.js',
+    '.es',
+    '.es6',
+    '.jsm',
+    '.jpg',
+    '.jpeg',
+    '.webp',
+    '.png',
+    '.gif',
+    '.bmp',
+    '.tif',
+    '.ico',
+)
+# Never query CDX for *all* snapshots at any of these domains (instead, always
+# query for each specific URL we want). This is usually because we assume these
+# domains are HUGE and completely impractical to query all pages on.
+NEVER_QUERY_DOMAINS = (
+    'instagram.com',
+    'youtube.com',
+    'amazon.com'
+)
+# Query an entire domain for snapshots if we are interested in more than this
+# many URLs in the domain (NEVER_QUERY_DOMAINS above overrides this).
+MAX_QUERY_URLS_PER_DOMAIN = 30
 
 
 # These functions lump together library code into monolithic operations for the
 # CLI. They also print. To access this functionality programmatically, it is
 # better to use the underlying library code.
 
+def _get_progress_meter(iterable):
+    # Use TQDM in all environments, but don't update very often if not a TTY.
+    # Basically, the idea here is to keep TQDM in our logs so we get stats, but
+    # not to waste a huge amount of space in the logs with it.
+    # NOTE: This is cribbed from TQDM's `disable=None` logic:
+    # https://github.com/tqdm/tqdm/blob/f2a60d1fb9e8a15baf926b4a67c02f90e0033eba/tqdm/_tqdm.py#L817-L830
+    file = sys.stderr
+    intervals = {}
+    if hasattr(file, "isatty") and not file.isatty():
+        intervals = dict(mininterval=10, maxinterval=60)
 
-def _add_and_monitor(versions):
+    return tqdm(iterable, desc='importing', unit=' versions', **intervals)
+
+
+def _add_and_monitor(versions, create_pages=True, skip_unchanged_versions=True, stop_event=None):
     cli = db.Client.from_env()  # will raise if env vars not set
     # Wrap verions in a progress bar.
-    versions = tqdm(versions, desc='importing', unit=' versions')
-    print('Submitting Versions to web-monitoring-db...')
-    import_ids = cli.add_versions(versions)
+    # TODO: create this on the main thread so we can update totals when we
+    # discover them in CDX, but update progress here as we import.
+    versions = _get_progress_meter(versions)
+    import_ids = cli.add_versions(versions, create_pages=create_pages,
+                                  skip_unchanged_versions=skip_unchanged_versions)
     print('Import jobs IDs: {}'.format(import_ids))
     print('Polling web-monitoring-db until import jobs are finished...')
-    errors = cli.monitor_import_statuses(import_ids)
+    errors = cli.monitor_import_statuses(import_ids, stop_event)
     if errors:
         print("Errors: {}".format(errors))
 
 
-def import_ia(url, *, from_date=None, to_date=None, maintainers=None,
-              tags=None, skip_unchanged='resolved-response'):
+def _log_adds(versions):
+    versions = _get_progress_meter(versions)
+    for version in versions:
+        print(json.dumps(version))
+
+
+class WaybackRecordsWorker(threading.Thread):
+    def __init__(self, records, results_queue, maintainers, tags, cancel,
+                 failure_queue=None, session_options=None,
+                 unplaybackable=None):
+        super().__init__()
+        self.summary = self.create_summary()
+        self.results_queue = results_queue
+        self.failure_queue = failure_queue
+        self.cancel = cancel
+        self.records = records
+        self.maintainers = maintainers
+        self.tags = tags
+        self.unplaybackable = unplaybackable
+        session_options = session_options or dict(retries=3, backoff=2,
+                                                  timeout=(30.5, 2))
+        session = ia.WaybackSession(**session_options)
+        self.wayback = ia.WaybackClient(session=session)
+
+    def reset_client(self):
+        self.wayback.session.reset()
+
+    def is_active(self):
+        return not self.cancel.is_set()
+
+    def run(self):
+        """
+        Work through the queue of CDX records to load them from Wayback,
+        transform them to Web Monitoring DB import entries, and queue them for
+        importing.
+        """
+        self.reset_client()
+
+        while self.is_active():
+            try:
+                record = next(self.records)
+                self.summary['total'] += 1
+            except StopIteration:
+                break
+
+            self.handle_record(record, retry_connection_failures=True)
+
+        self.wayback.close()
+        return self.summary
+
+    def handle_record(self, record, retry_connection_failures=False):
+        """
+        Handle a single CDX record.
+        """
+        # Check for whether we already know this can't be played and bail out.
+        if self.unplaybackable is not None and record.raw_url in self.unplaybackable:
+            self.summary['playback'] += 1
+            return
+
+        try:
+            version = self.process_record(record, retry_connection_failures=True)
+            self.results_queue.put(version)
+            self.summary['success'] += 1
+        except ia.MementoPlaybackError as error:
+            self.summary['playback'] += 1
+            if self.unplaybackable is not None:
+                self.unplaybackable[record.raw_url] = datetime.utcnow()
+            logger.info(f'  {error}')
+        except requests.exceptions.HTTPError as error:
+            if error.response.status_code == 404:
+                logger.info(f'  Missing memento: {record.raw_url}')
+                self.summary['missing'] += 1
+            else:
+                # TODO: consider not logging this at a lower level, like debug
+                # unless failure_queue does not exist. Unsure how big a deal
+                # this error is to log if we are retrying.
+                logger.info(f'  (HTTPError) {error}')
+                # TODO: definitely don't count it if we are going to retry it
+                self.summary['unknown'] += 1
+                if self.failure_queue:
+                    self.failure_queue.put(record)
+        except ia.WaybackRetryError as error:
+            # TODO: don't count or log (well, maybe DEBUG log) if failure_queue
+            # is present and we are ultimately going to retry.
+            self.summary['unknown'] += 1
+            logger.info(f'  {error}; URL: {record.raw_url}')
+
+            if self.failure_queue:
+                self.failure_queue.put(record)
+        except Exception as error:
+            # FIXME: getting read timed out connection errors here...
+            # requests.exceptions.ConnectionError: HTTPConnectionPool(host='web.archive.org', port=80): Read timed out.
+            # TODO: don't count or log (well, maybe DEBUG log) if failure_queue
+            # is present and we are ultimately going to retry.
+            self.summary['unknown'] += 1
+            logger.exception(f'  ({type(error)}) {error}; URL: {record.raw_url}')
+
+            if self.failure_queue:
+                self.failure_queue.put(record)
+
+    def process_record(self, record, retry_connection_failures=False):
+        """
+        Load the actual Wayback memento for a CDX record and transform it to
+        a Web Monitoring DB import record.
+        """
+        try:
+            return self.wayback.timestamped_uri_to_version(record.date,
+                                                           record.raw_url,
+                                                           url=record.url,
+                                                           maintainers=self.maintainers,
+                                                           tags=self.tags,
+                                                           view_url=record.view_url)
+        except Exception as error:
+            # On connection failures, reset the session and try again. If we
+            # don't do this, the connection pool for this thread is pretty much
+            # dead. It's not clear to me whether there is a problem in urllib3
+            # or Wayback's servers that requires this.
+            # This unfortunately requires string checking because the error can
+            # get wrapped up into multiple kinds of higher-level errors :(
+            if retry_connection_failures and ('failed to establish a new connection' in str(error).lower()):
+                self.reset_client()
+                return self.process_record(record)
+
+            # Otherwise, re-raise the error.
+            raise error
+
+    @classmethod
+    def create_summary(cls):
+        return {'total': 0, 'success': 0, 'playback': 0, 'missing': 0,
+                'unknown': 0}
+
+    @classmethod
+    def summarize(cls, workers):
+        return cls.merge_summaries((w.summary for w in workers))
+
+    @classmethod
+    def merge_summaries(cls, summaries):
+        merged = cls.create_summary()
+        for summary in summaries:
+            for key in merged.keys():
+                merged[key] += summary[key]
+
+        # Add percentage calculations
+        if merged['total']:
+            merged.update({f'{k}_pct': 100 * v / merged['total']
+                           for k, v in merged.items()
+                           if k != 'total' and not k.endswith('_pct')})
+        else:
+            merged.update({f'{k}_pct': 0.0
+                           for k, v in merged.items()
+                           if k != 'total' and not k.endswith('_pct')})
+
+        return merged
+
+
+def iterate_into_queue(iterable, queue):
+    for item in iterable:
+        queue.put(item)
+    queue.put(None)
+
+
+async def import_ia_db_urls(*, from_date=None, to_date=None, maintainers=None,
+                            tags=None, skip_unchanged='resolved-response',
+                            url_pattern=None, worker_count=0,
+                            unplaybackable_path=None, dry_run=False):
+    client = db.Client.from_env()
+    logger.info('Loading known pages from web-monitoring-db instance...')
+    urls, version_filter = _get_db_page_url_info(client, url_pattern)
+
+    # Wayback search treats URLs as SURT, so dedupe obvious repeats first.
+    www_subdomain = re.compile(r'^https?://www\d*\.')
+    urls = set((www_subdomain.sub('http://', url) for url in urls))
+
+    logger.info(f'Found {len(urls)} CDX-queryable URLs')
+    logger.debug('\n  '.join(urls))
+
+    return await import_ia_urls(
+        urls=urls,
+        from_date=from_date,
+        to_date=to_date,
+        maintainers=maintainers,
+        tags=tags,
+        skip_unchanged=skip_unchanged,
+        version_filter=version_filter,
+        worker_count=worker_count,
+        create_pages=False,
+        unplaybackable_path=unplaybackable_path,
+        dry_run=dry_run)
+
+
+def load_from_wayback(records, versions_queue, maintainers, tags, cancel, unplaybackable, worker_count, tries=None):
+    if tries is None or len(tries) == 0:
+        tries = (None,)
+    if isinstance(records, queue.Queue):
+        records = utils.ThreadSafeIterator(utils.queue_iterator(records))
+
+    summary = WaybackRecordsWorker.create_summary()
+
+    total_tries = len(tries)
+    retry_queue = None
+    for index, try_setting in enumerate(tries):
+        if retry_queue and not retry_queue.empty():
+            print(f'\nRetrying about {retry_queue.qsize()} failed records...', flush=True)
+            retry_queue.put(None)
+            records = utils.ThreadSafeIterator(utils.queue_iterator(retry_queue))
+
+        if index == total_tries - 1:
+            retry_queue = None
+        else:
+            retry_queue = queue.Queue()
+
+        workers = []
+        for i in range(worker_count):
+            worker = WaybackRecordsWorker(records, versions_queue,
+                                          maintainers, tags, cancel,
+                                          retry_queue, try_setting,
+                                          unplaybackable)
+            workers.append(worker)
+            worker.start()
+
+        for worker in workers:
+            worker.join()
+
+        try_summary = WaybackRecordsWorker.summarize(workers)
+        if index == 0:
+            summary = try_summary
+        else:
+            summary['success'] += try_summary['success']
+            summary['playback'] += try_summary['playback']
+            summary['missing'] += try_summary['missing']
+            summary['unknown'] -= (try_summary['success'] +
+                                   try_summary['playback'] +
+                                   try_summary['missing'])
+
+    # Recalculate percentages
+    summary = WaybackRecordsWorker.merge_summaries([summary])
+    return summary
+
+
+# TODO: this function probably be split apart so `dry_run` doesn't need to
+# exist as an argument.
+async def import_ia_urls(urls, *, from_date=None, to_date=None,
+                         maintainers=None, tags=None,
+                         skip_unchanged='resolved-response',
+                         version_filter=None, worker_count=0,
+                         create_pages=True, unplaybackable_path=None,
+                         dry_run=False):
     skip_responses = skip_unchanged == 'response'
-    with ia.WaybackClient() as wayback:
-        # Pulling on this generator does the work.
-        versions = (wayback.timestamped_uri_to_version(version.date,
-                                                       version.raw_url,
-                                                       url=version.url,
-                                                       maintainers=maintainers,
-                                                       tags=tags,
-                                                       view_url=version.view_url)
-                    for version in wayback.list_versions(url,
-                                                         from_date=from_date,
-                                                         to_date=to_date,
-                                                         skip_repeats=skip_responses))
+    worker_count = worker_count if worker_count > 0 else PARALLEL_REQUESTS
+    unplaybackable = load_unplaybackable_mementos(unplaybackable_path)
 
-        if skip_unchanged == 'resolved-response':
-            versions = _filter_unchanged_versions(versions)
+    # Use a custom session to make sure CDX calls are extra robust.
+    session = ia.WaybackSession(retries=10, backoff=4)
 
-        _add_and_monitor(versions)
+    with utils.QuitSignal((signal.SIGINT, signal.SIGTERM)) as stop_event:
+        with ia.WaybackClient(session) as wayback:
+            # wayback_records = utils.ThreadSafeIterator(
+            #     _list_ia_versions_for_urls(
+            #         urls,
+            #         from_date,
+            #         to_date,
+            #         skip_responses,
+            #         version_filter,
+            #         client=wayback))
+
+            executor = concurrent.futures.ThreadPoolExecutor(max_workers=worker_count + 1)
+            loop = asyncio.get_event_loop()
+            versions_queue = queue.Queue()
+            versions = utils.queue_iterator(versions_queue)
+            if skip_unchanged == 'resolved-response':
+                versions = _filter_unchanged_versions(versions)
+
+            if dry_run:
+                uploader = loop.run_in_executor(executor, _log_adds, versions)
+            else:
+                uploader = loop.run_in_executor(executor, _add_and_monitor, versions, create_pages, stop_event)
+
+            # summary = merge_worker_summaries([worker_summary()])
+            summary = WaybackRecordsWorker.create_summary()
+            all_records = _list_ia_versions_for_urls(
+                urls,
+                from_date,
+                to_date,
+                skip_responses,
+                version_filter,
+                client=wayback,
+                stop=stop_event)
+            # for wayback_records in toolz.partition_all(2000, all_records):
+            # wayback_records = utils.ThreadSafeIterator(all_records)
+            wayback_records = queue.Queue()
+            cdx_task = loop.run_in_executor(executor, iterate_into_queue, all_records, wayback_records)
+
+            retry_settings = (None,
+                              dict(retries=3, backoff=4, timeout=(30.5, 2)),
+                              dict(retries=7, backoff=4, timeout=60.5))
+            summary = load_from_wayback(wayback_records,
+                                        versions_queue,
+                                        maintainers,
+                                        tags,
+                                        stop_event,
+                                        unplaybackable,
+                                        worker_count,
+                                        retry_settings)
+
+            print('\nLoaded {total} CDX records:\n'
+                  '  {success:6} successes ({success_pct:.2f}%),\n'
+                  '  {playback:6} could not be played back ({playback_pct:.2f}%),\n'
+                  '  {missing:6} had no actual memento ({missing_pct:.2f}%),\n'
+                  '  {unknown:6} unknown errors ({unknown_pct:.2f}%).'.format(
+                    **summary))
+
+            # Signal that there will be nothing else on the queue so uploading can finish
+            versions_queue.put(None)
+
+            if not dry_run:
+                print('Saving list of non-playbackable URLs...')
+                save_unplaybackable_mementos(unplaybackable_path, unplaybackable)
+
+            await cdx_task
+            await uploader
 
 
 def _filter_unchanged_versions(versions):
@@ -60,10 +445,195 @@ def _filter_unchanged_versions(versions):
             yield version
 
 
+def _list_ia_versions_for_urls(url_patterns, from_date, to_date,
+                               skip_repeats=True, version_filter=None,
+                               client=None, stop=None):
+    version_filter = version_filter or _is_page
+    skipped = 0
+
+    with client or ia.WaybackClient() as client:
+        for url in url_patterns:
+            if stop and stop.is_set():
+                break
+
+            ia_versions = client.list_versions(url,
+                                            from_date=from_date,
+                                            to_date=to_date,
+                                            skip_repeats=skip_repeats)
+            try:
+                for version in ia_versions:
+                    if stop and stop.is_set():
+                        break
+                    if version_filter(version):
+                        yield version
+                    else:
+                        skipped += 1
+                        logger.debug('Skipping URL "%s"', version.url)
+            except ia.BlockedByRobotsError as error:
+                logger.warn(str(error))
+            except ValueError as error:
+                # NOTE: this isn't really an exceptional case; list_versions()
+                # raises ValueError when Wayback has no matching records.
+                # TODO: there should probably be no exception in this case.
+                if 'does not have archived versions' not in str(error):
+                    logger.warn(error)
+            except ia.WaybackException as error:
+                logger.error(f'Error getting CDX data for {url}: {error}')
+            except Exception:
+                # Need to handle the exception here to let iteration continue
+                # and allow other threads that might be running to be joined.
+                logger.exception(f'Error processing versions of {url}')
+
+    if skipped > 0:
+        logger.info('Skipped %s URLs that did not match filters', skipped)
+
+
+def load_unplaybackable_mementos(path):
+    unplaybackable = {}
+    if path:
+        try:
+            with open(path) as file:
+                unplaybackable = json.load(file)
+        except FileNotFoundError:
+            pass
+    return unplaybackable
+
+
+def save_unplaybackable_mementos(path, mementos, expiration=7 * 24 * 60 * 60):
+    if path is None:
+        return
+
+    threshold = datetime.utcnow() - timedelta(seconds=expiration)
+    urls = list(mementos.keys())
+    for url in urls:
+        date = mementos[url]
+        needs_format = False
+        if isinstance(date, str):
+            date = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
+        else:
+            needs_format = True
+
+        if date < threshold:
+            del mementos[url]
+        elif needs_format:
+            mementos[url] = date.isoformat(timespec='seconds') + 'Z'
+
+    file_path = Path(path)
+    if not file_path.parent.exists():
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open('w') as file:
+        json.dump(mementos, file)
+
+
+# XXX: This is no longer really listing domains. Should we find a way to make
+# it do that again, or simply remove this functionality?
+def list_domains(url_pattern=None):
+    client = db.Client.from_env()
+    logger.info('Loading known pages from web-monitoring-db instance...')
+    domains, version_filter = _get_db_page_url_info(client, url_pattern)
+
+    text = '\n  '.join(domains)
+    print(f'Found {len(domains)} matching domains:\n  {text}')
+
+
+def _can_query_domain(domain):
+    if domain in NEVER_QUERY_DOMAINS:
+        return False
+
+    return next((False for item in NEVER_QUERY_DOMAINS
+                if domain.endswith(f'.{item}')), True)
+
+
+def _get_db_page_url_info(client, url_pattern=None):
+    # If these sets get too big, we can switch to a bloom filter. It's fine if
+    # we have some false positives. Any noise reduction is worthwhile.
+    url_keys = set()
+    domains = defaultdict(lambda: {'query_domain': False, 'urls': []})
+
+    domains_without_url_keys = set()
+    for page in _list_all_db_pages(client, url_pattern):
+        domain = HOST_EXPRESSION.match(page['url']).group(1)
+        data = domains[domain]
+        if not data['query_domain']:
+            if len(data['urls']) >= MAX_QUERY_URLS_PER_DOMAIN and _can_query_domain(domain):
+                data['query_domain'] = True
+            else:
+                data['urls'].append(page['url'])
+
+        if domain in domains_without_url_keys:
+            continue
+
+        url_key = page['url_key']
+        if url_key:
+            url_keys.add(_rough_url_key(url_key))
+        else:
+            domains_without_url_keys.add(domain)
+            logger.warn('Found DB page with no url_key; *all* pages in '
+                        f'"{domain}" will be imported')
+
+    def filterer(version, domain=None):
+        domain = domain or HOST_EXPRESSION.match(version.url).group(1)
+        if domain in domains_without_url_keys:
+            return _is_page(version)
+        else:
+            return _rough_url_key(version.key) in url_keys
+
+    url_list = []
+    for domain, data in domains.items():
+        if data['query_domain']:
+            url_list.append(f'http://{domain}/*')
+        else:
+            url_list.extend(data['urls'])
+
+    return url_list, filterer
+
+
+def _rough_url_key(url_key):
+    """
+    Create an ultra-loose version of a SURT key that should match regardless of
+    most SURT settings. (This allows lots of false positives.)
+    """
+    rough_key = url_key.lower()
+    rough_key = rough_key.split('?', 1)[0]
+    rough_key = rough_key.split('#', 1)[0]
+    rough_key = INDEX_PAGE_EXPRESSION.sub('', rough_key)
+    if rough_key.endswith('/'):
+        rough_key = rough_key[:-1]
+    return rough_key
+
+
+def _is_page(version):
+    """
+    Determine if a version might be a page we want to track. This is used to do
+    some really simplistic filtering on noisy Internet Archive results if we
+    aren't filtering down to a explicit list of URLs.
+    """
+    return (version.mime_type not in SUBRESOURCE_MIME_TYPES and
+            splitext(urlparse(version.url).path)[1] not in SUBRESOURCE_EXTENSIONS)
+
+
+# TODO: this should probably be a method on db.Client, but db.Client could also
+# do well to transform the `links` into callables, e.g:
+#     more_pages = pages['links']['next']()
+def _list_all_db_pages(client, url_pattern=None):
+    chunk = 1
+    while chunk > 0:
+        pages = client.list_pages(sort=['created_at:asc'], chunk_size=1000,
+                                  chunk=chunk, url=url_pattern, active=True)
+        yield from pages['data']
+        chunk = pages['links']['next'] and (chunk + 1) or -1
+
+
 def _parse_date_argument(date_string):
     """Parse a CLI argument that should represent a date into a datetime"""
     if not date_string:
         return None
+
+    try:
+        hours = float(date_string)
+        return datetime.utcnow() - timedelta(hours=hours)
+    except ValueError:
+        pass
 
     try:
         parsed = pandas.to_datetime(date_string)
@@ -76,17 +646,19 @@ def _parse_date_argument(date_string):
 
 
 def main():
-    doc = """Command Line Interface to the web_monitoring Python package
+    doc = f"""Command Line Interface to the web_monitoring Python package
 
 Usage:
-wm import ia <url> [--from <from_date>] [--to <to_date>] [options]
+wm import ia <url> [--from <from_date>] [--to <to_date>] [--tag <tag>...] [--maintainer <maintainer>...] [options]
+wm import ia-known-pages [--from <from_date>] [--to <to_date>] [--pattern <url_pattern>] [--tag <tag>...] [--maintainer <maintainer>...] [options]
+wm db list-domains [--pattern <url_pattern>]
 
 Options:
 -h --help                     Show this screen.
 --version                     Show version.
---maintainers <maintainers>   Comma-separated list of entities that maintain
-                              the imported pages.
---tags <tags>                 Comma-separated list of tags to apply to pages
+--maintainer <maintainer>     Name of entity that maintains the imported pages.
+                              Repeat to add multiple maintainers.
+--tag <tag>                   Tags to apply to pages. Repeat for multiple tags.
 --skip-unchanged <skip_type>  Skip consecutive captures of the same content.
                               Can be:
                                 `none` (no skipping),
@@ -94,8 +666,19 @@ Options:
                                 `resolved-response` (if the final response
                                     after redirects is unchanged)
                               [default: resolved-response]
+--pattern <url_pattern>       A pattern to match when retrieving URLs from a
+                              web-monitoring-db instance.
+--parallel <parallel_count>   Number of parallel network requests to support.
+                              [default: {PARALLEL_REQUESTS}]
+--unplaybackable <play_path>  A file in which to list memento URLs that can not
+                              be played back. When importing is complete, a
+                              list of unplaybackable mementos will be written
+                              to this file. If it exists before importing,
+                              memento URLs listed in it will be skipped.
+--dry-run                     Don't upload data to web-monitoring-db.
 """
     arguments = docopt(doc, version='0.0.1')
+    command = None
     if arguments['import']:
         skip_unchanged = arguments['--skip-unchanged']
         if skip_unchanged not in ('none', 'response', 'resolved-response'):
@@ -104,12 +687,35 @@ Options:
             return
 
         if arguments['ia']:
-            import_ia(url=arguments['<url>'],
-                      maintainers=arguments.get('--maintainers'),
-                      tags=arguments.get('--tags'),
-                      from_date=_parse_date_argument(arguments['<from_date>']),
-                      to_date=_parse_date_argument(arguments['<to_date>']),
-                      skip_unchanged=skip_unchanged)
+            command = import_ia_urls(
+                urls=[arguments['<url>']],
+                maintainers=arguments.get('--maintainer'),
+                tags=arguments.get('--tag'),
+                from_date=_parse_date_argument(arguments['<from_date>']),
+                to_date=_parse_date_argument(arguments['<to_date>']),
+                skip_unchanged=skip_unchanged,
+                unplaybackable_path=arguments.get('--unplaybackable'),
+                dry_run=arguments.get('--dry-run'))
+        elif arguments['ia-known-pages']:
+            command = import_ia_db_urls(
+                from_date=_parse_date_argument(arguments['<from_date>']),
+                to_date=_parse_date_argument(arguments['<to_date>']),
+                maintainers=arguments.get('--maintainer'),
+                tags=arguments.get('--tag'),
+                skip_unchanged=skip_unchanged,
+                url_pattern=arguments.get('--pattern'),
+                worker_count=int(arguments.get('--parallel')),
+                unplaybackable_path=arguments.get('--unplaybackable'),
+                dry_run=arguments.get('--dry-run'))
+
+    elif arguments['db']:
+        if arguments['list-domains']:
+            list_domains(url_pattern=arguments.get('--pattern'))
+
+    # Start a loop and execute commands that are async.
+    if asyncio.iscoroutine(command):
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(command)
 
 
 if __name__ == '__main__':

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -489,7 +489,7 @@ def _list_ia_versions_for_urls(url_patterns, from_date, to_date,
                         skipped += 1
                         logger.debug('Skipping URL "%s"', version.url)
             except ia.BlockedByRobotsError as error:
-                logger.warn(str(error))
+                logger.warn(f'CDX search error: {error!r}')
             except ValueError as error:
                 # NOTE: this isn't really an exceptional case; list_versions()
                 # raises ValueError when Wayback has no matching records.

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -203,7 +203,7 @@ class WaybackRecordsWorker(threading.Thread):
             # requests.exceptions.ConnectionError: HTTPConnectionPool(host='web.archive.org', port=80): Read timed out.
             # TODO: don't count or log (well, maybe DEBUG log) if failure_queue
             # is present and we are ultimately going to retry.
-            logger.exception(f'  ({type(error)}) {error}; URL: {record.raw_url}')
+            logger.exception(f'  {error!r}; URL: {record.raw_url}')
 
             if self.failure_queue:
                 self.failure_queue.put(record)
@@ -495,9 +495,9 @@ def _list_ia_versions_for_urls(url_patterns, from_date, to_date,
                 # raises ValueError when Wayback has no matching records.
                 # TODO: there should probably be no exception in this case.
                 if 'does not have archived versions' not in str(error):
-                    logger.warn(error)
+                    logger.warn(repr(error))
             except ia.WaybackException as error:
-                logger.error(f'Error getting CDX data for {url}: {error}')
+                logger.error(f'Error getting CDX data for {url}: {error!r}')
             except Exception:
                 # Need to handle the exception here to let iteration continue
                 # and allow other threads that might be running to be joined.

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -685,7 +685,6 @@ Options:
 --dry-run                     Don't upload data to web-monitoring-db.
 """
     arguments = docopt(doc, version='0.0.1')
-    command = None
     if arguments['import']:
         skip_unchanged = arguments['--skip-unchanged']
         if skip_unchanged not in ('none', 'response', 'resolved-response'):

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -544,17 +544,6 @@ def save_unplaybackable_mementos(path, mementos, expiration=7 * 24 * 60 * 60):
         json.dump(mementos, file)
 
 
-# XXX: This is no longer really listing domains. Should we find a way to make
-# it do that again, or simply remove this functionality?
-def list_domains(url_pattern=None):
-    client = db.Client.from_env()
-    logger.info('Loading known pages from web-monitoring-db instance...')
-    domains, version_filter = _get_db_page_url_info(client, url_pattern)
-
-    text = '\n  '.join(domains)
-    print(f'Found {len(domains)} matching domains:\n  {text}')
-
-
 def _can_query_domain(domain):
     if domain in NEVER_QUERY_DOMAINS:
         return False
@@ -670,7 +659,6 @@ def main():
 Usage:
 wm import ia <url> [--from <from_date>] [--to <to_date>] [--tag <tag>...] [--maintainer <maintainer>...] [options]
 wm import ia-known-pages [--from <from_date>] [--to <to_date>] [--pattern <url_pattern>] [--tag <tag>...] [--maintainer <maintainer>...] [options]
-wm db list-domains [--pattern <url_pattern>]
 
 Options:
 -h --help                     Show this screen.
@@ -726,9 +714,6 @@ Options:
                 worker_count=int(arguments.get('--parallel')),
                 unplaybackable_path=arguments.get('--unplaybackable'),
                 dry_run=arguments.get('--dry-run'))
-    elif arguments['db']:
-        if arguments['list-domains']:
-            list_domains(url_pattern=arguments.get('--pattern'))
 
 
 if __name__ == '__main__':

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -481,7 +481,11 @@ Alternatively, you can instaniate Client(user, password) directly.""")
             import_ids.append(import_id)
         return tuple(import_ids)
 
-    def monitor_import_statuses(self, import_ids):
+    # TODO: we probably need to change the return value here to support info
+    # about imports that didn't finish if we stopped early. May also want an
+    # optional timeout given that we get stuck sometimes if the DB drops an
+    # import off its queue (which is a problem that also needs solving in DB).
+    def monitor_import_statuses(self, import_ids, stop=None):
         """
         Poll status of Version import jobs until all complete.
 
@@ -490,7 +494,10 @@ Alternatively, you can instaniate Client(user, password) directly.""")
 
         Parameters
         ----------
-        import_ids: collection
+        import_ids : collection
+        stop : threading.Event, optional
+            A threading.Event to monitor in order to determine whether to stop
+            monitoring before all imports are complete.
 
         Returns
         -------
@@ -499,7 +506,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         errors = []
         import_ids = list(import_ids)  # to ensure mutable collection
         try:
-            while import_ids:
+            while import_ids and (stop is None or not stop.is_set()):
                 for import_id in tuple(import_ids):
                     # We are mainly interrested in processing errors. We don't
                     # expect HTTPErrors, so we'll just warn and hope that

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -514,8 +514,8 @@ class WaybackClient(utils.DepthCountedContext):
                                                  URL_DATE_FORMAT)
             except Exception:
                 if 'RobotAccessControlException' in text:
-                    raise BlockedByRobotsError(f'CDX search for URL was blocked by robots.txt "{query["url"]}" (parameters: {final_query})')
-                raise UnexpectedResponseFormat(f'Could not parse CDX output: "{text}" (parameters: {final_query})')
+                    raise BlockedByRobotsError(query["url"])
+                raise UnexpectedResponseFormat(f'Could not parse CDX output: "{text}" (query: {final_query})')
 
             clean_url = REDUNDANT_HTTPS_PORT.sub(
                 r'\1\2', REDUNDANT_HTTP_PORT.sub(

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -874,7 +874,6 @@ def format_version(*, url, dt, uri, version_hash, title, status, mime_type,
     # format into source_metadata, a free-form object for extra info that not
     # all sources are required to provide.
     metadata = {
-        'status_code': status,
         'mime_type': mime_type,
         'encoding': encoding,
         'headers': headers or {},
@@ -897,5 +896,6 @@ def format_version(*, url, dt, uri, version_hash, title, status, mime_type,
          uri=uri,
          version_hash=version_hash,
          source_type='internet_archive',
-         source_metadata=metadata
+         source_metadata=metadata,
+         status=status
     )

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -285,7 +285,7 @@ class WaybackSession(utils.DisableAfterCloseSession, requests.Session):
                     return result
             except WaybackSession.handleable_errors as error:
                 if retries >= maximum:
-                    raise WaybackRetryError(retries, total_time, error)
+                    raise WaybackRetryError(retries, total_time, error) from error
                 elif not self.should_retry_error(error):
                     raise
 

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -17,10 +17,28 @@ from base64 import b32encode
 from collections import namedtuple
 from datetime import datetime
 import hashlib
+import logging
 import urllib.parse
 import re
 import requests
-from web_monitoring import utils
+import time
+from urllib3.connectionpool import HTTPConnectionPool
+from web_monitoring import utils, __version__
+
+from requests.exceptions import (
+    ConnectionError,
+    ProxyError,
+    RetryError,
+    Timeout
+)
+from urllib3.exceptions import (
+    ConnectTimeoutError,
+    MaxRetryError,
+    ReadTimeoutError
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 class WaybackException(Exception):
@@ -32,22 +50,52 @@ class UnexpectedResponseFormat(WaybackException):
     ...
 
 
+class BlockedByRobotsError(WaybackException):
+    # A URL can't be queried in Wayback because it was blocked by robots.txt
+    ...
+
+
+# TODO: split this up into a family of more specific errors? When playback
+# failed partway into a redirect chain, when a redirect goes outside
+# redirect_target_window, when a memento was circular?
 class MementoPlaybackError(WaybackException):
     ...
 
 
-class SessionClosedError(WaybackException):
-    ...
+class WaybackRetryError(WaybackException):
+    def __init__(self, retries, total_time, causal_error):
+        self.retries = retries
+        self.cause = causal_error
+        self.time = total_time
+        super().__init__(f'Retried {retries} times over {total_time or "?"} seconds (error: {causal_error})')
 
 
 CDX_SEARCH_URL = 'http://web.archive.org/cdx/search/cdx'
+# This /web/timemap URL has newer features, but has other bugs and doesn't
+# support some features, like resume keys (for paging). It ignores robots.txt,
+# while /cdx/search obeys robots.txt (for now). It also has different/extra
+# columns. See https://github.com/internetarchive/wayback/blob/bd205b9b26664a6e2ea3c0c2a8948f0dc6ff4519/wayback-cdx-server/src/main/java/org/archive/cdxserver/format/CDX11Format.java#L13-L17
+# NOTE: the `length` and `robotflags` fields appear to always be empty
+# TODO: support new/upcoming CDX API
+# CDX_SEARCH_URL = 'http://web.archive.org/web/timemap/cdx'
+
 ARCHIVE_RAW_URL_TEMPLATE = 'http://web.archive.org/web/{timestamp}id_/{url}'
 ARCHIVE_VIEW_URL_TEMPLATE = 'http://web.archive.org/web/{timestamp}/{url}'
 URL_DATE_FORMAT = '%Y%m%d%H%M%S'
 MEMENTO_URL_PATTERN = re.compile(
-    r'^http(?:s)?://web.archive.org/web/\d+(?:id_)?/(.+)$')
+    r'^http(?:s)?://web.archive.org/web/(\d+)(?:id_)?/(.+)$')
 REDUNDANT_HTTP_PORT = re.compile(r'^(http://[^:/]+):80(.*)$')
 REDUNDANT_HTTPS_PORT = re.compile(r'^(https://[^:/]+):443(.*)$')
+DATA_URL_START = re.compile(r'data:[\w]+/[\w]+;base64')
+# Matches URLs w/ users w/no pass, e-mail addresses, and mailto: URLs. These
+# basically look like an e-mail or mailto: got `http://` pasted in front, e.g:
+#   http://b***z@pnnl.gov/
+#   http://@pnnl.gov/
+#   http://mailto:first.last@pnnl.gov/
+#   http://<<mailto:first.last@pnnl.gov>>/
+EMAILISH_URL = re.compile(r'^https?://(<*)((mailto:)|([^/@:]*@))')
+# Make sure it roughly starts with a valid protocol + domain + port?
+URL_ISH = re.compile(r'^[\w+\-]+://[^/?=&]+\.\w\w+(:\d+)?(/|$)')
 
 CdxRecord = namedtuple('CdxRecord', (
     # Raw CDX values
@@ -65,6 +113,43 @@ CdxRecord = namedtuple('CdxRecord', (
 ))
 
 
+def split_memento_url(memento_url):
+    'Extract the raw date and URL components from a memento URL.'
+    match = MEMENTO_URL_PATTERN.match(memento_url)
+    if match is None:
+        raise ValueError(f'"{memento_url}" is not a memento URL')
+
+    return match.group(2), match.group(1)
+
+
+def clean_memento_url_component(url):
+    # A URL *may* be percent encoded, decode ONLY if so (we don’t want to
+    # accidentally decode the querystring if there is one)
+    lower_url = url.lower()
+    if lower_url.startswith('http%3a') or lower_url.startswith('https%3a'):
+        url = urllib.parse.unquote(url)
+
+    return url
+
+
+def memento_url_data(memento_url):
+    """
+    Get the original URL and date that a memento URL represents a capture of.
+
+    Examples
+    --------
+    Extract original URL and date.
+
+    >>> memento_url_data('http://web.archive.org/web/20170813195036/https://arpa-e.energy.gov/?q=engage/events-workshops')
+    ('https://arpa-e.energy.gov/?q=engage/events-workshops', datetime.datetime(2017, 8, 13, 19, 50, 36))
+    """
+    raw_url, timestamp = split_memento_url(memento_url)
+    url = clean_memento_url_component(raw_url)
+    date = datetime.strptime(timestamp, URL_DATE_FORMAT)
+
+    return url, date
+
+
 def original_url_for_memento(memento_url):
     """
     Get the original URL that a memento URL represents a capture of.
@@ -76,19 +161,21 @@ def original_url_for_memento(memento_url):
     >>> original_url_for_memento('http://web.archive.org/web/20170813195036/https://arpa-e.energy.gov/?q=engage/events-workshops')
     'https://arpa-e.energy.gov/?q=engage/events-workshops'
     """
-    match = MEMENTO_URL_PATTERN.match(memento_url)
-    if match is None:
-        raise ValueError(f'"{memento_url}" is not a memento URL')
+    return clean_memento_url_component(split_memento_url(memento_url)[0])
 
-    url = match.group(1)
 
-    # A URL *may* be percent encoded, decode ONLY if so (we don’t want to
-    # accidentally decode the querystring if there is one)
-    lower_url = url.lower()
-    if lower_url.startswith('http%3a') or lower_url.startswith('https%3a'):
-        url = urllib.parse.unquote(url)
+def is_malformed_url(url):
+    if DATA_URL_START.search(url):
+        return True
 
-    return url
+    # TODO: restrict to particular protocols?
+    if url.startswith('mailto:') or EMAILISH_URL.match(url):
+        return True
+
+    if URL_ISH.match(url) is None:
+        return True
+
+    return False
 
 
 def cdx_hash(content):
@@ -97,30 +184,151 @@ def cdx_hash(content):
     return b32encode(hashlib.sha1(content).digest()).decode()
 
 
-class WaybackSession(requests.Session):
+#####################################################################
+# HACK: handle malformed Content-Encoding headers from Wayback.
+# When you send `Accept-Encoding: gzip` on a request for a memento, Wayback
+# will faithfully gzip the response body. However, if the original response
+# from the web server that was snapshotted was gzipped, Wayback screws up the
+# `Content-Encoding` header on the memento response, leading any HTTP client to
+# *not* decompress the gzipped body. Wayback folks have no clear timeline for
+# a fix, hence the workaround here. More info in this issue:
+# https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/309
+#
+# This subclass of urllib3's response class identifies the malformed headers
+# and repairs them before instantiating the actual response object, so when it
+# reads the body, it knows to decode it correctly.
+#
+# See what we're overriding from urllib3:
+# https://github.com/urllib3/urllib3/blob/a6ec68a5c5c5743c59fe5c62c635c929586c429b/src/urllib3/response.py#L499-L526
+class WaybackResponse(HTTPConnectionPool.ResponseCls):
+    @classmethod
+    def from_httplib(cls, httplib_response, **response_kwargs):
+        headers = httplib_response.msg
+        pairs = headers.items()
+        if ('content-encoding', '') in pairs and ('Content-Encoding', 'gzip') in pairs:
+            del headers['content-encoding']
+            headers['Content-Encoding'] = 'gzip'
+        return super().from_httplib(httplib_response, **response_kwargs)
+
+
+HTTPConnectionPool.ResponseCls = WaybackResponse
+# END HACK
+#####################################################################
+
+
+# TODO: make rate limiting configurable at the session level, rather than
+# arbitrarily set inside get_memento(). Idea: have a rate limit lock type and
+# pass an instance to the constructor here.
+class WaybackSession(utils.DisableAfterCloseSession, requests.Session):
     """
-    A custom session object that network pools connections and resources. It
-    raises a :class:`SessionClosedError` if you try and use it after closing
-    it, to help identify and avoid potentially dangerous code patterns.
-    (Standard session objects continue to be usable after closing, even if they
-    may not work exactly as expected.)
+    A custom session object that network pools connections and resources for
+    requests to the Wayback Machine.
+
+    Parameters
+    ----------
+    retries : int, optional
+        The maximum number of retries for requests.
+    backoff : int or float, optional
+        Number of seconds from which to calculate how long to back off and wait
+        when retrying requests. The first retry is always immediate, but
+        subsequent retries increase by powers of 2:
+            seconds = backoff * 2 ^ (retry number - 1)
+        So if this was `4`, retries would happen after the following delays:
+            0 seconds, 4 seconds, 8 seconds, 16 seconds, ...
+    timeout : int or float or tuple of (int or float, int or float), optional
+        A timeout to use for all requests. If not set, there will be no
+        no explicit timeout. See the Requests docs for more:
+        http://docs.python-requests.org/en/master/user/advanced/#timeouts
+    user_agent : str, optional
+        A custom user-agent string to use in all requests.
     """
 
-    _closed = False
+    # It seems Wayback sometimes produces 500 errors for transient issues, so
+    # they make sense to retry here. Usually not in other contexts, though.
+    retryable_statuses = frozenset((413, 421, 429, 500, 502, 503, 504, 599))
 
-    def close(self):
-        super().close()
-        self._closed = True
+    retryable_errors = (ConnectTimeoutError, MaxRetryError, ReadTimeoutError,
+                        ProxyError, RetryError, Timeout)
+    handleable_errors = (ConnectionError,) + retryable_errors
 
+    def __init__(self, retries=6, backoff=2, timeout=None, user_agent=None):
+        super().__init__()
+        self.retries = retries
+        self.backoff = backoff
+        self.timeout = timeout
+        self.headers = {
+            'User-Agent': user_agent or f'edgi.web_monitoring.WaybackClient/{__version__}',
+            'Accept-Encoding': 'gzip, deflate'
+        }
+        # NOTE: the nice way to accomplish retry/backoff is with a urllib3:
+        #     adapter = requests.adapters.HTTPAdapter(
+        #         max_retries=Retry(total=5, backoff_factor=2,
+        #                           status_forcelist=(503, 504)))
+        #     self.mount('http://', adapter)
+        # But Wayback mementos can have errors, which complicates things. See:
+        # https://github.com/urllib3/urllib3/issues/1445#issuecomment-422950868
+
+    # Customize the built-in `send` functionality with retryability.
+    # NOTE: worth considering whether we should push this logic to a custom
+    # requests.adapters.HTTPAdapter
     def send(self, *args, **kwargs):
-        if self._closed:
-            raise SessionClosedError('This session has already been closed '
-                                     'and cannot send new HTTP requests.')
+        if self.timeout is not None and 'timeout' not in kwargs:
+            kwargs['timeout'] = self.timeout
 
-        return super().send(*args, **kwargs)
+        total_time = 0
+        maximum = self.retries
+        retries = 0
+        while True:
+            try:
+                result = super().send(*args, **kwargs)
+                if retries >= maximum or not self.should_retry(result):
+                    return result
+            except WaybackSession.handleable_errors as error:
+                if retries >= maximum:
+                    raise WaybackRetryError(retries, total_time, error)
+                elif not self.should_retry_error(error):
+                    raise
+
+            # The first retry has no delay.
+            if retries > 0:
+                seconds = self.backoff * 2 ** (retries - 1)
+                total_time += seconds
+                time.sleep(seconds)
+
+            retries += 1
+
+    def should_retry(self, response):
+        # A memento may actually be a capture of an error, so don't retry it :P
+        if 'Memento-Datetime' in response.headers:
+            return False
+
+        return response.status_code in self.retryable_statuses
+
+    def should_retry_error(self, error):
+        if isinstance(error, WaybackSession.retryable_errors):
+            return True
+        elif isinstance(error, ConnectionError):
+            text = str(error)
+            if 'NewConnectionError' in text or 'Max retries' in text:
+                return True
+
+        return False
+
+    def reset(self):
+        "Reset any network connections the session is using."
+        # Close really just closes all the adapters in `self.adapters`. We
+        # could do that directly, but `self.adapters` is not documented/public,
+        # so might be somewhat risky.
+        self.close(disable=False)
+        # Re-build the standard adapters. See:
+        # https://github.com/kennethreitz/requests/blob/v2.22.0/requests/sessions.py#L415-L418
+        self.mount('https://', requests.adapters.HTTPAdapter())
+        self.mount('http://', requests.adapters.HTTPAdapter())
 
 
-class WaybackClient:
+# TODO: add retry, backoff, cross_thread_backoff, and rate_limit options that
+# create a custom instance of urllib3.utils.Retry
+class WaybackClient(utils.DepthCountedContext):
     """
     A client for retrieving data from the Internet Archive's Wayback Machine.
 
@@ -136,10 +344,7 @@ class WaybackClient:
     def __init__(self, session=None):
         self.session = session or WaybackSession()
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
+    def __exit_all__(self, type, value, traceback):
         self.close()
 
     def close(self):
@@ -150,7 +355,7 @@ class WaybackClient:
                fastLatest=None, gzip=None, from_date=None, to_date=None,
                filter_field=None, collapse=None, showResumeKey=True,
                resumeKey=None, page=None, pageSize=None, resolveRevisits=True,
-               **kwargs):
+               skip_malformed_results=True, **kwargs):
         """
         Search archive.org's CDX API for all captures of a given URL.
 
@@ -220,6 +425,13 @@ class WaybackClient:
             Attempt to resolve `warc/revisit` records to their actual content
             type and response code. Not supported on all CDX servers. Defaults
             to True.
+        skip_malformed_results : bool, optional
+            If true, don't yield records that look like they have no actual
+            memento associated with them. Some crawlers will erroneously
+            attempt to capture bad URLs like `http://mailto:someone@domain.com`
+            or `http://data:image/jpeg;base64,AF34...` and so on. This is a
+            filter performed client side and is not a CDX API argument.
+            (Default: True)
         **kwargs
             Any additional CDX API options.
 
@@ -262,9 +474,8 @@ class WaybackClient:
                 else:
                     final_query[key] = str(value).lower()
 
-        response = utils.retryable_request('GET', CDX_SEARCH_URL,
-                                           params=final_query,
-                                           session=self.session)
+        response = self.session.request('GET', CDX_SEARCH_URL,
+                                        params=final_query)
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as error:
@@ -288,11 +499,15 @@ class WaybackClient:
                 capture_time = datetime.strptime(data.timestamp,
                                                  URL_DATE_FORMAT)
             except Exception:
-                raise UnexpectedResponseFormat(text)
+                if 'RobotAccessControlException' in text:
+                    raise BlockedByRobotsError(f'CDX search for URL was blocked by robots.txt "{query["url"]}" (parameters: {final_query})')
+                raise UnexpectedResponseFormat(f'Could not parse CDX output: "{text}" (parameters: {final_query})')
 
             clean_url = REDUNDANT_HTTPS_PORT.sub(
                 r'\1\2', REDUNDANT_HTTP_PORT.sub(
                     r'\1\2', data.url))
+            if skip_malformed_results and is_malformed_url(clean_url):
+                continue
             if clean_url != data.url:
                 data = data._replace(url=clean_url)
 
@@ -376,6 +591,12 @@ class WaybackClient:
 
         last_hashes = {}
         for version in self.search(**params):
+            # TODO: make skip_repeats smarter so we can use it again: only
+            # check & skip the hash if the mime_type is not `warc/revisit`,
+            # `unk`, `-` or `` and status_code is not `3xx`, `-` or ``.
+            # Possible betterment: CAN skip warc/revisits with same hash IF
+            # previous version of this URL with the same hash was not a revisit
+            # and was not a 3xx status code.
             # TODO: may want to follow redirects and resolve them in the future
             if not skip_repeats or last_hashes.get(version.url) != version.digest:
                 last_hashes[version.url] = version.digest
@@ -385,6 +606,153 @@ class WaybackClient:
         if not last_hashes:
             raise ValueError("Internet archive does not have archived "
                              "versions of {}".format(url))
+
+    # TODO: make this nicer by taking an optional date, so `url` can be a
+    # memento url or an original URL + plus date and we'll compose a memento
+    # URL.
+    # TODO: for generic use, needs to be able to return the memento itself if
+    # the memento was a redirect (different than allowing a nearby-in-time
+    # memento of the same URL, which would be the above argument). Probably
+    # call this `follow_redirects=True`?
+    def get_memento(self, url, exact=True, exact_redirects=None,
+                    target_window=24 * 60 * 60):
+        """
+        Fetch a memento from the Wayback Machine. This retrieves the content
+        that was ultimately returned from a memento, following any redirects
+        that were present at the time the memento was captured. (That is, if
+        `http://example.com/a` redirected to `http://example.com/b`, this
+        returns the memento for `/b` when you request `/a`.)
+
+        Parameters
+        ----------
+        url : string
+            URL of memento in Wayback (e.g.
+            `http://web.archive.org/web/20180816111911id_/http://www.nws.noaa.gov/sp/`)
+        exact : boolean, optional
+            If false and the requested memento either doesn't exist or can't be
+            played back, this returns the closest-in-time memento to the
+            requested one, so long as it is within `target_window`.
+            Default: True
+        exact_redirects : boolean, optional
+            If false and the requested memento is a redirect whose *target*
+            doesn't exist or or can't be played back, this returns the closest-
+            in-time memento to the intended target, so long as it is within
+            `target_window`. If unset, this will be the same as `exact`.
+        target_window : int, optional
+            If the memento is of a redirect, allow up to this many seconds
+            between the capture of the redirect and the capture of the target
+            URL. (Note this does NOT apply when the originally requested
+            memento didn't exist and wayback redirects to the next-closest-in-
+            -time one. That will always raise a MementoPlaybackError.)
+            Defaults to 86,400 (24 hours).
+
+        Returns
+        -------
+        dict : requests.Response
+            An HTTP response with the content of the memento, including a
+            history of any redirects involved.
+        """
+        if exact_redirects is None:
+            exact_redirects = exact
+
+        with utils.rate_limited(calls_per_second=30, group='get_memento'):
+            # Correctly following redirects is actually pretty complicated. In
+            # the simplest case, a memento is a simple web page, and that's
+            # no problem. However...
+            #   1.  If the response was a >= 400 status, we have to determine
+            #       whether that status is coming from the memento or from the
+            #       the Wayback Machine itself.
+            #   2.  If the response was a 3xx status (a redirect) we have to
+            #       determine the same thing, but it's a little more complex...
+            #       a) If the redirect *is* the memento, its target may be an
+            #          actual memento (see #1) or it may be a redirect (#2).
+            #          The targeted URL is frequently captured anywhere from
+            #          the same second to a few hours later, so it is likely
+            #          the target will result in case 2b (below).
+            #       b) If there is no memento for the requested time, but there
+            #          are mementos for the same URL at another time, Wayback
+            #          *may* redirect to that memento.
+            #          - If this was on the original request, that's *not* ok
+            #            because it means we're getting a different memento
+            #            than we asked for.
+            #          - If the redirect came from a URL that was the target of
+            #            of a memento redirect (2a), then this is expected.
+            #            Before following the redirect, though, we first sanity
+            #            check it to make sure the memento we are redirecting
+            #            to actually came from nearby in time (sometimes
+            #            Wayback will redirect to captures *months* away).
+            history = []
+            urls = set()
+            previous_was_memento = False
+            orginal_url, original_date = memento_url_data(url)
+            response = self.session.request('GET', url, allow_redirects=False)
+            protocol_and_www = re.compile(r'^https?://(www\d?\.)?')
+            while True:
+                is_memento = 'Memento-Datetime' in response.headers
+
+                if not is_memento:
+                    # The exactness requirements for redirects from memento
+                    # playbacks and non-playbacks is different -- even with
+                    # strict matching, a memento that redirects to a non-
+                    # memento is normal and ok; the target of a redirect will
+                    # rarely have been captured at the same time as the
+                    # redirect itself. (See 2b)
+                    playable = False
+                    if response.next and (
+                       (len(history) == 0 and exact == False) or
+                       (len(history) > 0 and (previous_was_memento or exact_redirects == False))):
+                        current_url = original_url_for_memento(response.url)
+                        target_url, target_date = memento_url_data(response.next.url)
+                        # A non-memento redirect is generally taking us to the
+                        # closest-in-time capture of the same URL. Note that is
+                        # NOT the next capture -- i.e. the one that would have
+                        # been produced by an earlier memento redirect -- it's
+                        # just the *closest* one. The first job here is to make
+                        # sure it fits within our target window.
+                        if abs(target_date - original_date).seconds <= target_window:
+                            # The redirect will point to the closest-in-time
+                            # SURT URL, which will often not be an exact URL
+                            # match. If we aren't looking for exact matches,
+                            # then just assume wherever we're redirecting to is
+                            # ok. Otherwise, try to sanity-check the URL.
+                            if exact_redirects:
+                                # FIXME: what should *really* happen here, if
+                                # we want exactness, is a CDX search for the
+                                # next-int-time capture of the exact URL we
+                                # redirected to. I'm not totally sure how
+                                # great that is (also it seems high overhead to
+                                # do a search in the middle of this series of
+                                # memento lookups), so just do a loose URL
+                                # check for now.
+                                current_nice_url = protocol_and_www.sub('', current_url).casefold()
+                                target_nice_url = protocol_and_www.sub('', target_url).casefold()
+                                playable = current_nice_url == target_nice_url
+                            else:
+                                playable = True
+
+                    if not playable:
+                        message = response.headers.get('X-Archive-Wayback-Runtime-Error')
+                        if message:
+                            raise MementoPlaybackError(f'Memento at {url} could not be played: {message}')
+                        elif response.ok:
+                            raise MementoPlaybackError(f'Memento at {url} could not be played')
+                        else:
+                            response.raise_for_status()
+
+                if response.next:
+                    previous_was_memento = is_memento
+                    urls.add(response.url)
+                    # Wayback sometimes has circular memento redirects ¯\_(ツ)_/¯
+                    if response.next.url in urls:
+                        raise MementoPlaybackError(f'Memento at {url} is circular')
+
+                    history.append(response)
+                    response = self.session.send(response.next, allow_redirects=False)
+                else:
+                    break
+
+            response.history = history
+            return response
 
     def timestamped_uri_to_version(self, dt, uri, *, url,
                                    maintainers=None, tags=None, view_url=None):
@@ -411,27 +779,7 @@ class WaybackClient:
         dict : Version
             suitable for passing to :class:`Client.add_versions`
         """
-        with utils.rate_limited(group='timestamped_uri_to_version'):
-            # Check to make sure we are actually getting a memento playback.
-            res = utils.retryable_request(
-                'GET', uri, allow_redirects=False, session=self.session)
-            if res.headers.get('memento-datetime') is None:
-                message = res.headers.get('X-Archive-Wayback-Runtime-Error')
-                if message:
-                    raise MementoPlaybackError(f'Memento at {uri} could not be played: {message}')
-                elif res.ok:
-                    raise MementoPlaybackError(f'Memento at {uri} could not be played')
-                else:
-                    res.raise_for_status()
-
-            # If the playback includes a redirect, continue on.
-            if res.status_code >= 300 and res.status_code < 400:
-                original = res
-                res = utils.retryable_request(
-                    'GET', res.headers.get('location'), session=self.session)
-                res.history.insert(0, original)
-                res.request = original.request
-
+        res = self.get_memento(uri, exact_redirects=False)
         version_hash = utils.hash_content(res.content)
         title = utils.extract_title(res.content)
         content_type = (res.headers['content-type'] or '').split(';', 1)

--- a/web_monitoring/tests/test_ia.py
+++ b/web_monitoring/tests/test_ia.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import pytest
 import vcr
 from web_monitoring.utils import SessionClosedError
-from web_monitoring.internetarchive import (WaybackClient,
+from web_monitoring.internetarchive import (WaybackSession,
+                                            WaybackClient,
                                             original_url_for_memento,
                                             MementoPlaybackError)
 
@@ -112,3 +113,31 @@ def test_timestamped_uri_to_version_should_fail_for_non_playbackable_mementos():
                 datetime(2017, 9, 29, 0, 27, 12),
                 'http://web.archive.org/web/20170929002712id_/https://www.fws.gov/birds/',
                 url='https://www.fws.gov/birds/')
+
+
+class TestWaybackSession:
+    def test_request_retries(self, requests_mock):
+        requests_mock.get('http://test.com', [{'text': 'bad1', 'status_code': 503},
+                                              {'text': 'bad2', 'status_code': 503},
+                                              {'text': 'good', 'status_code': 200}])
+        session = WaybackSession(retries=2, backoff=0.1)
+        response = session.request('GET', 'http://test.com')
+        assert response.ok
+
+        session.close()
+
+    def test_stops_after_given_retries(self, requests_mock):
+        requests_mock.get('http://test.com', [{'text': 'bad1', 'status_code': 503},
+                                              {'text': 'bad2', 'status_code': 503},
+                                              {'text': 'good', 'status_code': 200}])
+        session = WaybackSession(retries=1, backoff=0.1)
+        response = session.request('GET', 'http://test.com')
+        assert response.status_code == 503
+        assert response.text == 'bad2'
+
+    def test_only_retries_some_errors(self, requests_mock):
+        requests_mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
+                                              {'text': 'good', 'status_code': 200}])
+        session = WaybackSession(retries=1, backoff=0.1)
+        response = session.request('GET', 'http://test.com')
+        assert response.status_code == 400

--- a/web_monitoring/tests/test_ia.py
+++ b/web_monitoring/tests/test_ia.py
@@ -2,10 +2,10 @@ from datetime import datetime
 from pathlib import Path
 import pytest
 import vcr
+from web_monitoring.utils import SessionClosedError
 from web_monitoring.internetarchive import (WaybackClient,
                                             original_url_for_memento,
-                                            MementoPlaybackError,
-                                            SessionClosedError)
+                                            MementoPlaybackError)
 
 
 # This stashes HTTP responses in JSON files (one per test) so that an actual

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+import pytest
 import requests_mock
-from web_monitoring.utils import extract_title, retryable_request, rate_limited
+from web_monitoring.utils import extract_title, rate_limited
 
 
 def test_extract_title():
@@ -17,6 +18,21 @@ def test_extract_title_from_titleless_page():
         <body>Blah</body>
     </html>''')
     assert title == ''
+
+
+def test_extract_title_handles_whitespace():
+    title = extract_title(b'''<html>
+        <head>
+            <meta charset="utf-8">
+            <title>
+
+                THIS IS
+                THE  TITLE
+            </title>
+        </head>
+        <body>Blah</body>
+    </html>''')
+    assert title == 'THIS IS THE TITLE'
 
 
 def test_rate_limited():
@@ -45,38 +61,44 @@ def test_separate_rate_limited_groups_do_not_affect_each_other():
     assert duration.total_seconds() < 0.55
 
 
-def test_retryable_request_retries():
-    with requests_mock.Mocker() as mock:
-        mock.get('http://test.com', [{'text': 'bad', 'status_code': 503},
-                                     {'text': 'good', 'status_code': 200}])
-        response = retryable_request('GET', 'http://test.com', backoff=0)
-        assert response.ok
+# FIXME: Run some similar tests against WaybackSession, which now has built-in
+# retry logic.
+# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
+# def test_retryable_request_retries():
+#     with requests_mock.Mocker() as mock:
+#         mock.get('http://test.com', [{'text': 'bad', 'status_code': 503},
+#                                      {'text': 'good', 'status_code': 200}])
+#         response = retryable_request('GET', 'http://test.com', backoff=0)
+#         assert response.ok
 
 
-def test_retryable_request_stops_after_given_retries():
-    with requests_mock.Mocker() as mock:
-        mock.get('http://test.com', [{'text': 'bad1', 'status_code': 503},
-                                     {'text': 'bad2', 'status_code': 503},
-                                     {'text': 'bad3', 'status_code': 503},
-                                     {'text': 'good', 'status_code': 200}])
-        response = retryable_request('GET', 'http://test.com', retries=2, backoff=0)
-        assert response.status_code == 503
-        assert response.text == 'bad3'
+# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
+# def test_retryable_request_stops_after_given_retries():
+#     with requests_mock.Mocker() as mock:
+#         mock.get('http://test.com', [{'text': 'bad1', 'status_code': 503},
+#                                      {'text': 'bad2', 'status_code': 503},
+#                                      {'text': 'bad3', 'status_code': 503},
+#                                      {'text': 'good', 'status_code': 200}])
+#         response = retryable_request('GET', 'http://test.com', retries=2, backoff=0)
+#         assert response.status_code == 503
+#         assert response.text == 'bad3'
 
 
-def test_retryable_request_only_retries_gateway_errors():
-    with requests_mock.Mocker() as mock:
-        mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
-                                     {'text': 'good', 'status_code': 200}])
-        response = retryable_request('GET', 'http://test.com', backoff=0)
-        assert response.status_code == 400
+# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
+# def test_retryable_request_only_retries_gateway_errors():
+#     with requests_mock.Mocker() as mock:
+#         mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
+#                                      {'text': 'good', 'status_code': 200}])
+#         response = retryable_request('GET', 'http://test.com', backoff=0)
+#         assert response.status_code == 400
 
 
-def test_retryable_request_with_custom_retry_logic():
-    with requests_mock.Mocker() as mock:
-        mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
-                                     {'text': 'good', 'status_code': 200}])
+# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
+# def test_retryable_request_with_custom_retry_logic():
+#     with requests_mock.Mocker() as mock:
+#         mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
+#                                      {'text': 'good', 'status_code': 200}])
 
-        response = retryable_request('GET', 'http://test.com', backoff=0,
-                                     should_retry=lambda r: r.status_code == 400)
-        assert response.status_code == 200
+#         response = retryable_request('GET', 'http://test.com', backoff=0,
+#                                      should_retry=lambda r: r.status_code == 400)
+#         assert response.status_code == 200

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -61,48 +61,6 @@ def test_separate_rate_limited_groups_do_not_affect_each_other():
     assert duration.total_seconds() < 0.55
 
 
-# FIXME: Run some similar tests against WaybackSession, which now has built-in
-# retry logic.
-# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
-# def test_retryable_request_retries():
-#     with requests_mock.Mocker() as mock:
-#         mock.get('http://test.com', [{'text': 'bad', 'status_code': 503},
-#                                      {'text': 'good', 'status_code': 200}])
-#         response = retryable_request('GET', 'http://test.com', backoff=0)
-#         assert response.ok
-
-
-# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
-# def test_retryable_request_stops_after_given_retries():
-#     with requests_mock.Mocker() as mock:
-#         mock.get('http://test.com', [{'text': 'bad1', 'status_code': 503},
-#                                      {'text': 'bad2', 'status_code': 503},
-#                                      {'text': 'bad3', 'status_code': 503},
-#                                      {'text': 'good', 'status_code': 200}])
-#         response = retryable_request('GET', 'http://test.com', retries=2, backoff=0)
-#         assert response.status_code == 503
-#         assert response.text == 'bad3'
-
-
-# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
-# def test_retryable_request_only_retries_gateway_errors():
-#     with requests_mock.Mocker() as mock:
-#         mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
-#                                      {'text': 'good', 'status_code': 200}])
-#         response = retryable_request('GET', 'http://test.com', backoff=0)
-#         assert response.status_code == 400
-
-
-# @pytest.mark.skip(reason='Retryable request is deprecated; need to test new retry method')
-# def test_retryable_request_with_custom_retry_logic():
-#     with requests_mock.Mocker() as mock:
-#         mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
-#                                      {'text': 'good', 'status_code': 200}])
-
-#         response = retryable_request('GET', 'http://test.com', backoff=0,
-#                                      should_retry=lambda r: r.status_code == 400)
-#         assert response.status_code == 200
-
 class TestFiniteQueue:
     def test_queue_ends_with_QUEUE_END(self):
         test_queue = FiniteQueue()

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 import pytest
+import queue
 import requests_mock
-from web_monitoring.utils import extract_title, rate_limited
+import threading
+from web_monitoring.utils import extract_title, rate_limited, FiniteQueue
 
 
 def test_extract_title():
@@ -102,3 +104,44 @@ def test_separate_rate_limited_groups_do_not_affect_each_other():
 #         response = retryable_request('GET', 'http://test.com', backoff=0,
 #                                      should_retry=lambda r: r.status_code == 400)
 #         assert response.status_code == 200
+
+class TestFiniteQueue:
+    def test_queue_ends_with_QUEUE_END(self):
+        test_queue = FiniteQueue()
+        test_queue.put('First')
+        test_queue.end()
+
+        assert test_queue.get() == 'First'
+        assert test_queue.get() is FiniteQueue.QUEUE_END
+        # We should keep getting QUEUE_END from now on, too.
+        assert test_queue.get() is FiniteQueue.QUEUE_END
+
+    def test_queue_is_iterable(self):
+        test_queue = FiniteQueue()
+        test_queue.put('First')
+        test_queue.end()
+
+        result = list(test_queue)
+        assert result == ['First']
+
+    def test_queue_can_be_safely_read_from_multiple_threads(self):
+        # We want to make sure that a thread can't get stuck waiting for the
+        # next item on a queue that is already ended.
+        test_queue = FiniteQueue()
+        results = queue.SimpleQueue()
+
+        def read_one_item():
+            try:
+                results.put(test_queue.get(timeout=1))
+            except queue.Empty as error:
+                results.put(error)
+
+        threads = [threading.Thread(target=read_one_item) for i in range(3)]
+        [thread.start() for thread in threads]
+        test_queue.put('First')
+        test_queue.end()
+        [thread.join() for thread in threads]
+
+        assert results.get() == 'First'
+        assert results.get() is FiniteQueue.QUEUE_END
+        assert results.get() is FiniteQueue.QUEUE_END

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -1,7 +1,5 @@
 from datetime import datetime
-import pytest
 import queue
-import requests_mock
 import threading
 from web_monitoring.utils import extract_title, rate_limited, FiniteQueue
 

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -1,11 +1,33 @@
 from collections import defaultdict
 from contextlib import contextmanager
+import functools
 import hashlib
 import io
+import itertools
+import logging
 import lxml.html
 import os
+import re
 import requests
+import requests.adapters
+import signal
+import threading
 import time
+import urllib.parse
+
+from requests.exceptions import ConnectionError
+from urllib3.exceptions import (
+    ConnectTimeoutError,
+    MaxRetryError,
+    ReadTimeoutError
+)
+
+
+logger = logging.getLogger(__name__)
+
+_backoff_locks = defaultdict(threading.Lock)
+
+WHITESPACE_PATTERN = re.compile(r'\s+')
 
 
 def extract_title(content_bytes, encoding='utf-8'):
@@ -17,10 +39,12 @@ def extract_title(content_bytes, encoding='utf-8'):
         title = lxml.html.parse(content_as_file).find(".//title")
     except Exception:
         return ''
-    if title is None:
+
+    if title is None or title.text is None:
         return ''
-    else:
-        return title.text
+
+    # In HTML, all consecutive whitespace (including line breaks) collapses
+    return WHITESPACE_PATTERN.sub(' ', title.text.strip())
 
 
 def hash_content(content_bytes):
@@ -28,56 +52,8 @@ def hash_content(content_bytes):
     return hashlib.sha256(content_bytes).hexdigest()
 
 
-def _should_retry(response):
-    return response.status_code == 503 or response.status_code == 504
-
-
-def retryable_request(method, url, retries=3, backoff=20,
-                      should_retry=_should_retry, session=None, **kwargs):
-    """
-    Make a request with the `requests` library that will be automatically
-    retried up to a set number of times.
-
-    Parameters
-    ----------
-    method : string
-        HTTP request method to use
-    url : string
-        URL to request data from
-    retries : int, optional
-        Maximum number of retries
-    backoff : int or float, optional
-        Maximum number of seconds to wait before retrying. After each attempt,
-        the wait time is calculated by: `backoff / retries_left`, so the final
-        attempt will occur `backoff` seconds after the penultimate attempt.
-    should_retry : function, optional
-        A callback that receives the HTTP response and returns a boolean
-        indicating whether the call should be retried. By default, it retries
-        for responses with 503 and 504 status codes (gateway errors).
-    session : requests.Session, optional
-        A session object to use when making requests.
-    **kwargs : dict, optional
-        Any additional keyword parameters are passed on to `requests`
-
-    Returns
-    -------
-    response : requests.Response
-        The HTTP response object from `requests`
-    """
-    internal_session = session or requests.Session()
-    response = internal_session.request(method, url, **kwargs)
-    if should_retry(response) and retries > 0:
-        time.sleep(backoff / retries)
-        response = retryable_request(method, url, retries - 1, backoff,
-                                     session=internal_session, **kwargs)
-
-    if internal_session is not session:
-        internal_session.close()
-
-    return response
-
-
 _last_call_by_group = defaultdict(int)
+_rate_limit_lock = threading.Lock()
 
 
 @contextmanager
@@ -98,13 +74,14 @@ def rate_limited(calls_per_second=2, group='default'):
     if calls_per_second <= 0:
         yield
     else:
-        last_call = _last_call_by_group[group]
-        minimum_wait = 1.0 / calls_per_second
-        current_time = time.time()
-        if current_time - last_call < minimum_wait:
-            time.sleep(minimum_wait - (current_time - last_call))
+        with _rate_limit_lock:
+            last_call = _last_call_by_group[group]
+            minimum_wait = 1.0 / calls_per_second
+            current_time = time.time()
+            if current_time - last_call < minimum_wait:
+                time.sleep(minimum_wait - (current_time - last_call))
+            _last_call_by_group[group] = time.time()
         yield
-        _last_call_by_group[group] = time.time()
 
 
 def get_color_palette():
@@ -122,3 +99,181 @@ def get_color_palette():
     differ_deletion = os.environ.get('DIFFER_COLOR_DELETION', '#e8a4c8')
     return {'differ_insertion': differ_insertion,
             'differ_deletion': differ_deletion}
+
+
+class ThreadSafeIterator:
+    """
+    Wraps an iterator with locks to make reading from it thread-safe.
+
+    Parameters
+    ----------
+    iterator : iterator
+    """
+    def __init__(self, iterator):
+        self.iterator = iter(iterator)
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            return next(self.iterator)
+
+
+def queue_iterator(queue, auto_done=True):
+    """
+    Create an iterator over the items in a :class:`queue.Queue`. The iterator
+    will stop if it encounters a `None` item.
+
+    Parameters
+    ----------
+    queue : queue.Queue
+    auto_done : bool, optional
+        If true (the default value), the iterator will automatically call
+        `queue.task_done()` for each item. If you want to actually make use of
+        this queue feature, set it to false so you can manually call
+        `queue.task_done()` at the appropriate time.
+    """
+    while True:
+        value = queue.get()
+        if auto_done:
+            queue.task_done()
+        if value:
+            yield value
+        else:
+            return
+
+
+class DepthCountedContext:
+    """
+    DepthCountedContext is a mixin or base class for context managers that need
+    to be perform special operations only when all nested contexts they might
+    be used in have exited.
+
+    Override the `__exit_all__(self, type, value, traceback)` method to get a
+    version of `__exit__` that is only called when exiting the top context.
+
+    As a convenience, the built-in `__enter__` returns `self`, which is fairly
+    common, so in many cases you don't need to author your own `__enter__` or
+    `__exit__` methods.
+    """
+    _context_depth = 0
+
+    def __enter__(self):
+        self._context_depth += 1
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self._context_depth > 0:
+            self._context_depth -= 1
+        if self._context_depth == 0:
+            return self.__exit_all__(type, value, traceback)
+
+    def __exit_all__(self, type, value, traceback):
+        """
+        A version of the normal `__exit__` context manager method that only
+        gets called when the top level context is exited. This is meant to be
+        overridden in your class.
+        """
+        pass
+
+
+class SessionClosedError(Exception):
+    ...
+
+
+class DisableAfterCloseSession(requests.Session):
+    """
+    A custom session object raises a :class:`SessionClosedError` if you try to
+    use it after closing it, to help identify and avoid potentially dangerous
+    code patterns. (Standard session objects continue to be usable after
+    closing, even if they may not work exactly as expected.)
+    """
+    _closed = False
+
+    def close(self, disable=True):
+        super().close()
+        if disable:
+            self._closed = True
+
+    def send(self, *args, **kwargs):
+        if self._closed:
+            raise SessionClosedError('This session has already been closed '
+                                     'and cannot send new HTTP requests.')
+
+        return super().send(*args, **kwargs)
+
+
+class Signal:
+    """
+    A context manager to handle signals from the system safely. It keeps track
+    of previous signal handlers and ensures that they are put back into place
+    when the context exits.
+
+    Parameters
+    ----------
+    signals : int or tuple of int
+        The signal or list of signals to handle.
+    handler : callable
+        A signal handler function of the same type used with `signal.signal()`.
+        See: https://docs.python.org/3.6/library/signal.html#signal.signal
+    """
+    def __init__(self, signals, handler):
+        self.handler = handler
+        self.old_handlers = {}
+        try:
+            self.signals = tuple(signals)
+        except TypeError:
+            self.signals = (signals,)
+
+    def __enter__(self):
+        for signal_type in self.signals:
+            self.old_handlers[signal_type] = signal.getsignal(signal_type)
+            signal.signal(signal_type, self.handler)
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+        for signal_type in self.signals:
+            self.old_handlers[signal_type] = signal.getsignal(signal_type)
+            signal.signal(signal_type, self.old_handlers[signal_type])
+
+
+class QuitSignal(Signal):
+    """
+    A context manager that handles system signals by triggering a
+    `threading.Event` instance, giving your program an opportunity to clean up
+    and shut down gracefully. If the signal is repeated a second time, the
+    process quites immediately.
+
+    Parameters
+    ----------
+    signals : int or tuple of int
+        The signal or list of signals to handle.
+    graceful_message : string, optional
+        A message to print to stdout when a signal is received.
+    final_message : string, optional
+        A message to print to stdout before exiting the process when a repeat
+        signal is received.
+    """
+    def __init__(self, signals, graceful_message=None, final_message=None):
+        self.event = threading.Event()
+        self.graceful_message = graceful_message or (
+            'Attempting to finish existing work before exiting. Press ctrl+c '
+            'to stop immediately.')
+        self.final_message = final_message or (
+            'Stopping immediately and aborting all work!')
+        super().__init__(signals, self.handle_interrupt)
+
+    def handle_interrupt(self, signal_type, frame):
+        if not self.event.is_set():
+            print(self.graceful_message)
+            self.event.set()
+        else:
+            print(self.final_message)
+            os._exit(100)
+
+    def __enter__(self):
+        super().__enter__()
+        return self.event

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -102,49 +102,18 @@ def get_color_palette():
             'differ_deletion': differ_deletion}
 
 
-class ThreadSafeIterator:
+def iterate_into_queue(queue, iterable):
     """
-    Wraps an iterator with locks to make reading from it thread-safe.
+    Read items from an iterable and place them onto a FiniteQueue.
 
     Parameters
     ----------
-    iterator : iterator
+    queue: FiniteQueue
+    iterable: sequence
     """
-    def __init__(self, iterator):
-        self.iterator = iter(iterator)
-        self.lock = threading.Lock()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        with self.lock:
-            return next(self.iterator)
-
-
-def queue_iterator(queue, auto_done=True):
-    """
-    Create an iterator over the items in a :class:`queue.Queue`. The iterator
-    will stop if it encounters a `None` item.
-
-    Parameters
-    ----------
-    queue : queue.Queue
-    auto_done : bool, optional
-        If true (the default value), the iterator will automatically call
-        `queue.task_done()` for each item. If you want to actually make use of
-        this queue feature, set it to false so you can manually call
-        `queue.task_done()` at the appropriate time.
-    """
-    auto_done = auto_done and hasattr(queue, 'task_done')
-    while True:
-        value = queue.get()
-        if auto_done:
-            queue.task_done()
-        if value:
-            yield value
-        else:
-            return
+    for item in iterable:
+        queue.put(item)
+    queue.end()
 
 
 class FiniteQueue(queue.SimpleQueue):

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -223,6 +223,16 @@ class Signal:
     handler : callable
         A signal handler function of the same type used with `signal.signal()`.
         See: https://docs.python.org/3.6/library/signal.html#signal.signal
+
+    Examples
+    --------
+    Ignore SIGINT (ctrl+c) and print a glib message instead of quitting:
+
+    >>> def ignore_signal(signal_type, frame):
+    >>>     print("Sorry, but you can't quit this program that way!")
+    >>>
+    >>> with Signal((signal.SIGINT, signal.SIGTERM), ignore_signal):
+    >>>     do_some_work_that_cant_be_interrupted()
     """
     def __init__(self, signals, handler):
         self.handler = handler
@@ -260,6 +270,16 @@ class QuitSignal(Signal):
     final_message : string, optional
         A message to print to stdout before exiting the process when a repeat
         signal is received.
+
+    Examples
+    --------
+    Quit on SIGINT (ctrl+c) or SIGTERM:
+
+    >>> with QuitSignal((signal.SIGINT, signal.SIGTERM)) as cancel:
+    >>>     for item in some_list:
+    >>>         if cancel.is_set():
+    >>>             break
+    >>>         do_some_work()
     """
     def __init__(self, signals, graceful_message=None, final_message=None):
         self.event = threading.Event()

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -250,7 +250,7 @@ class QuitSignal(Signal):
     A context manager that handles system signals by triggering a
     `threading.Event` instance, giving your program an opportunity to clean up
     and shut down gracefully. If the signal is repeated a second time, the
-    process quites immediately.
+    process quits immediately.
 
     Parameters
     ----------

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -16,8 +16,6 @@ import time
 
 logger = logging.getLogger(__name__)
 
-_backoff_locks = defaultdict(threading.Lock)
-
 WHITESPACE_PATTERN = re.compile(r'\s+')
 
 

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -1,9 +1,7 @@
 from collections import defaultdict
 from contextlib import contextmanager
-import functools
 import hashlib
 import io
-import itertools
 import logging
 import lxml.html
 import os
@@ -14,14 +12,6 @@ import requests.adapters
 import signal
 import threading
 import time
-import urllib.parse
-
-from requests.exceptions import ConnectionError
-from urllib3.exceptions import (
-    ConnectTimeoutError,
-    MaxRetryError,
-    ReadTimeoutError
-)
 
 
 logger = logging.getLogger(__name__)

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -241,7 +241,6 @@ class Signal:
 
     def __exit__(self, type, value, traceback):
         for signal_type in self.signals:
-            self.old_handlers[signal_type] = signal.getsignal(signal_type)
             signal.signal(signal_type, self.old_handlers[signal_type])
 
 

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import lxml.html
 import os
+import queue
 import re
 import requests
 import requests.adapters
@@ -135,6 +136,7 @@ def queue_iterator(queue, auto_done=True):
         this queue feature, set it to false so you can manually call
         `queue.task_done()` at the appropriate time.
     """
+    auto_done = auto_done and hasattr(queue, 'task_done')
     while True:
         value = queue.get()
         if auto_done:
@@ -143,6 +145,52 @@ def queue_iterator(queue, auto_done=True):
             yield value
         else:
             return
+
+
+class FiniteQueue(queue.SimpleQueue):
+    """
+    A queue that is iterable, with a defined end.
+
+    The end of the queue is indicated by the `FiniteQueue.QUEUE_END` object.
+    If you are using the iterator interface, you won't ever encounter it, but
+    if reading the queue with `queue.get`, you will receive
+    `FiniteQueue.QUEUE_END` if you’ve reached the end.
+    """
+
+    # Use a class instad of `object()` for more readable names for debugging.
+    class QUEUE_END:
+        ...
+
+    def __init__(self):
+        super().__init__()
+        self._ended = False
+        # The Queue documentation suggests that put/get calls can be
+        # re-entrant, so we need to use RLock here.
+        self._lock = threading.RLock()
+
+    def end(self):
+        self.put(self.QUEUE_END)
+
+    def get(self, *args, **kwargs):
+        with self._lock:
+            if self._ended:
+                return self.QUEUE_END
+            else:
+                value = super().get(*args, **kwargs)
+                if value is self.QUEUE_END:
+                    self._ended = True
+
+                return value
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        item = self.get()
+        if item is self.QUEUE_END:
+            raise StopIteration
+
+        return item
 
 
 class DepthCountedContext:


### PR DESCRIPTION
Fixes #86, based on #173.

This adds the `import ia-known-pages` command, which imports only pages we already know about in the DB from Internet Archive. Use it like so:

```sh
> ./scripts/wm import ia-known-pages --from 2018-03-17
Importing 192 URLs from 2 Domains:
  yosemite.epa.gov
  www.usgs.gov
importing: 0 versions [00:00, ? versions/s]Submitting Versions to web-monitoring-db...
importing: 7 versions [00:18,  1.85s/ versions]
Import jobs IDs: (66,)
Polling web-monitoring-db until import jobs are finished...
```

If you set `LOG_LEVEL=INFO`, it’ll tell you how many URLs IA had that we skipped because we didn’t know them.

If you set `LOG_LEVEL=DEBUG`, it’ll print every skipped URL.