### PR TITLE
Add `--skip-unchanged` CLI option for `wm import`

### DIFF
--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -1,0 +1,23 @@
+from web_monitoring.cli import _filter_unchanged_versions
+
+
+def test_filter_unchanged_versions():
+    versions = (
+        {'page_url': 'http://example.com', 'version_hash': 'a'},
+        {'page_url': 'http://example.com', 'version_hash': 'b'},
+        {'page_url': 'http://example.com', 'version_hash': 'b'},
+        {'page_url': 'http://other.com',   'version_hash': 'b'},
+        {'page_url': 'http://example.com', 'version_hash': 'b'},
+        {'page_url': 'http://example.com', 'version_hash': 'c'},
+        {'page_url': 'http://other.com',   'version_hash': 'd'},
+        {'page_url': 'http://other.com',   'version_hash': 'b'},
+    )
+
+    assert list(_filter_unchanged_versions(versions)) == [
+        {'page_url': 'http://example.com', 'version_hash': 'a'},
+        {'page_url': 'http://example.com', 'version_hash': 'b'},
+        {'page_url': 'http://other.com',   'version_hash': 'b'},
+        {'page_url': 'http://example.com', 'version_hash': 'c'},
+        {'page_url': 'http://other.com',   'version_hash': 'd'},
+        {'page_url': 'http://other.com',   'version_hash': 'b'},
+    ]


### PR DESCRIPTION
Has three possible values, which configures how consecutive versions are judged to be the same and whether they get sent to the server's import endpoint:

- `none` to import everything
- `response` to skip consecutive versions with the same immediate response to the URL (this is the behavior prior to this commit)
- `resolved-response` to skip consecutive versions with the same *resolved* response (the response after following redirects). This is the default.

Also fixes a latent bug with specifying maintainers and tags!

Fixes #176.