### PR TITLE
Add rate limiting & backoff for IA HTTP requests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,6 @@ doctr
 ipython
 matplotlib
 numpydoc
+requests-mock
 sphinx
 sphinx_rtd_theme

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -334,7 +334,8 @@ def timestamped_uri_to_version(dt, uri, *, url, maintainers=None, tags=None,
     dict : Version
         suitable for passing to :class:`Client.add_versions`
     """
-    res = requests.get(uri)
+    with utils.rate_limited(group='timestamped_uri_to_version'):
+        res = utils.retryable_request('GET', uri)
 
     # IA's memento server responds with the status of the original request, so
     # use the presence of the 'Memento-Datetime' header to determine if we

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+import requests_mock
+from web_monitoring.utils import extract_title, retryable_request, rate_limited
+
+
+def test_extract_title():
+    title = extract_title(b'''<html>
+        <head><title>THIS IS THE TITLE</title></head>
+        <body>Blah</body>
+    </html>''')
+    assert title == 'THIS IS THE TITLE'
+
+
+def test_extract_title_from_titleless_page():
+    title = extract_title(b'''<html>
+        <head><meta charset="utf-8"></head>
+        <body>Blah</body>
+    </html>''')
+    assert title == ''
+
+
+def test_rate_limited():
+    start_time = datetime.utcnow()
+    for i in range(2):
+        with rate_limited(calls_per_second=2):
+            1 + 1
+    duration = datetime.utcnow() - start_time
+    assert duration.total_seconds() > 0.5
+
+
+def test_separate_rate_limited_groups_do_not_affect_each_other():
+    start_time = datetime.utcnow()
+
+    with rate_limited(calls_per_second=2, group='a'):
+        1 + 1
+    with rate_limited(calls_per_second=2, group='b'):
+        1 + 1
+    with rate_limited(calls_per_second=2, group='a'):
+        1 + 1
+    with rate_limited(calls_per_second=2, group='b'):
+        1 + 1
+
+    duration = datetime.utcnow() - start_time
+    assert duration.total_seconds() > 0.5
+    assert duration.total_seconds() < 0.55
+
+
+def test_retryable_request_retries():
+    with requests_mock.Mocker() as mock:
+        mock.get('http://test.com', [{'text': 'bad', 'status_code': 503},
+                                     {'text': 'good', 'status_code': 200}])
+        response = retryable_request('GET', 'http://test.com', backoff=0)
+        assert response.ok
+
+
+def test_retryable_request_stops_after_given_retries():
+    with requests_mock.Mocker() as mock:
+        mock.get('http://test.com', [{'text': 'bad1', 'status_code': 503},
+                                     {'text': 'bad2', 'status_code': 503},
+                                     {'text': 'bad3', 'status_code': 503},
+                                     {'text': 'good', 'status_code': 200}])
+        response = retryable_request('GET', 'http://test.com', retries=2, backoff=0)
+        assert response.status_code == 503
+        assert response.text == 'bad3'
+
+
+def test_retryable_request_only_retries_gateway_errors():
+    with requests_mock.Mocker() as mock:
+        mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
+                                     {'text': 'good', 'status_code': 200}])
+        response = retryable_request('GET', 'http://test.com', backoff=0)
+        assert response.status_code == 400
+
+
+def test_retryable_request_with_custom_retry_logic():
+    with requests_mock.Mocker() as mock:
+        mock.get('http://test.com', [{'text': 'bad1', 'status_code': 400},
+                                     {'text': 'good', 'status_code': 200}])
+
+        response = retryable_request('GET', 'http://test.com', backoff=0,
+                                     should_retry=lambda r: r.status_code == 400)
+        assert response.status_code == 200

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -1,6 +1,10 @@
+from collections import defaultdict
+from contextlib import contextmanager
 import hashlib
 import io
 import lxml.html
+import requests
+import time
 
 
 def extract_title(content_bytes, encoding='utf-8'):
@@ -21,3 +25,75 @@ def extract_title(content_bytes, encoding='utf-8'):
 def hash_content(content_bytes):
     "Create a version_hash for the content of a snapshot."
     return hashlib.sha256(content_bytes).hexdigest()
+
+
+def _should_retry(response):
+    return response.status_code == 503 or response.status_code == 504
+
+
+def retryable_request(method, url, retries=3, backoff=20,
+                      should_retry=_should_retry, **kwargs):
+    """
+    Make a request with the `requests` library that will be automatically
+    retried up to a set number of times.
+
+    Parameters
+    ----------
+    method : string
+        HTTP request method to use
+    url : string
+        URL to request data from
+    retries : int, optional
+        Maximum number of retries
+    backoff : int or float, optional
+        Maximum number of seconds to wait before retrying. After each attempt,
+        the wait time is calculated by: `backoff / retries_left`, so the final
+        attempt will occur `backoff` seconds after the penultimate attempt.
+    should_retry : function, optional
+        A callback that receives the HTTP response and returns a boolean
+        indicating whether the call should be retried. By default, it retries
+        for responses with 503 and 504 status codes (gateway errors).
+    **kwargs : dict, optional
+        Any additional keyword parameters are passed on to `requests`
+
+    Returns
+    -------
+    response : requests.Response
+        The HTTP response object from `requests`
+    """
+    response = requests.request(method, url, **kwargs)
+    if should_retry(response) and retries > 0:
+        time.sleep(backoff / retries)
+        return retryable_request(method, url, retries - 1, backoff, **kwargs)
+    else:
+        return response
+
+
+_last_call_by_group = defaultdict(int)
+
+
+@contextmanager
+def rate_limited(calls_per_second=2, group='default'):
+    """
+    A context manager that restricts entries to its body to occur only N times
+    per second (N can be a float). The current thread will be put to sleep in
+    order to delay calls.
+
+    Parameters
+    ----------
+    calls_per_second : float or int, optional
+        Maximum number of calls into this context allowed per second
+    group : string, optional
+        Unique name to scope rate limiting. If two contexts have different
+        `group` values, their timings will be tracked separately.
+    """
+    if calls_per_second <= 0:
+        yield
+    else:
+        last_call = _last_call_by_group[group]
+        minimum_wait = 1.0 / calls_per_second
+        current_time = time.time()
+        if current_time - last_call < minimum_wait:
+            time.sleep(minimum_wait - (current_time - last_call))
+        yield
+        _last_call_by_group[group] = time.time()


### PR DESCRIPTION
This adds some very simplistic tools to `utils` and makes use of them when loading raw content from Internet Archive:

- `rate_limited()` is a context manager that limits the rate at which the code inside it is executed. The rate is specified as a maximum number of calls per second. It can be a float, so you can do something like 0.5 for 1 call every 2 seconds. A `group` keyword allows you to create non-interfering rate-limited contexts.

- `retryable_request()` is a wrapper around `requests.request()` that will automatically retry failed requests up to a given number of times and optionally back off by progressively greater amounts of time with each retry.

Fixes #177.

We may also want to expose CLI options to tweak these values, but that's not essential and not handled here.

If you aren’t able to provide a good review of the code itself, I’d appreciate feedback on whether this approach makes sense and whether the default values seem good:

- The default rate is 2 requests per second
- The default retry amount is 3 retries, with a backoff of 20 seconds (that’s 6.7 seconds, 10 seconds, and finally 20 seconds of pause before each retry, respectively).