### PR TITLE
Run tests in CI without secret credentials

### DIFF
--- a/web_monitoring/tests/fixtures/versions/775a8b04-9bac-4d0d-8db0-a8e133c4a964
+++ b/web_monitoring/tests/fixtures/versions/775a8b04-9bac-4d0d-8db0-a8e133c4a964
@@ -1,0 +1,1682 @@
+
+<!doctype html>
+  <head profile="http://www.w3.org/1999/xhtml/vocab">
+    <!--[if IE]><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta property="fb:admins" content="10718899,1407911,20010394,13004794,207303407,203176,747807274,100001088239132,1384028141" />
+<meta name="google-site-verification" content="ABr0J9KwVb6OpJyjJyQ2WjRFzfXbCsGbsHty4mdXy_c" />
+<link rel="shortcut icon" href="https://energy.gov/sites/all/themes/clean_energy/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="https://energy.gov/" />
+<link rel="shortlink" href="https://energy.gov/" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:url" content="https://energy.gov/" />
+<meta name="twitter:title" content="Department of Energy" />
+
+    <title>Department of Energy</title>
+    <link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__vNsJ9dO9uM-_bY3sV9uYXqsmJlRuiPez5_jxjdB2qx0___S5D9wpKufOlZx5WUcpV6IGoQB3AwS_xvDKyJlsY7JM__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__7E4PQLEVrbgUR-S6I0pBduNYcrRn4phJp9K5D0UNe58__MCQhRHCool1Ersq-srHybqrtIwW909tFfAB4qHG-t4s__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//fast.fonts.com/t/1.css?apiType=css&amp;projectid=b893a4ff-9ea3-4ce8-bf77-c8d3e3a3de97" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__DJVWsB9CJVs_1IGdy-_cGuq4r6SVVaWbEnbS1U2p6y4__-VZwo-nOHQ8jOwHBs8iAakXDmGrlSDpOMrchWH61En8__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css___BT9KELVHngeMchzMHHJlK2HMFMITPlOs8ZmiG6guxQ__jX4UXuK4UFBZ9_ePAhpLVYpQt4qDv3FbpPpkmzKscKA__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__rp1vOLONZeM4aap_3G0pMbeXQDzJTFkXSVI8rG2mO3c__6dwFf23F2Vr0k7UcqQ1HkFiyqjhUJsFrUSOBPytOxzk__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-fid-1202676 > .content { background-image: url("https://energy.gov/sites/prod/files/2017/09/f37/36634871684_8c59235d2f_o.jpg") !important;}.image-background-large-fid-1140013 > .content { background-image: url("https://energy.gov/sites/prod/files/image8grid_0.jpg") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__HTGmlxHp2bJS6Rm4lYdv1YPgQ-JSuuO355PGJQ9xt_M__cJsvcnfs9fKIXnQUMn0PEs23Wg328JLYunYSrpXcT0A__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-fid-1190789 > .content { background-image: url("https://energy.gov/sites/prod/files/2017/08/f36/STEM%20resources3.jpg") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css___EW1Lfz_YceXSL0sM78NHMnd2Rlpc5j-mD7t4m18phA__5db1AK6VA9IKDQM72zlEkoVKhTQAHAFP4yWEEcS0yuY__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-2816100 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/6189797301_d42618a57c_o.jpg?itok=p-a_UIpw") !important;}.image-background-large-2788803 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/28576577376_c2cc9939a1_o_0.jpg?itok=JzDyMwtt") !important;}.image-background-large-2788173 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/40_CGF_STILL_00022_1600.jpg?itok=4FZQpnOC") !important;}.image-background-large-2788041 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/2017/09/f36/DJhWXGDUIAAx4zf.jpg?itok=_06S_e__") !important;}.image-background-large-2731185 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/doestock-women-in-stem-3_resized.jpg?itok=1ExGtO1F") !important;}.image-background-large-2714185 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/2017/08/f35/SolarEclipse2017Infographic%20%282%29.png?itok=h1lmIiMm") !important;}.image-background-large-908796 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/Block%20Island.Schroeder.jpg?itok=M4AqIiOH") !important;}.image-background-large-714436 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/26785.jpg?itok=fOPJ-5ny") !important;}.image-background-large-2696966 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/2017/08/f35/distributed-wind-nrel-33943_0.jpg?itok=O6jhC-gg") !important;}.image-background-large-383293 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/wind%20turbine%20rappel%20.jpg?itok=YSMvD-pK") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__pW5vNQJuSmsMpOmMZL_s14WfGL9RqNDDeVKsMnDkmbo__gEZBAQ2r5JuG_6OPhnhZo2tMjW0KZeJ9loDNunx9MmA__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-2404268 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/NoraStanton-WIS.png?itok=RZu5CKlN") !important;}.image-background-large-2386276 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/RubyHirose-WIS.png?itok=11-QgkUg") !important;}.image-background-large-2367988 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/Barbara%20McClintock.png?itok=rvBkRB1a") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__axMOHTxcLD0CqjKTsuo48w0ynWLokyCV-2TRFn-uKJ0__uhDNqg7St7zZjH650-Dc79MAVovTq0LWMYpKAINIcxc__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-2366716 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/Evelyn.png?itok=QHKDXYor") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__XE3FFdx87jKxGtPHOkdxm34PKID8DFaDqgr6UOR379g__2LfTCTY0HeQ6-uHpsrrgP5C--TusyLm1SfnQrQ9R75g__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__IDz4UT5INU7fVtFVM4n7xQOo49HkwCZU0Co-Y-PL5kg__T9Bqw4IsdZoUOuuWeAVRIVXW4rX0BosIlCRKSrSaBhg__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+
+    <meta name="viewport" content="width=device-width, maximum-scale=2, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+  </head>
+  <body class="html front not-logged-in no-sidebars page-node page-node- page-node-2791 node-type-homepage og-context og-context-taxonomy-term og-context-taxonomy-term-31 node-display-homepage" lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" dir="ltr" >
+    
+    <div id="body-inner" class="page-office-main">
+
+            <header id="header">
+                  <div class="header-top">
+              <div class="region region-header">
+    
+
+  <div id="block-energy-core-energy-core-header-utility" class="block block-energy-core block-energy-core-header-utility block-header-utility">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first leaf"><a href="/national-laboratories">National Labs</a></li>
+<li class="leaf"><a href="/offices">Offices</a></li>
+<li class="last collapsed"><a href="/about-us">About</a></li>
+</ul>
+    </div>
+    
+  </div>
+
+
+
+  <div id="block-energy-social-energy-social-top-level" class="block block-energy-social block-energy-social-top-level">
+
+        
+        
+    
+        <div class="content">
+      <div class="energy-social-widget ">
+<div class="item-list"><ul><li class="first"><a href="/exit?url=https%3A//www.facebook.com/energygov" class="energy-social-link energy-social-link-facebook"><i class="icon-facebook"></i><span class="element-invisible">Link to facebook</span></a></li>
+<li><a href="/exit?url=https%3A//twitter.com/energy" class="energy-social-link energy-social-link-twitter"><i class="icon-twitter"></i><span class="element-invisible">Link to twitter</span></a></li>
+<li><a href="/exit?url=https%3A//www.youtube.com/user/USdepartmentofenergy" class="energy-social-link energy-social-link-youtube"><i class="icon-youtube"></i><span class="element-invisible">Link to youtube</span></a></li>
+<li><a href="/exit?url=https%3A//www.instagram.com/energy" class="energy-social-link energy-social-link-instagram"><i class="icon-instagram"></i><span class="element-invisible">Link to instagram</span></a></li>
+<li class="last"><a href="/exit?url=https%3A//www.linkedin.com/company-beta/5556" class="energy-social-link energy-social-link-linkedin"><i class="icon-linkedin"></i><span class="element-invisible">Link to linkedin</span></a></li>
+</ul></div>
+</div>
+    </div>
+    
+  </div>
+
+  </div>
+
+          </div>
+        
+                              <nav id="navigation">
+                <div class="region region-navigation">
+    
+
+  <div id="block-energy-core-site-name" class="block block-energy-core block-site-name block-site-name">
+
+        
+        
+    
+    
+
+<div class="site-name"><a href="/" class="active"><img src="/sites/all/themes/clean_energy/images/energy_crest_smaller.png" alt="Department of Energy" /></a></div>
+
+
+
+
+
+  </div>
+
+
+
+  <div id="block-energy-core-navigation-main" class="block block-energy-core block-navigation-main">
+
+        
+        
+    
+        <div class="content">
+      
+
+  <div id="block-search-form" class="block block-search block-form">
+
+        
+        
+    
+        <div class="content">
+      <form action="/" method="post" id="search-block-form" accept-charset="UTF-8"><div><div class="container-inline">
+      <h2 class="element-invisible">Search form</h2>
+    <div class="form-item form-type-textfield form-item-search-block-form">
+  <label class="element-invisible" for="edit-search-block-form--2">Search </label>
+ <input title="Enter the terms you wish to search for." placeholder="Search" aria-label="Enter the terms you wish to search for." size="30" type="text" id="edit-search-block-form--2" name="search_block_form" value="" maxlength="128" class="form-text" />
+</div>
+<div class="form-actions form-wrapper" id="edit-actions"><input alt="Submit search query" type="image" id="edit-submit" name="submit" value="Search" src="https://energy.gov/sites/all/themes/clean_energy/images/Magnifying_glass_icon.svg" class="form-submit" /></div><input type="hidden" name="form_build_id" value="form-nB9WwZdnyMoixyN56iYjyssirntRDRMZ9pe8G4lObOQ" />
+<input type="hidden" name="form_id" value="search_block_form" />
+</div>
+</div></form>
+    </div>
+    
+  </div>
+
+<div class="primary-nav overlay"><div class="primary-nav-inner overlay-back"><div id="nav-menu-wrap"><a href="/" class="header-mobile-home active">Energy.gov Home</a><ul class="menu" role="menubar" title="Main Menu" tabindex="0"><li class="first expanded depth-1" tabindex="1" role="menuitem" aria-haspopup="true"><a href="/science-innovation"><span>Science & Innovation</span></a><div class="child-menu"><span class="menu-parent">Science & Innovation</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/science-innovation">Science &amp; Innovation Home</a></li>
+<li class="expanded depth-2 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/clean-energy">Clean Energy</a><div class="child-menu"><span class="menu-parent">Clean Energy</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/clean-energy">Clean Energy Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/innovation/hubs">Hubs</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/science-innovation/innovation/emerging-technologies">Emerging Technologies</a></li>
+<li class="expanded depth-3" tabindex="3" role="menuitem"><a href="/science-innovation/innovation/commercialization">Commercialization</a><div class="child-menu"><span class="menu-parent">Commercialization</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-4" role="menuitem"><a href="/science-innovation/innovation/commercialization">Commercialization Home</a></li>
+<li class="last leaf depth-4 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/innovation/commercialization/national-clean-energy-business-plan-competition">National Clean Energy Business Plan Competition</a></li>
+</ul></div></li>
+<li class="last leaf depth-3" tabindex="4" role="menuitem"><a href="/science-innovation/innovation/lab-breakthroughs">Lab Breakthroughs</a></li>
+</ul></div></li>
+<li class="expanded depth-2" tabindex="2" role="menuitem"><a href="/science-innovation/energy-efficiency">Energy Efficiency</a><div class="child-menu"><span class="menu-parent">Energy Efficiency</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/energy-efficiency">Energy Efficiency Home</a></li>
+<li class="last expanded depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/commercial-buildings">Building Design</a><div class="child-menu"><span class="menu-parent">Building Design</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-4" role="menuitem"><a href="/public-services/commercial-buildings">Building Design Home</a></li>
+<li class="leaf depth-4 original-first" tabindex="1" role="menuitem"><a href="/public-services/building-design/construction">Construction</a></li>
+<li class="leaf depth-4" tabindex="2" role="menuitem"><a href="/public-services/building-design/commercial-heating-cooling">Industrial Heating &amp; Cooling</a></li>
+<li class="last leaf depth-4" tabindex="3" role="menuitem"><a href="/public-services/building-design/commercial-lighting">Industrial Lighting</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="expanded depth-2" tabindex="3" role="menuitem"><a href="/science-innovation/vehicles">Vehicles</a><div class="child-menu"><span class="menu-parent">Vehicles</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/vehicles">Vehicles Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/vehicles/alternative-fuel-vehicles">Alternative Fuel Vehicles</a></li>
+<li class="last leaf depth-3" tabindex="2" role="menuitem"><a href="/public-services/vehicles/batteries">Batteries</a></li>
+</ul></div></li>
+<li class="leaf depth-2" tabindex="4" role="menuitem"><a href="/science-innovation/climate-change">Climate Change</a></li>
+<li class="expanded depth-2" tabindex="5" role="menuitem"><a href="/science-innovation/energy-sources">Energy Sources</a><div class="child-menu"><span class="menu-parent">Energy Sources</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/energy-sources">Energy Sources Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/solar">Solar</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/wind">Wind</a></li>
+<li class="leaf depth-3" tabindex="3" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/water">Water</a></li>
+<li class="leaf depth-3" tabindex="4" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/geothermal">Geothermal</a></li>
+<li class="leaf depth-3" tabindex="5" role="menuitem"><a href="/science-innovation/energy-sources/fossil">Fossil</a></li>
+<li class="leaf depth-3" tabindex="6" role="menuitem"><a href="/public-services/vehicles/hydrogen-fuel-cells">Electric Power</a></li>
+<li class="leaf depth-3" tabindex="7" role="menuitem"><a href="/science-innovation/electric-power/storage">Energy Storage</a></li>
+<li class="expanded depth-3" tabindex="8" role="menuitem"><a href="/science-innovation/electric-power">Hydrogen and Fuel Cells</a><div class="child-menu"><span class="menu-parent">Hydrogen and Fuel Cells</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-4" role="menuitem"><a href="/science-innovation/electric-power">Hydrogen and Fuel Cells Home</a></li>
+<li class="last leaf depth-4 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/electric-power/smart-grid">Smart Grid</a></li>
+</ul></div></li>
+<li class="leaf depth-3" tabindex="9" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/bioenergy">Bio-Energy</a></li>
+<li class="last leaf depth-3" tabindex="10" role="menuitem"><a href="/science-innovation/energy-sources/nuclear">Nuclear</a></li>
+</ul></div></li>
+<li class="last leaf depth-2" tabindex="6" role="menuitem"><a href="/science-innovation/stem">STEM</a></li>
+</ul></div></li>
+<li class="expanded depth-1" tabindex="2" role="menuitem" aria-haspopup="true"><a href="/energy-economy"><span>Energy Economy</span></a><div class="child-menu"><span class="menu-parent">Energy Economy</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/energy-economy">Energy Economy Home</a></li>
+<li class="leaf depth-2 original-first" tabindex="1" role="menuitem"><a href="/energy-economy/prices-trends">Prices &amp; Trends</a></li>
+<li class="leaf depth-2" tabindex="2" role="menuitem"><a href="/energy-economy/funding-financing">Funding &amp; Financing</a></li>
+<li class="leaf depth-2" tabindex="3" role="menuitem"><a href="/energy-economy/state-local-government">State &amp; Local Government</a></li>
+<li class="last leaf depth-2" tabindex="4" role="menuitem"><a href="/energy-economy/manufacturing">Advanced Manufacturing</a></li>
+</ul></div></li>
+<li class="expanded depth-1" tabindex="3" role="menuitem" aria-haspopup="true"><a href="/national-security-safety"><span>Security & Safety</span></a><div class="child-menu"><span class="menu-parent">Security & Safety</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/national-security-safety">Security &amp; Safety Home</a></li>
+<li class="leaf depth-2 original-first" tabindex="1" role="menuitem"><a href="/national-security-safety/nuclear-security-nonproliferation">Nuclear Security</a></li>
+<li class="leaf depth-2" tabindex="2" role="menuitem"><a href="/national-security-safety/cybersecurity">Cybersecurity</a></li>
+<li class="leaf depth-2" tabindex="3" role="menuitem"><a href="/national-security-safety/environmental-cleanup">Environmental Cleanup</a></li>
+<li class="last leaf depth-2" tabindex="4" role="menuitem"><a href="/national-security-safety/emergency-response">Emergency Response</a></li>
+</ul></div></li>
+<li class="last expanded depth-1" tabindex="4" role="menuitem" aria-haspopup="true"><a href="/energysaver/energy-saver" class="energy-saver"><span>Save Energy, Save Money</span></a><div class="child-menu"><span class="menu-parent">Save Energy, Save Money</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/energysaver/energy-saver" class="energy-saver">Save Energy, Save Money Home</a></li>
+<li class="expanded depth-2 original-first" tabindex="1" role="menuitem"><a href="/energysaver/heat-and-cool">Heating &amp; Cooling</a><div class="child-menu"><span class="menu-parent">Heating & Cooling</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/energysaver/heat-and-cool">Heating &amp; Cooling Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/homes/heating-cooling/heat-pumps">Heat Pumps</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/public-services/homes/heating-cooling/home-cooling">Home Cooling</a></li>
+<li class="leaf depth-3" tabindex="3" role="menuitem"><a href="/public-services/homes/heating-cooling/home-heating">Home Heating</a></li>
+<li class="leaf depth-3" tabindex="4" role="menuitem"><a href="/energysaver/water-heating">Water Heating</a></li>
+<li class="last leaf depth-3" tabindex="5" role="menuitem"><a href="/public-services/homes/home-weatherization/home-energy-audits">Home Energy Audits</a></li>
+</ul></div></li>
+<li class="leaf depth-2" tabindex="2" role="menuitem"><a href="/energysaver/weatherize">Weatherization</a></li>
+<li class="leaf depth-2" tabindex="3" role="menuitem"><a href="/energysaver/windows-doors-and-skylights">Windows, Doors &amp; Skylights</a></li>
+<li class="expanded depth-2" tabindex="4" role="menuitem"><a href="/energysaver/design">Design &amp; Remodeling</a><div class="child-menu"><span class="menu-parent">Design & Remodeling</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/energysaver/design">Design &amp; Remodeling Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/homes/home-design-remodeling">Home Design &amp; Remodeling</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/energysaver/lighting-choices-save-you-money">Lighting</a></li>
+<li class="last leaf depth-3" tabindex="3" role="menuitem"><a href="/public-services/homes/landscaping">Landscaping</a></li>
+</ul></div></li>
+<li class="leaf depth-2" tabindex="5" role="menuitem"><a href="/energysaver/save-electricity-and-fuel">Electricity &amp; Fuel</a></li>
+<li class="leaf depth-2" tabindex="6" role="menuitem"><a href="/energysaver/services/energy-saver-guide-tips-saving-money-and-energy-home">Start Saving</a></li>
+<li class="leaf depth-2" tabindex="7" role="menuitem"><a href="/energysaver/insulation">Insulation</a></li>
+<li class="leaf depth-2" tabindex="8" role="menuitem"><a href="/energysaver/air-sealing-your-home">Sealing Your Home</a></li>
+<li class="last leaf depth-2" tabindex="9" role="menuitem"><a href="/energysaver/ventilation">Ventilation</a></li>
+</ul></div></li>
+</ul>
+
+  <div id="block-energy-core-energy-core-header-utility--2" class="block block-energy-core block-energy-core-header-utility block-header-utility">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first leaf"><a href="/national-laboratories">National Labs</a></li>
+<li class="leaf"><a href="/offices">Offices</a></li>
+<li class="last collapsed"><a href="/about-us">About</a></li>
+</ul>
+    </div>
+    
+  </div>
+
+</div></div></div>
+    </div>
+    
+  </div>
+
+  <div id="block-main-nav-suffix" class="block">
+    <input id="search-form-nav-reveal" class="search-form-reveal form-search" name="search-form-nav-reveal" value="" alt="Reveal Search Box" type="submit" /><input id="main-menu-nav-reveal" name="main-menu-nav-reveal" value="" alt="Reveal Main Menu" class="overlay-reveal overlayTarget-primary-nav form-menu" type="submit" />
+  </div>
+  </div>
+
+            </nav>
+                  
+                              <nav id="subnavigation">
+                <div class="region region-subnavigation">
+    
+
+  <div id="block-energy-core-subnavigation" class="block block-energy-core block-subnavigation">
+
+        
+        
+    
+        <div class="content">
+      
+    </div>
+    
+  </div>
+
+  </div>
+
+            </nav>
+                        </header>
+      
+      
+      
+        <div id="top">
+                                    
+              
+
+
+
+          </div>
+    
+    <div id="page"  class="page-node page-node-homepage">
+        <div id="main-content" class="clearfix">
+      
+      <div id="content-wrapper">
+        
+        <div id="content-top">
+
+          
+
+        </div>
+
+                <div id="content" class="clearfix">
+          
+            <div class="region region-content">
+    
+
+  <div id="block-system-main" class="block block-system block-main">
+
+        
+        
+    
+        <div class="content">
+      <div class="node node-homepage clearfix" about="/energygov" typeof="sioc:Item foaf:Document">
+      
+  
+    
+            <span property="dc:title" content="Energy.gov" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    
+<div class="paragraphs-items paragraphs-items-field-homepage-hero-feat-items paragraphs-items-field-homepage-hero-feat-items-teaser paragraphs-items-teaser">
+    <div class="field field-name-field-homepage-hero-feat-items field-type-paragraphs field-label-hidden featured-3-up">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-ref psp light-foreground-over-dark-background dark-background light-foreground image-background image-background-large-fid-1202676"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-energy-ref-item field-type-entityreference field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div class="node node-article node-teaser clearfix" about="/oe/articles/doe-emergency-responders-active-power-restoration-efforts-puerto-rico-and-us-virgin" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="DOE Emergency Responders Active in Power Restoration Efforts in Puerto Rico and the U.S. Virgin Islands" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/oe/articles/doe-emergency-responders-active-power-restoration-efforts-puerto-rico-and-us-virgin" class="title-link" aria-label="Read more about &#039;DOE Emergency Responders Active in Power Restoration Efforts in Puerto Rico and the U.S. Virgin Islands&#039;" title="Read more about &#039;DOE Emergency Responders Active in Power Restoration Efforts in Puerto Rico and the U.S. Virgin Islands&#039;">Working Together to Restore Power in Puerto Rico and the U.S. Virgin Islands</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-ref psp light-foreground-over-dark-background dark-background light-foreground image-background image-background-large-fid-1140013"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-energy-ref-item field-type-entityreference field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div class="node node-page node-teaser clearfix" about="/staff-report-secretary-electricity-markets-and-reliability" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Staff Report to the Secretary on Electricity Markets and Reliability" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/staff-report-secretary-electricity-markets-and-reliability" class="title-link" aria-label="Read more about &#039;Staff Report to the Secretary on Electricity Markets and Reliability&#039;" title="Read more about &#039;Staff Report to the Secretary on Electricity Markets and Reliability&#039;">Staff Report to the Secretary on Electricity Markets and Reliability</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-ref psp light-foreground-over-dark-background dark-background light-foreground image-background image-background-large-fid-1190789"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-energy-ref-item field-type-entityreference field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div class="node node-topic node-teaser clearfix" about="/science-innovation/stem" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="STEM" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/science-innovation/stem" class="title-link" aria-label="Read more about &#039;STEM&#039;" title="Read more about &#039;STEM&#039;">STEM Education Resources </a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+<div class="paragraphs-items paragraphs-items-field-body-paragraphs paragraphs-items-field-body-paragraphs-full paragraphs-items-full">
+    <div class="field field-name-field-body-paragraphs field-type-paragraphs field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading psp listing-horizontal psp listing listing-title-summary-date"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 classes="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading">Energy News</h2>
+</div>
+                  </div>
+      </div>
+<div class="energy-listing-readmore field_para_energy_listing_ref-readmore"><a href="/listings/energy-news" aria-label="View all related pages." title="View all related pages.">View All</a></div>  <div class="field field-name-field-para-energy-listing-ref field-type-entityreference field-label-hidden">
+            
+      <div class="field-items energy-listing">
+                    <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/secretary-perry-announces-conditional-commitment-support-continued-construction-vogtle" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary Perry Announces Conditional Commitment to Support Continued Construction of Vogtle Advanced Nuclear Energy Project" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-perry-announces-conditional-commitment-support-continued-construction-vogtle" class="title-link" aria-label="Read more about &#039;Secretary Perry Announces Conditional Commitment to Support Continued Construction of Vogtle Advanced Nuclear Energy Project&#039;" title="Read more about &#039;Secretary Perry Announces Conditional Commitment to Support Continued Construction of Vogtle Advanced Nuclear Energy Project&#039;">Secretary Perry Announces Conditional Commitment to Support Continued Construction of Vogtle Advanced Nuclear Energy Project</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">The Vogtle project is the first new nuclear power plant to be licensed and begin construction in the United States in more than three decades. </div>
+                  </div>
+      </div>
+<div class="date">September 29, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-perry-announces-conditional-commitment-support-continued-construction-vogtle" class="view-more" title="Read more about &#039;Secretary Perry Announces Conditional Commitment to Support Continued Construction of Vogtle Advanced Nuclear Energy Project&#039;" aria-label="Read more about &#039;Secretary Perry Announces Conditional Commitment to Support Continued Construction of Vogtle Advanced Nuclear Energy Project&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/secretary-perry-urges-ferc-take-swift-action-address-threats-grid-resiliency" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary Perry Urges FERC to Take Swift Action to Address Threats to Grid Resiliency" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-perry-urges-ferc-take-swift-action-address-threats-grid-resiliency" class="title-link" aria-label="Read more about &#039;Secretary Perry Urges FERC to Take Swift Action to Address Threats to Grid Resiliency&#039;" title="Read more about &#039;Secretary Perry Urges FERC to Take Swift Action to Address Threats to Grid Resiliency&#039;">Secretary Perry Urges FERC to Take Swift Action to Address Threats to Grid Resiliency</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Secretary of Energy Rick Perry formally proposes that the Federal Energy Regulatory Commission (FERC) take swift action to address threats to grid. </div>
+                  </div>
+      </div>
+<div class="date">September 29, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-perry-urges-ferc-take-swift-action-address-threats-grid-resiliency" class="view-more" title="Read more about &#039;Secretary Perry Urges FERC to Take Swift Action to Address Threats to Grid Resiliency&#039;" aria-label="Read more about &#039;Secretary Perry Urges FERC to Take Swift Action to Address Threats to Grid Resiliency&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-36-million-projects-advance-carbon-capture" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-36-million-projects-advance-carbon-capture" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;">Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Projects will continue the development of carbon capture technologies to either the engineering scale or to a commercial design.</div>
+                  </div>
+      </div>
+<div class="date">September 22, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-36-million-projects-advance-carbon-capture" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-integrated-biorefinery-optimization-projects" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-integrated-biorefinery-optimization-projects" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;">Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Projects will work to solve critical research and developmental challenges encountered for the successful scale-up of integrated biorefineries. </div>
+                  </div>
+      </div>
+<div class="date">September 20, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-integrated-biorefinery-optimization-projects" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-high-performance-computing-materials-program-help" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material..." class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-high-performance-computing-materials-program-help" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Materials for Severe Environments&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Materials for Severe Environments&#039;">Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material...</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Initiative will initially focus on challenges facing industry as they work to develop new or improved materials that can sustain extreme conditions. </div>
+                  </div>
+      </div>
+<div class="date">September 19, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-high-performance-computing-materials-program-help" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material...&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material...&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/department-energy-announces-18-new-projects-accelerate-production-macroalgae-energy-and" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/department-energy-announces-18-new-projects-accelerate-production-macroalgae-energy-and" class="title-link" aria-label="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;" title="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;">Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">New projects will develop the tools to enable the United States to become a leading producer of seaweed, helping to improve U.S. energy security. </div>
+                  </div>
+      </div>
+<div class="date">September 19, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/department-energy-announces-18-new-projects-accelerate-production-macroalgae-energy-and" class="view-more" title="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;" aria-label="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/department-energy-national-labs-recognized-international-rd-hub-international-atomic-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Department of Energy National Labs Recognized as International R&amp;D Hub by International Atomic Energy Agency" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/department-energy-national-labs-recognized-international-rd-hub-international-atomic-energy" class="title-link" aria-label="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;" title="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;">Department of Energy National Labs Recognized as International R&amp;D Hub by International Atomic Energy Agency</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">The IAEA designation makes the United States one of only three countries identified for unique capabilities and excellence in nuclear research. </div>
+                  </div>
+      </div>
+<div class="date">September 18, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/department-energy-national-labs-recognized-international-rd-hub-international-atomic-energy" class="view-more" title="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;" aria-label="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/us-department-energy-authorizes-eagle-maxville-small-scale-liquefied-natural-gas-exports" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/us-department-energy-authorizes-eagle-maxville-small-scale-liquefied-natural-gas-exports" class="title-link" aria-label="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;" title="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;">U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Eagle Maxville authorized to export domestically produced LNG in ISO containers loaded at the Maxville Facility located in Jacksonville. </div>
+                  </div>
+      </div>
+<div class="date">September 15, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/us-department-energy-authorizes-eagle-maxville-small-scale-liquefied-natural-gas-exports" class="view-more" title="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;" aria-label="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-nearly-20-million-help-commercialize-promising-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-nearly-20-million-help-commercialize-promising-energy" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;">Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">This second Department-wide round of funding through the Office of Technology Transitionâs Technology Commercialization Fund will support 54 projects.</div>
+                  </div>
+      </div>
+<div class="date">September 13, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-nearly-20-million-help-commercialize-promising-energy" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/energy-department-announces-achievement-sunshot-goal-new-focus-solar-energy-office" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/energy-department-announces-achievement-sunshot-goal-new-focus-solar-energy-office" class="title-link" aria-label="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;" title="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;">Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Average price of utility-scale solar is now 6 cents per kilowatt-hour (kWh).</div>
+                  </div>
+      </div>
+<div class="date">September 12, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/energy-department-announces-achievement-sunshot-goal-new-focus-solar-energy-office" class="view-more" title="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;" aria-label="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;">View Article</a></div>
+            </div>
+  </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading psp listing-horizontal psp listing listing-title-summary-image"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 classes="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading">ENERGY BLOG </h2>
+</div>
+                  </div>
+      </div>
+<div class="energy-listing-readmore field_para_energy_listing_ref-readmore"><a href="/listings/blog-archive" aria-label="View all related pages." title="View all related pages.">View All</a></div>  <div class="field field-name-field-para-energy-listing-ref field-type-entityreference field-label-hidden">
+            
+      <div class="field-items energy-listing">
+                    <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2816100 clearfix" about="/articles/solar-decathlon-3-stem-resources-teachers" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Solar Decathlon: 3 STEM Resources for Teachers" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/solar-decathlon-3-stem-resources-teachers" class="title-link" aria-label="Read more about &#039;Solar Decathlon: 3 STEM Resources for Teachers&#039;" title="Read more about &#039;Solar Decathlon: 3 STEM Resources for Teachers&#039;">Solar Decathlon: 3 STEM Resources for Teachers</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Solar Decathlon can serve as a teaching tool for educators interested in teaching science, engineering, technology and math â or STEM.</div>
+                  </div>
+      </div>
+<a href="/articles/solar-decathlon-3-stem-resources-teachers" class="more-link" aria-label="Learn More about &quot;Solar Decathlon: 3 STEM Resources for Teachers&quot;" title="Learn More about &quot;Solar Decathlon: 3 STEM Resources for Teachers&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2788803 clearfix" about="/indianenergy/articles/doe-joins-american-indian-science-and-engineering-society-pledge-encourage" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="DOE Joins AISES Pledge to Encourage Natives in STEM" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/indianenergy/articles/doe-joins-american-indian-science-and-engineering-society-pledge-encourage" class="title-link" aria-label="Read more about &#039;DOE Joins AISES Pledge to Encourage Natives in STEM&#039;" title="Read more about &#039;DOE Joins AISES Pledge to Encourage Natives in STEM&#039;">DOE Joins AISES Pledge to Encourage Natives in STEM</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">DOE has joined AISES in its #PledgeNativesInSTEM campaign, an effort to raise awareness and facilitate dialogue on the importance of STEM for natives.</div>
+                  </div>
+      </div>
+<a href="/indianenergy/articles/doe-joins-american-indian-science-and-engineering-society-pledge-encourage" class="more-link" aria-label="Learn More about &quot;DOE Joins AISES Pledge to Encourage Natives in STEM&quot;" title="Learn More about &quot;DOE Joins AISES Pledge to Encourage Natives in STEM&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2788173 clearfix" about="/articles/nuclear-heart-cassini" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="The Nuclear Heart of Cassini" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/nuclear-heart-cassini" class="title-link" aria-label="Read more about &#039;The Nuclear Heart of Cassini&#039;" title="Read more about &#039;The Nuclear Heart of Cassini&#039;">The Nuclear Heart of Cassini</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">A farewell tribute to NASA&#039;s Cassini spacecraft, which was powered by plutonium from the Department of Energy.</div>
+                  </div>
+      </div>
+<a href="/articles/nuclear-heart-cassini" class="more-link" aria-label="Learn More about &quot;The Nuclear Heart of Cassini&quot;" title="Learn More about &quot;The Nuclear Heart of Cassini&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2788041 clearfix" about="/articles/working-together-restore-power-after-hurricane-irma" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Restoring Power After Irma" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/working-together-restore-power-after-hurricane-irma" class="title-link" aria-label="Read more about &#039;Restoring Power After Irma&#039;" title="Read more about &#039;Restoring Power After Irma&#039;">Restoring Power After Irma</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">The Department of Energy came together with public and private sector partners to respond and rebuild in the wake of Hurricane Irma.</div>
+                  </div>
+      </div>
+<a href="/articles/working-together-restore-power-after-hurricane-irma" class="more-link" aria-label="Learn More about &quot;Restoring Power After Irma&quot;" title="Learn More about &quot;Restoring Power After Irma&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2731185 clearfix" about="/articles/secretary-perry-statement-womens-equality-day" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Women&#039;s Equality Day" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-perry-statement-womens-equality-day" class="title-link" aria-label="Read more about &#039;Women&amp;#039;s Equality Day&#039;" title="Read more about &#039;Women&amp;#039;s Equality Day&#039;">Women&#039;s Equality Day</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Secretary Perry&#039;s statement on Womenâs Equality Day, Aug. 26, 2017, marking the 97th anniversary of the 19th Amendment securing womenâs right to vote.</div>
+                  </div>
+      </div>
+<a href="/articles/secretary-perry-statement-womens-equality-day" class="more-link" aria-label="Learn More about &quot;Women&#039;s Equality Day&quot;" title="Learn More about &quot;Women&#039;s Equality Day&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2714185 clearfix" about="/articles/throwing-shade-3-things-know-about-solar-eclipse" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Throwing Shade: 3 Things to Know About the Solar Eclipse" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/throwing-shade-3-things-know-about-solar-eclipse" class="title-link" aria-label="Read more about &#039;Throwing Shade: 3 Things to Know About the Solar Eclipse&#039;" title="Read more about &#039;Throwing Shade: 3 Things to Know About the Solar Eclipse&#039;">Throwing Shade: 3 Things to Know About the Solar Eclipse</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Solar eclipse mania is sweeping across America and for good reason. Here are a few things to keep in mind as the big day approaches. </div>
+                  </div>
+      </div>
+<a href="/articles/throwing-shade-3-things-know-about-solar-eclipse" class="more-link" aria-label="Learn More about &quot;Throwing Shade: 3 Things to Know About the Solar Eclipse&quot;" title="Learn More about &quot;Throwing Shade: 3 Things to Know About the Solar Eclipse&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-908796 clearfix" about="/eere/wind/articles/top-10-things-you-didn-t-know-about-offshore-wind-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Top 10 Things You Didnât Know About Offshore Wind Energy " class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-offshore-wind-energy" class="title-link" aria-label="Read more about &#039;Top 10 Things You Didnât Know About Offshore Wind Energy &#039;" title="Read more about &#039;Top 10 Things You Didnât Know About Offshore Wind Energy &#039;">Top 10 Things You Didnât Know About Offshore Wind Energy </a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Learn more about efforts to develop America&#039;s vast offshore wind resources. </div>
+                  </div>
+      </div>
+<a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-offshore-wind-energy" class="more-link" aria-label="Learn More about &quot;Top 10 Things You Didnât Know About Offshore Wind Energy &quot;" title="Learn More about &quot;Top 10 Things You Didnât Know About Offshore Wind Energy &quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-714436 clearfix" about="/eere/wind/articles/top-10-things-you-didn-t-know-about-distributed-wind-power" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Top 10 Things You Didnât Know About Distributed Wind Power" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-distributed-wind-power" class="title-link" aria-label="Read more about &#039;Top 10 Things You Didnât Know About Distributed Wind Power&#039;" title="Read more about &#039;Top 10 Things You Didnât Know About Distributed Wind Power&#039;">Top 10 Things You Didnât Know About Distributed Wind Power</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Learn about key facts related to wind turbines used in distributed applications. </div>
+                  </div>
+      </div>
+<a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-distributed-wind-power" class="more-link" aria-label="Learn More about &quot;Top 10 Things You Didnât Know About Distributed Wind Power&quot;" title="Learn More about &quot;Top 10 Things You Didnât Know About Distributed Wind Power&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2696966 clearfix" about="/articles/5-things-you-should-know-about-wind-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="5 Things You Should Know About Wind Energy" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/5-things-you-should-know-about-wind-energy" class="title-link" aria-label="Read more about &#039;5 Things You Should Know About Wind Energy&#039;" title="Read more about &#039;5 Things You Should Know About Wind Energy&#039;">5 Things You Should Know About Wind Energy</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">From utility-scale wind farms to the nationâs first offshore wind project, the U.S. wind industry continued to grow in 2016.</div>
+                  </div>
+      </div>
+<a href="/articles/5-things-you-should-know-about-wind-energy" class="more-link" aria-label="Learn More about &quot;5 Things You Should Know About Wind Energy&quot;" title="Learn More about &quot;5 Things You Should Know About Wind Energy&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-383293 clearfix" about="/eere/wind/articles/top-10-things-you-didnt-know-about-wind-power" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Top 10 Things You Didn&#039;t Know About Wind Power" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/eere/wind/articles/top-10-things-you-didnt-know-about-wind-power" class="title-link" aria-label="Read more about &#039;Top 10 Things You Didn&amp;#039;t Know About Wind Power&#039;" title="Read more about &#039;Top 10 Things You Didn&amp;#039;t Know About Wind Power&#039;">Top 10 Things You Didn&#039;t Know About Wind Power</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Get the details on a few of the lesser known wind energy facts.</div>
+                  </div>
+      </div>
+<a href="/eere/wind/articles/top-10-things-you-didnt-know-about-wind-power" class="more-link" aria-label="Learn More about &quot;Top 10 Things You Didn&#039;t Know About Wind Power&quot;" title="Learn More about &quot;Top 10 Things You Didn&#039;t Know About Wind Power&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+            </div>
+  </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-multi-column psp emphasis-right"  about="" typeof="">
+  
+    <div class="content" >
+    
+<div class="paragraphs-items paragraphs-items-field-para-energy-layout-col1 paragraphs-items-field-para-energy-layout-col1-full paragraphs-items-full">
+    <div class="field field-name-field-para-energy-layout-col1 field-type-paragraphs field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-heading psp section-heading"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 id="A-Shot-in-the-Dark" classes="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-heading psp section-heading"><a href="/darkmatter">Direct Current: An Energy.gov Podcast</a></h2>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-rich-text"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-rich-text field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><p>An unknown, invisibleâ¦ somethingâ¦ Itâs one of the most staggering scientific puzzles in the history of human knowledge. A mystery that goes back to the very birth of our universe. Luckily, our detective-producers are on the case.</p></div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+<div class="paragraphs-items paragraphs-items-field-para-energy-layout-col2 paragraphs-items-field-para-energy-layout-col2-full paragraphs-items-full">
+    <div class="field field-name-field-para-energy-layout-col2 field-type-paragraphs field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-image caption"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-img field-type-image field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><a href="/darkmatter"><img class="borealis image-style-photo_gallery_large borealis-js" data-borealis-respondsmall="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondsmall/public/2017/09/f36/ShotintheDark-homepage.png?itok=6GoEjDGD" data-borealis-respondmedium="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondmedium/public/2017/09/f36/ShotintheDark-homepage.png?itok=vmSDe1Yp" data-borealis-respondlarge="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondlarge/public/2017/09/f36/ShotintheDark-homepage.png?itok=5lNiulrt" data-borealis-respondxl="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl/public/2017/09/f36/ShotintheDark-homepage.png?itok=YfZTRRn9" data-borealis-respondxl2="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl2/public/2017/09/f36/ShotintheDark-homepage.png?itok=Fy_a6p1b" data-borealis-respondxl3="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl3/public/2017/09/f36/ShotintheDark-homepage.png?itok=0SmBsIYY" data-borealis-respondxl4="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl4/public/2017/09/f36/ShotintheDark-homepage.png?itok=C8HTTBLW" typeof="foaf:Image" src="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondsmall/public/2017/09/f36/ShotintheDark-homepage.png?itok=6GoEjDGD" alt="A Shot In The Dark home page"/></a></div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading psp listing-vertical psp listing listing-title-summary-image-date"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 classes="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading">#WomeninSTEM</h2>
+</div>
+                  </div>
+      </div>
+<div class="energy-listing-readmore field_para_energy_listing_ref-readmore"><a href="/listings/womeninstem-blog" aria-label="View all related pages." title="View all related pages.">View All</a></div>  <div class="field field-name-field-para-energy-listing-ref field-type-entityreference field-label-hidden">
+            
+      <div class="field-items energy-listing">
+                  <div class="energy-listing-column">
+                <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2404268 clearfix" about="/articles/five-fast-facts-about-nora-stanton-blatch-barney" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts about Nora Stanton Blatch Barney" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-nora-stanton-blatch-barney" class="title-link" aria-label="Read more about &#039;Five Fast Facts about Nora Stanton Blatch Barney&#039;" title="Read more about &#039;Five Fast Facts about Nora Stanton Blatch Barney&#039;">Five Fast Facts about Nora Stanton Blatch Barney</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Nora Stanton Blatch Barney was the first American woman to become a civil engineer in 1905 and granddaughter of a womenâs rights icon.</div>
+                  </div>
+      </div>
+<div class="date">March 30, 2017</div><a href="/articles/five-fast-facts-about-nora-stanton-blatch-barney" class="more-link" aria-label="Learn More about &quot;Five Fast Facts about Nora Stanton Blatch Barney&quot;" title="Learn More about &quot;Five Fast Facts about Nora Stanton Blatch Barney&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2386276 clearfix" about="/articles/five-fast-facts-about-dr-ruby-hirose" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts about Dr. Ruby Hirose" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-dr-ruby-hirose" class="title-link" aria-label="Read more about &#039;Five Fast Facts about Dr. Ruby Hirose&#039;" title="Read more about &#039;Five Fast Facts about Dr. Ruby Hirose&#039;">Five Fast Facts about Dr. Ruby Hirose</a><div class="date">March 23, 2017</div><p>Dr. Ruby Hirose was a Japanese-American researcher whose research helped lead to vaccines against polio and other diseases.
+</p><a href="/articles/five-fast-facts-about-dr-ruby-hirose" class="more-link" aria-label="Learn More about &quot;Five Fast Facts about Dr. Ruby Hirose&quot;" title="Learn More about &quot;Five Fast Facts about Dr. Ruby Hirose&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+              </div>
+                        <div class="energy-listing-column">
+                <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2367988 clearfix" about="/articles/five-fast-facts-about-barbara-mcclintock" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts About Barbara McClintock" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-barbara-mcclintock" class="title-link" aria-label="Read more about &#039;Five Fast Facts About Barbara McClintock&#039;" title="Read more about &#039;Five Fast Facts About Barbara McClintock&#039;">Five Fast Facts About Barbara McClintock</a><div class="date">March 16, 2017</div><p>Barbara McClintock was a pioneer in the field of cytogenetics, the study of the structure and function of cells.
+</p><a href="/articles/five-fast-facts-about-barbara-mcclintock" class="more-link" aria-label="Learn More about &quot;Five Fast Facts About Barbara McClintock&quot;" title="Learn More about &quot;Five Fast Facts About Barbara McClintock&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2366716 clearfix" about="/articles/five-fast-facts-about-evelyn-boyd-granville" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts About Evelyn Boyd Granville" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-evelyn-boyd-granville" class="title-link" aria-label="Read more about &#039;Five Fast Facts About Evelyn Boyd Granville&#039;" title="Read more about &#039;Five Fast Facts About Evelyn Boyd Granville&#039;">Five Fast Facts About Evelyn Boyd Granville</a><div class="date">March 9, 2017</div><p>Dr. Evelyn Boyd Granville was the second African-American woman to earn a Ph.D. in mathematics and worked on early U.S. space missions.
+</p><a href="/articles/five-fast-facts-about-evelyn-boyd-granville" class="more-link" aria-label="Learn More about &quot;Five Fast Facts About Evelyn Boyd Granville&quot;" title="Learn More about &quot;Five Fast Facts About Evelyn Boyd Granville&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+              </div>
+            </div>
+  </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-youtube psp align-center-full caption"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-energy-youtube-browser field-type-file field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div id="file-1140641" class="file file-video file-video-youtube" >
+
+    
+  
+    
+      
+    <div class="content">
+    
+    <div class="energy-paragraphs-youtube-video youtube-player-6cbaf3815af0c0a90e3b80432ae401d4">
+  <div class="youtube-player" data-id="6njUXBi3HtE"><span class="youtube-title">U.S. Department of Energy: Science for the People</span></div>
+</div>
+
+  </div>
+  
+  
+
+</div>
+</div>
+                  </div>
+      </div>
+<div class="field-group-format group_psp_caption field-group-div group-psp-caption psp-caption speed-fast effect-none">  <div class="field field-name-field-energy-youtube-caption field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">The challenges that face us now in energy, science, and nuclear security won't wait.Â </div>
+                  </div>
+      </div>
+  <div class="field field-name-field-energy-youtube-attribution field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">U.S. Department of Energy</div>
+                  </div>
+      </div>
+</div>
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+  </div>
+  
+    
+  
+  
+</div>
+
+    </div>
+    
+  </div>
+
+  </div>
+
+
+        </div>
+        
+        <div id="content-bottom">
+          
+        </div>
+      </div>
+
+    </div>
+      </div>
+  
+    <footer id="footer">
+        <div id="footer-admin">
+      
+    </div>
+    
+    <div class="footer-top">
+      <div class="footer-inner">
+        <div class="footer-inner-left">
+              <div id="footer-info" class="footer-primary">
+      <div class="region region-footer-info">
+    
+
+  <div id="block-energy-core-site-name--2" class="block block-energy-core block-site-name block-site-name">
+
+        
+        
+    
+    
+
+<div class="site-name"><a href="/" class="active"><img src="/sites/all/themes/clean_energy/images/logo_footer_white.png" alt="Department of Energy" /></a></div>
+
+
+
+
+
+  </div>
+
+
+
+  <div id="block-energy-core-footer-contact-info" class="block block-energy-core block-footer-contact-info">
+
+        
+        
+    
+        <div class="content">
+      <div class="contact-info">
+  <div class="office-name"></div><p>1000 Independence Ave. SW<br>Washington DC 20585<br>202-586-5000</p>
+</div>
+
+    </div>
+    
+  </div>
+
+
+
+  <div id="block-energy-social-energy-social-email-signup" class="block block-energy-social block-energy-social-email-signup">
+
+        
+        
+    
+        <div class="content">
+      <div class="mc_embed_signup_wrapper"><a href="/exit?url=http%3A//energy.us5.list-manage.com/subscribe/post%3Fu%3Dd8fbb7a1814155cc38f24adeb%26id%3Da6805280ba">Sign Up for Email Updates</a></div>
+    </div>
+    
+  </div>
+
+
+
+  <div id="block-energy-social-energy-gov-social-block" class="block block-energy-social block-energy-gov-social-block">
+
+        
+        
+    
+        <div class="content">
+      <div class="energy-social-widget ">
+<div class="item-list"><ul><li class="first"><a href="/exit?url=https%3A//www.facebook.com/energygov" class="energy-social-link energy-social-link-facebook"><i class="icon-facebook"></i><span class="element-invisible">Link to facebook</span></a></li>
+<li><a href="/exit?url=https%3A//twitter.com/energy" class="energy-social-link energy-social-link-twitter"><i class="icon-twitter"></i><span class="element-invisible">Link to twitter</span></a></li>
+<li><a href="/exit?url=https%3A//www.youtube.com/user/USdepartmentofenergy" class="energy-social-link energy-social-link-youtube"><i class="icon-youtube"></i><span class="element-invisible">Link to youtube</span></a></li>
+<li><a href="/exit?url=https%3A//www.instagram.com/energy" class="energy-social-link energy-social-link-instagram"><i class="icon-instagram"></i><span class="element-invisible">Link to instagram</span></a></li>
+<li class="last"><a href="/exit?url=https%3A//www.linkedin.com/company-beta/5556" class="energy-social-link energy-social-link-linkedin"><i class="icon-linkedin"></i><span class="element-invisible">Link to linkedin</span></a></li>
+</ul></div>
+</div>
+    </div>
+    
+  </div>
+
+  </div>
+
+  </div>
+              <div id="footer-nav" class="footer-primary">
+      <div class="region region-footer-nav">
+    
+
+  <div id="block-energy-core-footer-main-menu" class="block block-energy-core block-footer-main-menu">
+
+        
+        
+    
+        <div class="content">
+      
+<ul class="menu footer-secondary-menu">
+  <li class="first expanded">
+    <a href="/" class="active">About Energy.gov</a>
+    <ul class="menu"><li class="first leaf"><a href="/management/office-management/operational-management/history">History</a></li>
+<li class="leaf"><a href="/leadership">Leadership</a></li>
+<li class="leaf"><a href="/news-blog">News</a></li>
+<li class="leaf"><a href="/science-innovation/stem">Science Education</a></li>
+<li class="leaf"><a href="/jobs/jobs">Work with Us</a></li>
+<li class="leaf"><a href="/jobs/jobs">Careers &amp; Internships</a></li>
+<li class="last leaf"><a href="/contact-us">Contact Us</a></li>
+</ul>
+  </li>
+</ul>
+
+    </div>
+    
+  </div>
+
+  </div>
+
+  </div>
+        </div>
+            <div id="footer-legal" class="footer-primary">
+      <div class="region region-footer-legal">
+    
+
+  <div id="block-menu-menu-footer-secondary-menu" class="block block-menu block-menu-footer-secondary-menu">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first expanded"><a href="/" class="active">Energy.gov Resources</a><ul class="menu"><li class="first leaf"><a href="/budget-performance">Budget &amp; Performance</a></li>
+<li class="leaf"><a href="https://www.directives.doe.gov">Directives, Delegations &amp; Requirements</a></li>
+<li class="leaf"><a href="/management/office-management/operational-management/freedom-information-act">FOIA</a></li>
+<li class="leaf"><a href="/ig/office-inspector-general">Inspector General</a></li>
+<li class="leaf"><a href="/cio/office-chief-information-officer/services/guidance/privacy-program">Privacy Program</a></li>
+<li class="leaf"><a href="/osdbu/office-small-and-disadvantaged-business-utilization">Small Business</a></li>
+<li class="last leaf"><a href="/about-us/staff-and-contractors">Staff &amp; Contractor Resources</a></li>
+</ul></li>
+<li class="last expanded"><a href="/" class="active">Federal Government</a><ul class="menu"><li class="first leaf"><a href="http://www.whitehouse.gov">The White House</a></li>
+<li class="last leaf"><a href="http://www.usa.gov">USA.gov</a></li>
+</ul></li>
+</ul>
+    </div>
+    
+  </div>
+
+  </div>
+
+  </div>
+      </div>
+    </div>
+
+    <div class="footer-bottom">
+      <div class="footer-inner">
+                <div id="footer-utility">
+            <div class="region region-footer-utility">
+    
+
+  <div id="block-menu-menu-footer-utility" class="block block-menu block-menu-footer-utility">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first leaf"><a href="/about-us/web-policies">Web Policies</a></li>
+<li class="leaf"><a href="/about-us/web-policies/privacy">Privacy</a></li>
+<li class="leaf"><a href="/diversity/services/protecting-civil-rights/no-fear-act">No Fear Act</a></li>
+<li class="leaf"><a href="https://www.osc.gov/Pages/DOW.aspx">Whistleblower Protection</a></li>
+<li class="leaf"><a href="/cio/department-energy-information-quality-guidelines">Information Quality</a></li>
+<li class="leaf"><a href="/open-government">Open Gov</a></li>
+<li class="leaf"><a href="/cio/accessibility-standard-statement">Accessibility</a></li>
+<li class="last leaf"><a href="/data/open-energy-data-old">Data &amp; Developer Tools</a></li>
+</ul>
+    </div>
+    
+  </div>
+
+  </div>
+
+        </div>
+              </div>
+    </div>
+
+  </footer>
+  
+</div>
+
+    <script type="text/javascript" src="/sites/prod/files/advagg_js/js__cCLTChfB28X41VSzdhvWEOHRvLudHi0Jq-Yiy8WS4js__QHMdM4IajNxVPKUuieSV2WKLYOoPGPSQsh0o7nVlINg__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_mediaqueries.js?ox108p"></script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__2fSLsqMXq9Tq836ak8GSps0-bN2MIXTAPbnPdTRaE2o__lJ5Iv3pIV9rQ9z9k8SyqldVnVEl6FA67UwOspHfVjoU__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_header.js?ox108p"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_footer.js?ox108p"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_overlay.js?ox108p"></script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__KEmQaQ1AHW-FKByVITBadf_xsLxbmuthMs8Z1lWLy-E__IzyZtJVuXOU0zZqAh9XgHUc_fNUW6lHOX67KW4yeMuw__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"clean_energy","theme_token":"6zHJE5mFS5GAziQcdYSRwwWqiKbxRMCrGAA9Iag9K00","css":{"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.button.css":1,"misc\/ui\/jquery.ui.resizable.css":1,"misc\/ui\/jquery.ui.dialog.css":1,"modules\/system\/system.base.css":1,"modules\/system\/system.menus.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/date\/date_api\/date.css":1,"sites\/all\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"sites\/all\/modules\/custom\/energy_media\/sites\/all\/modules\/custom\/energy_media\/styles\/energy.media.css":1,"sites\/all\/modules\/contrib\/environment_indicator\/environment_indicator.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"modules\/search\/search.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/media\/modules\/media_wysiwyg\/css\/media_wysiwyg.base.css":1,"\/\/fast.fonts.com\/t\/1.css?apiType=css\u0026projectid=b893a4ff-9ea3-4ce8-bf77-c8d3e3a3de97":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/custom\/energy_admin\/css\/users_online.css":1,"sites\/all\/modules\/custom\/energy_content\/css\/energy_content_wysiwyg.css":1,"0":1,"1":1,"sites\/all\/modules\/custom\/energy_paragraphs\/modules\/energy_paragraphs_superpack_style\/src\/Plugin\/SuperpackProcessor\/css\/color.css":1,"2":1,"sites\/all\/libraries\/slick\/slick.css":1,"3":1,"4":1,"5":1,"6":1,"7":1,"8":1,"9":1,"10":1,"11":1,"12":1,"sites\/all\/modules\/contrib\/borealis\/borealis_ri\/css\/borealis-ri_images.css":1,"sites\/all\/modules\/contrib\/paragraphs_superpack\/modules\/paragraphs_superpack_style\/src\/Plugin\/SuperpackProcessor\/css\/style.css":1,"13":1,"14":1,"15":1,"sites\/all\/modules\/contrib\/wysiwyg_tools_plus\/css\/wysiwyg_tools_plus.css":1,"16":1,"sites\/all\/modules\/custom\/energy_paragraphs\/modules\/energy_paragraphs_youtube\/css\/energy_paragraphs_youtube.css":1,"sites\/all\/modules\/contrib\/field_group\/field_group.css":1,"sites\/all\/themes\/clean_energy\/style\/clean_energy.css":1},"js":{"sites\/all\/libraries\/slick\/slick.min.js":1,"sites\/all\/modules\/custom\/energy_content\/js\/jquery.dataTables.js":1,"sites\/all\/themes\/clean_energy\/scripts\/enquire\/enquire.min.js":1,"sites\/all\/modules\/custom\/energy_admin\/js\/users_online.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/event_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/related_content_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/breadcrumb_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/context_callout_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/energy_ext_link_page.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_listings.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.8\/jquery.min.js":1,"misc\/jquery.once.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.button.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.mouse.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.draggable.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.position.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.resizable.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.dialog.min.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_mediaqueries.js":1,"sites\/all\/modules\/contrib\/environment_indicator\/tinycon.min.js":1,"sites\/all\/modules\/contrib\/environment_indicator\/environment_indicator.js":1,"sites\/all\/modules\/contrib\/environment_indicator\/color.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_header.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_footer.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_overlay.js":1,"sites\/all\/modules\/contrib\/ext_link_page\/ext_link_page.js":1,"sites\/all\/modules\/contrib\/image_caption\/image_caption.min.js":1,"sites\/all\/modules\/custom\/energy_social\/js\/eventTracking.js":1,"sites\/all\/modules\/contrib\/borealis\/borealis_ri\/js\/borealis_ri.js":1,"sites\/all\/modules\/contrib\/wysiwyg_tools_plus\/js\/tab_builder.js":1,"sites\/all\/modules\/custom\/energy_paragraphs\/modules\/energy_paragraphs_youtube\/js\/player.js":1,"misc\/form.js":1,"misc\/collapse.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1}},"energy_content":{"nid":"2791","base_url":"https:\/\/energy.gov"},"drupal_ga_accounts":["UA-17192165-1"],"energyCore":{"pageTitle":"Energy.gov"},"ext_link_page":{"pathLinkPage":"\/exit","messageTitle":"You are now leaving Energy.gov","messageBody":"\u003Cstrong\u003EYou will be automatically redirected to:\u003C\/strong\u003E\u003Cbr \/\u003E\n  [link]\u003Cbr \/\u003E\n  in [delay] seconds\u003Cspan class=\u0022ext-link-modal-message\u0022\u003E or you may click \u0022Continue to the Site\u0022\u003C\/span\u003E.\n","extLinkClass":"ext","directDisable":0,"delay":10,"siteName":"Department of Energy"},"urlIsAjaxTrusted":{"\/":true},"heroVertical":{"limitVertical":["961921","1155948","1154396","1153152","1151932"]},"borealis_ri":{"sizes":{"respondsmall":350,"respondmedium":525,"respondlarge":787.5,"respondxl":1181.25,"respondxl2":1771.875,"respondxl3":2657.8125,"respondxl4":3986.71875},"lazyload":false,"aspect_ratio":0.75},"energyParagraphsYoutube":[{"title":"U.S. Department of Energy: Science for the People","thumbnail_url":"https:\/\/i.ytimg.com\/vi\/6njUXBi3HtE\/hqdefault.jpg","data_id":"6njUXBi3HtE","start_time":null,"end_time":null,"fid":0,"md5hash":"6cbaf3815af0c0a90e3b80432ae401d4"}],"field_group":{"div":"full"},"ogContext":{"groupType":"taxonomy_term","gid":"31"}});
+//--><!]]>
+</script>
+
+    <script type="text/javascript" src="/sites/prod/files/advagg_js/js__g7YdHgS5VRw1P5w-qQZhr4w_jNMRiAulRmpRIZj9Tws__YQ8FpSPjSNUGlzHZG_V1-MuEelCwLiBM7yhcJ4b4bqk__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/enquire/enquire.min.js?ox108p"></script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__1usYMFM4q12UFLhIqQ8IwGGbXx8HlZpStgfU-3zvslk__FSMCFO8o7mJG3kCrbCJ_i6cwLJfnX7SLLQI_vd2S4x4__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+
+var _gaq = _gaq || [];
+_gaq.push(
+  
+  ['_setAccount', 'UA-17192165-1'],
+  ['_trackPageview'],
+  ['_setDomainName', '.energy.gov']
+);
+(function() {
+  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+})();
+//--><!]]>
+</script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__TpZ0d-9GdeYsZGgpmUf71BeemkZXSm9n10iJCjMlqFM__d7PvNjqjzZ0lHiIG3IVa3FGzevl5ey2rwczqvDe1KjQ__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_listings.js?ox108p"></script>
+
+  <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOE"></script>
+  </body>
+</html>

--- a/web_monitoring/tests/fixtures/versions/9d4de183-a186-456c-bffb-55d82989877d
+++ b/web_monitoring/tests/fixtures/versions/9d4de183-a186-456c-bffb-55d82989877d
@@ -1,0 +1,1682 @@
+
+<!doctype html>
+  <head profile="http://www.w3.org/1999/xhtml/vocab">
+    <!--[if IE]><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta property="fb:admins" content="10718899,1407911,20010394,13004794,207303407,203176,747807274,100001088239132,1384028141" />
+<meta name="google-site-verification" content="ABr0J9KwVb6OpJyjJyQ2WjRFzfXbCsGbsHty4mdXy_c" />
+<link rel="shortcut icon" href="https://energy.gov/sites/all/themes/clean_energy/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="https://energy.gov/" />
+<link rel="shortlink" href="https://energy.gov/" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:url" content="https://energy.gov/" />
+<meta name="twitter:title" content="Department of Energy" />
+
+    <title>Department of Energy</title>
+    <link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__vNsJ9dO9uM-_bY3sV9uYXqsmJlRuiPez5_jxjdB2qx0___S5D9wpKufOlZx5WUcpV6IGoQB3AwS_xvDKyJlsY7JM__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__7E4PQLEVrbgUR-S6I0pBduNYcrRn4phJp9K5D0UNe58__MCQhRHCool1Ersq-srHybqrtIwW909tFfAB4qHG-t4s__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//fast.fonts.com/t/1.css?apiType=css&amp;projectid=b893a4ff-9ea3-4ce8-bf77-c8d3e3a3de97" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__DJVWsB9CJVs_1IGdy-_cGuq4r6SVVaWbEnbS1U2p6y4__-VZwo-nOHQ8jOwHBs8iAakXDmGrlSDpOMrchWH61En8__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css___BT9KELVHngeMchzMHHJlK2HMFMITPlOs8ZmiG6guxQ__jX4UXuK4UFBZ9_ePAhpLVYpQt4qDv3FbpPpkmzKscKA__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__rp1vOLONZeM4aap_3G0pMbeXQDzJTFkXSVI8rG2mO3c__6dwFf23F2Vr0k7UcqQ1HkFiyqjhUJsFrUSOBPytOxzk__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-fid-1202676 > .content { background-image: url("https://energy.gov/sites/prod/files/2017/09/f37/36634871684_8c59235d2f_o.jpg") !important;}.image-background-large-fid-1140013 > .content { background-image: url("https://energy.gov/sites/prod/files/image8grid_0.jpg") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__HTGmlxHp2bJS6Rm4lYdv1YPgQ-JSuuO355PGJQ9xt_M__cJsvcnfs9fKIXnQUMn0PEs23Wg328JLYunYSrpXcT0A__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-fid-1190789 > .content { background-image: url("https://energy.gov/sites/prod/files/2017/08/f36/STEM%20resources3.jpg") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css___EW1Lfz_YceXSL0sM78NHMnd2Rlpc5j-mD7t4m18phA__5db1AK6VA9IKDQM72zlEkoVKhTQAHAFP4yWEEcS0yuY__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-2816100 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/6189797301_d42618a57c_o.jpg?itok=p-a_UIpw") !important;}.image-background-large-2788803 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/28576577376_c2cc9939a1_o_0.jpg?itok=JzDyMwtt") !important;}.image-background-large-2788173 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/40_CGF_STILL_00022_1600.jpg?itok=4FZQpnOC") !important;}.image-background-large-2788041 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/2017/09/f36/DJhWXGDUIAAx4zf.jpg?itok=_06S_e__") !important;}.image-background-large-2731185 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/doestock-women-in-stem-3_resized.jpg?itok=1ExGtO1F") !important;}.image-background-large-2714185 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/2017/08/f35/SolarEclipse2017Infographic%20%282%29.png?itok=h1lmIiMm") !important;}.image-background-large-908796 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/Block%20Island.Schroeder.jpg?itok=M4AqIiOH") !important;}.image-background-large-714436 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/26785.jpg?itok=fOPJ-5ny") !important;}.image-background-large-2696966 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/2017/08/f35/distributed-wind-nrel-33943_0.jpg?itok=O6jhC-gg") !important;}.image-background-large-383293 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/wind%20turbine%20rappel%20.jpg?itok=YSMvD-pK") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__pW5vNQJuSmsMpOmMZL_s14WfGL9RqNDDeVKsMnDkmbo__gEZBAQ2r5JuG_6OPhnhZo2tMjW0KZeJ9loDNunx9MmA__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-2404268 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/NoraStanton-WIS.png?itok=RZu5CKlN") !important;}.image-background-large-2386276 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/RubyHirose-WIS.png?itok=11-QgkUg") !important;}.image-background-large-2367988 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/Barbara%20McClintock.png?itok=rvBkRB1a") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__axMOHTxcLD0CqjKTsuo48w0ynWLokyCV-2TRFn-uKJ0__uhDNqg7St7zZjH650-Dc79MAVovTq0LWMYpKAINIcxc__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<style type="text/css" media="all">
+/* <![CDATA[ */
+.image-background-large-2366716 .background-container { background-image: url("https://energy.gov/sites/prod/files/styles/large/public/Evelyn.png?itok=QHKDXYor") !important;}
+/* ]]> */
+</style>
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__XE3FFdx87jKxGtPHOkdxm34PKID8DFaDqgr6UOR379g__2LfTCTY0HeQ6-uHpsrrgP5C--TusyLm1SfnQrQ9R75g__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/sites/prod/files/advagg_css/css__IDz4UT5INU7fVtFVM4n7xQOo49HkwCZU0Co-Y-PL5kg__T9Bqw4IsdZoUOuuWeAVRIVXW4rX0BosIlCRKSrSaBhg__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.css" media="all" />
+
+    <meta name="viewport" content="width=device-width, maximum-scale=2, minimum-scale=1, initial-scale=1, user-scalable=yes" />
+  </head>
+  <body class="html front not-logged-in no-sidebars page-node page-node- page-node-2791 node-type-homepage og-context og-context-taxonomy-term og-context-taxonomy-term-31 node-display-homepage" lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" dir="ltr" >
+    
+    <div id="body-inner" class="page-office-main">
+
+            <header id="header">
+                  <div class="header-top">
+              <div class="region region-header">
+    
+
+  <div id="block-energy-core-energy-core-header-utility" class="block block-energy-core block-energy-core-header-utility block-header-utility">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first leaf"><a href="/national-laboratories">National Labs</a></li>
+<li class="leaf"><a href="/offices">Offices</a></li>
+<li class="last collapsed"><a href="/about-us">About</a></li>
+</ul>
+    </div>
+    
+  </div>
+
+
+
+  <div id="block-energy-social-energy-social-top-level" class="block block-energy-social block-energy-social-top-level">
+
+        
+        
+    
+        <div class="content">
+      <div class="energy-social-widget ">
+<div class="item-list"><ul><li class="first"><a href="/exit?url=https%3A//www.facebook.com/energygov" class="energy-social-link energy-social-link-facebook"><i class="icon-facebook"></i><span class="element-invisible">Link to facebook</span></a></li>
+<li><a href="/exit?url=https%3A//twitter.com/energy" class="energy-social-link energy-social-link-twitter"><i class="icon-twitter"></i><span class="element-invisible">Link to twitter</span></a></li>
+<li><a href="/exit?url=https%3A//www.youtube.com/user/USdepartmentofenergy" class="energy-social-link energy-social-link-youtube"><i class="icon-youtube"></i><span class="element-invisible">Link to youtube</span></a></li>
+<li><a href="/exit?url=https%3A//www.instagram.com/energy" class="energy-social-link energy-social-link-instagram"><i class="icon-instagram"></i><span class="element-invisible">Link to instagram</span></a></li>
+<li class="last"><a href="/exit?url=https%3A//www.linkedin.com/company-beta/5556" class="energy-social-link energy-social-link-linkedin"><i class="icon-linkedin"></i><span class="element-invisible">Link to linkedin</span></a></li>
+</ul></div>
+</div>
+    </div>
+    
+  </div>
+
+  </div>
+
+          </div>
+        
+                              <nav id="navigation">
+                <div class="region region-navigation">
+    
+
+  <div id="block-energy-core-site-name" class="block block-energy-core block-site-name block-site-name">
+
+        
+        
+    
+    
+
+<div class="site-name"><a href="/" class="active"><img src="/sites/all/themes/clean_energy/images/energy_crest_smaller.png" alt="Department of Energy" /></a></div>
+
+
+
+
+
+  </div>
+
+
+
+  <div id="block-energy-core-navigation-main" class="block block-energy-core block-navigation-main">
+
+        
+        
+    
+        <div class="content">
+      
+
+  <div id="block-search-form" class="block block-search block-form">
+
+        
+        
+    
+        <div class="content">
+      <form action="/" method="post" id="search-block-form" accept-charset="UTF-8"><div><div class="container-inline">
+      <h2 class="element-invisible">Search form</h2>
+    <div class="form-item form-type-textfield form-item-search-block-form">
+  <label class="element-invisible" for="edit-search-block-form--2">Search </label>
+ <input title="Enter the terms you wish to search for." placeholder="Search" aria-label="Enter the terms you wish to search for." size="30" type="text" id="edit-search-block-form--2" name="search_block_form" value="" maxlength="128" class="form-text" />
+</div>
+<div class="form-actions form-wrapper" id="edit-actions"><input alt="Submit search query" type="image" id="edit-submit" name="submit" value="Search" src="https://energy.gov/sites/all/themes/clean_energy/images/Magnifying_glass_icon.svg" class="form-submit" /></div><input type="hidden" name="form_build_id" value="form-lXmwP-LaQMZJnkZR4Zv7q2Yy2uCkq-bdv85VrQuh_iU" />
+<input type="hidden" name="form_id" value="search_block_form" />
+</div>
+</div></form>
+    </div>
+    
+  </div>
+
+<div class="primary-nav overlay"><div class="primary-nav-inner overlay-back"><div id="nav-menu-wrap"><a href="/" class="header-mobile-home active">Energy.gov Home</a><ul class="menu" role="menubar" title="Main Menu" tabindex="0"><li class="first expanded depth-1" tabindex="1" role="menuitem" aria-haspopup="true"><a href="/science-innovation"><span>Science & Innovation</span></a><div class="child-menu"><span class="menu-parent">Science & Innovation</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/science-innovation">Science &amp; Innovation Home</a></li>
+<li class="expanded depth-2 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/clean-energy">Clean Energy</a><div class="child-menu"><span class="menu-parent">Clean Energy</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/clean-energy">Clean Energy Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/innovation/hubs">Hubs</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/science-innovation/innovation/emerging-technologies">Emerging Technologies</a></li>
+<li class="expanded depth-3" tabindex="3" role="menuitem"><a href="/science-innovation/innovation/commercialization">Commercialization</a><div class="child-menu"><span class="menu-parent">Commercialization</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-4" role="menuitem"><a href="/science-innovation/innovation/commercialization">Commercialization Home</a></li>
+<li class="last leaf depth-4 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/innovation/commercialization/national-clean-energy-business-plan-competition">National Clean Energy Business Plan Competition</a></li>
+</ul></div></li>
+<li class="last leaf depth-3" tabindex="4" role="menuitem"><a href="/science-innovation/innovation/lab-breakthroughs">Lab Breakthroughs</a></li>
+</ul></div></li>
+<li class="expanded depth-2" tabindex="2" role="menuitem"><a href="/science-innovation/energy-efficiency">Energy Efficiency</a><div class="child-menu"><span class="menu-parent">Energy Efficiency</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/energy-efficiency">Energy Efficiency Home</a></li>
+<li class="last expanded depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/commercial-buildings">Building Design</a><div class="child-menu"><span class="menu-parent">Building Design</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-4" role="menuitem"><a href="/public-services/commercial-buildings">Building Design Home</a></li>
+<li class="leaf depth-4 original-first" tabindex="1" role="menuitem"><a href="/public-services/building-design/construction">Construction</a></li>
+<li class="leaf depth-4" tabindex="2" role="menuitem"><a href="/public-services/building-design/commercial-heating-cooling">Industrial Heating &amp; Cooling</a></li>
+<li class="last leaf depth-4" tabindex="3" role="menuitem"><a href="/public-services/building-design/commercial-lighting">Industrial Lighting</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="expanded depth-2" tabindex="3" role="menuitem"><a href="/science-innovation/vehicles">Vehicles</a><div class="child-menu"><span class="menu-parent">Vehicles</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/vehicles">Vehicles Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/vehicles/alternative-fuel-vehicles">Alternative Fuel Vehicles</a></li>
+<li class="last leaf depth-3" tabindex="2" role="menuitem"><a href="/public-services/vehicles/batteries">Batteries</a></li>
+</ul></div></li>
+<li class="leaf depth-2" tabindex="4" role="menuitem"><a href="/science-innovation/climate-change">Climate Change</a></li>
+<li class="expanded depth-2" tabindex="5" role="menuitem"><a href="/science-innovation/energy-sources">Energy Sources</a><div class="child-menu"><span class="menu-parent">Energy Sources</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/science-innovation/energy-sources">Energy Sources Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/solar">Solar</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/wind">Wind</a></li>
+<li class="leaf depth-3" tabindex="3" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/water">Water</a></li>
+<li class="leaf depth-3" tabindex="4" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/geothermal">Geothermal</a></li>
+<li class="leaf depth-3" tabindex="5" role="menuitem"><a href="/science-innovation/energy-sources/fossil">Fossil</a></li>
+<li class="leaf depth-3" tabindex="6" role="menuitem"><a href="/public-services/vehicles/hydrogen-fuel-cells">Electric Power</a></li>
+<li class="leaf depth-3" tabindex="7" role="menuitem"><a href="/science-innovation/electric-power/storage">Energy Storage</a></li>
+<li class="expanded depth-3" tabindex="8" role="menuitem"><a href="/science-innovation/electric-power">Hydrogen and Fuel Cells</a><div class="child-menu"><span class="menu-parent">Hydrogen and Fuel Cells</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-4" role="menuitem"><a href="/science-innovation/electric-power">Hydrogen and Fuel Cells Home</a></li>
+<li class="last leaf depth-4 original-first" tabindex="1" role="menuitem"><a href="/science-innovation/electric-power/smart-grid">Smart Grid</a></li>
+</ul></div></li>
+<li class="leaf depth-3" tabindex="9" role="menuitem"><a href="/science-innovation/energy-sources/renewable-energy/bioenergy">Bio-Energy</a></li>
+<li class="last leaf depth-3" tabindex="10" role="menuitem"><a href="/science-innovation/energy-sources/nuclear">Nuclear</a></li>
+</ul></div></li>
+<li class="last leaf depth-2" tabindex="6" role="menuitem"><a href="/science-innovation/stem">STEM</a></li>
+</ul></div></li>
+<li class="expanded depth-1" tabindex="2" role="menuitem" aria-haspopup="true"><a href="/energy-economy"><span>Energy Economy</span></a><div class="child-menu"><span class="menu-parent">Energy Economy</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/energy-economy">Energy Economy Home</a></li>
+<li class="leaf depth-2 original-first" tabindex="1" role="menuitem"><a href="/energy-economy/prices-trends">Prices &amp; Trends</a></li>
+<li class="leaf depth-2" tabindex="2" role="menuitem"><a href="/energy-economy/funding-financing">Funding &amp; Financing</a></li>
+<li class="leaf depth-2" tabindex="3" role="menuitem"><a href="/energy-economy/state-local-government">State &amp; Local Government</a></li>
+<li class="last leaf depth-2" tabindex="4" role="menuitem"><a href="/energy-economy/manufacturing">Advanced Manufacturing</a></li>
+</ul></div></li>
+<li class="expanded depth-1" tabindex="3" role="menuitem" aria-haspopup="true"><a href="/national-security-safety"><span>Security & Safety</span></a><div class="child-menu"><span class="menu-parent">Security & Safety</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/national-security-safety">Security &amp; Safety Home</a></li>
+<li class="leaf depth-2 original-first" tabindex="1" role="menuitem"><a href="/national-security-safety/nuclear-security-nonproliferation">Nuclear Security</a></li>
+<li class="leaf depth-2" tabindex="2" role="menuitem"><a href="/national-security-safety/cybersecurity">Cybersecurity</a></li>
+<li class="leaf depth-2" tabindex="3" role="menuitem"><a href="/national-security-safety/environmental-cleanup">Environmental Cleanup</a></li>
+<li class="last leaf depth-2" tabindex="4" role="menuitem"><a href="/national-security-safety/emergency-response">Emergency Response</a></li>
+</ul></div></li>
+<li class="last expanded depth-1" tabindex="4" role="menuitem" aria-haspopup="true"><a href="/energysaver/energy-saver" class="energy-saver"><span>Save Energy, Save Money</span></a><div class="child-menu"><span class="menu-parent">Save Energy, Save Money</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-2" role="menuitem"><a href="/energysaver/energy-saver" class="energy-saver">Save Energy, Save Money Home</a></li>
+<li class="expanded depth-2 original-first" tabindex="1" role="menuitem"><a href="/energysaver/heat-and-cool">Heating &amp; Cooling</a><div class="child-menu"><span class="menu-parent">Heating & Cooling</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/energysaver/heat-and-cool">Heating &amp; Cooling Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/homes/heating-cooling/heat-pumps">Heat Pumps</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/public-services/homes/heating-cooling/home-cooling">Home Cooling</a></li>
+<li class="leaf depth-3" tabindex="3" role="menuitem"><a href="/public-services/homes/heating-cooling/home-heating">Home Heating</a></li>
+<li class="leaf depth-3" tabindex="4" role="menuitem"><a href="/energysaver/water-heating">Water Heating</a></li>
+<li class="last leaf depth-3" tabindex="5" role="menuitem"><a href="/public-services/homes/home-weatherization/home-energy-audits">Home Energy Audits</a></li>
+</ul></div></li>
+<li class="leaf depth-2" tabindex="2" role="menuitem"><a href="/energysaver/weatherize">Weatherization</a></li>
+<li class="leaf depth-2" tabindex="3" role="menuitem"><a href="/energysaver/windows-doors-and-skylights">Windows, Doors &amp; Skylights</a></li>
+<li class="expanded depth-2" tabindex="4" role="menuitem"><a href="/energysaver/design">Design &amp; Remodeling</a><div class="child-menu"><span class="menu-parent">Design & Remodeling</span><ul class="menu" role="menu" aria-hidden="true"><li class="first leaf parent-link depth-3" role="menuitem"><a href="/energysaver/design">Design &amp; Remodeling Home</a></li>
+<li class="leaf depth-3 original-first" tabindex="1" role="menuitem"><a href="/public-services/homes/home-design-remodeling">Home Design &amp; Remodeling</a></li>
+<li class="leaf depth-3" tabindex="2" role="menuitem"><a href="/energysaver/lighting-choices-save-you-money">Lighting</a></li>
+<li class="last leaf depth-3" tabindex="3" role="menuitem"><a href="/public-services/homes/landscaping">Landscaping</a></li>
+</ul></div></li>
+<li class="leaf depth-2" tabindex="5" role="menuitem"><a href="/energysaver/save-electricity-and-fuel">Electricity &amp; Fuel</a></li>
+<li class="leaf depth-2" tabindex="6" role="menuitem"><a href="/energysaver/services/energy-saver-guide-tips-saving-money-and-energy-home">Start Saving</a></li>
+<li class="leaf depth-2" tabindex="7" role="menuitem"><a href="/energysaver/insulation">Insulation</a></li>
+<li class="leaf depth-2" tabindex="8" role="menuitem"><a href="/energysaver/air-sealing-your-home">Sealing Your Home</a></li>
+<li class="last leaf depth-2" tabindex="9" role="menuitem"><a href="/energysaver/ventilation">Ventilation</a></li>
+</ul></div></li>
+</ul>
+
+  <div id="block-energy-core-energy-core-header-utility--2" class="block block-energy-core block-energy-core-header-utility block-header-utility">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first leaf"><a href="/national-laboratories">National Labs</a></li>
+<li class="leaf"><a href="/offices">Offices</a></li>
+<li class="last collapsed"><a href="/about-us">About</a></li>
+</ul>
+    </div>
+    
+  </div>
+
+</div></div></div>
+    </div>
+    
+  </div>
+
+  <div id="block-main-nav-suffix" class="block">
+    <input id="search-form-nav-reveal" class="search-form-reveal form-search" name="search-form-nav-reveal" value="" alt="Reveal Search Box" type="submit" /><input id="main-menu-nav-reveal" name="main-menu-nav-reveal" value="" alt="Reveal Main Menu" class="overlay-reveal overlayTarget-primary-nav form-menu" type="submit" />
+  </div>
+  </div>
+
+            </nav>
+                  
+                              <nav id="subnavigation">
+                <div class="region region-subnavigation">
+    
+
+  <div id="block-energy-core-subnavigation" class="block block-energy-core block-subnavigation">
+
+        
+        
+    
+        <div class="content">
+      
+    </div>
+    
+  </div>
+
+  </div>
+
+            </nav>
+                        </header>
+      
+      
+      
+        <div id="top">
+                                    
+              
+
+
+
+          </div>
+    
+    <div id="page"  class="page-node page-node-homepage">
+        <div id="main-content" class="clearfix">
+      
+      <div id="content-wrapper">
+        
+        <div id="content-top">
+
+          
+
+        </div>
+
+                <div id="content" class="clearfix">
+          
+            <div class="region region-content">
+    
+
+  <div id="block-system-main" class="block block-system block-main">
+
+        
+        
+    
+        <div class="content">
+      <div class="node node-homepage clearfix" about="/energygov" typeof="sioc:Item foaf:Document">
+      
+  
+    
+            <span property="dc:title" content="Energy.gov" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    
+<div class="paragraphs-items paragraphs-items-field-homepage-hero-feat-items paragraphs-items-field-homepage-hero-feat-items-teaser paragraphs-items-teaser">
+    <div class="field field-name-field-homepage-hero-feat-items field-type-paragraphs field-label-hidden featured-3-up">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-ref psp light-foreground-over-dark-background dark-background light-foreground image-background image-background-large-fid-1202676"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-energy-ref-item field-type-entityreference field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div class="node node-article node-teaser clearfix" about="/oe/articles/doe-emergency-responders-active-power-restoration-efforts-puerto-rico-and-us-virgin" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="DOE Emergency Responders Active in Power Restoration Efforts in Puerto Rico and the U.S. Virgin Islands" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/oe/articles/doe-emergency-responders-active-power-restoration-efforts-puerto-rico-and-us-virgin" class="title-link" aria-label="Read more about &#039;DOE Emergency Responders Active in Power Restoration Efforts in Puerto Rico and the U.S. Virgin Islands&#039;" title="Read more about &#039;DOE Emergency Responders Active in Power Restoration Efforts in Puerto Rico and the U.S. Virgin Islands&#039;">Working Together to Restore Power in Puerto Rico and the U.S. Virgin Islands</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-ref psp light-foreground-over-dark-background dark-background light-foreground image-background image-background-large-fid-1140013"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-energy-ref-item field-type-entityreference field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div class="node node-page node-teaser clearfix" about="/staff-report-secretary-electricity-markets-and-reliability" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Staff Report to the Secretary on Electricity Markets and Reliability" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/staff-report-secretary-electricity-markets-and-reliability" class="title-link" aria-label="Read more about &#039;Staff Report to the Secretary on Electricity Markets and Reliability&#039;" title="Read more about &#039;Staff Report to the Secretary on Electricity Markets and Reliability&#039;">Staff Report to the Secretary on Electricity Markets and Reliability</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-ref psp light-foreground-over-dark-background dark-background light-foreground image-background image-background-large-fid-1190789"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-energy-ref-item field-type-entityreference field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div class="node node-topic node-teaser clearfix" about="/science-innovation/stem" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="STEM" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/science-innovation/stem" class="title-link" aria-label="Read more about &#039;STEM&#039;" title="Read more about &#039;STEM&#039;">STEM Education Resources </a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+<div class="paragraphs-items paragraphs-items-field-body-paragraphs paragraphs-items-field-body-paragraphs-full paragraphs-items-full">
+    <div class="field field-name-field-body-paragraphs field-type-paragraphs field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading psp listing-horizontal psp listing listing-title-summary-date"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 classes="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading">Energy News</h2>
+</div>
+                  </div>
+      </div>
+<div class="energy-listing-readmore field_para_energy_listing_ref-readmore"><a href="/listings/energy-news" aria-label="View all related pages." title="View all related pages.">View All</a></div>  <div class="field field-name-field-para-energy-listing-ref field-type-entityreference field-label-hidden">
+            
+      <div class="field-items energy-listing">
+                    <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-36-million-projects-advance-carbon-capture" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-36-million-projects-advance-carbon-capture" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;">Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Projects will continue the development of carbon capture technologies to either the engineering scale or to a commercial design.</div>
+                  </div>
+      </div>
+<div class="date">September 22, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-36-million-projects-advance-carbon-capture" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces $36 Million for Projects to Advance Carbon Capture Technologies&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-integrated-biorefinery-optimization-projects" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-integrated-biorefinery-optimization-projects" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;">Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Projects will work to solve critical research and developmental challenges encountered for the successful scale-up of integrated biorefineries. </div>
+                  </div>
+      </div>
+<div class="date">September 20, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-integrated-biorefinery-optimization-projects" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Integrated Biorefinery Optimization Projects&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-high-performance-computing-materials-program-help" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material..." class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-high-performance-computing-materials-program-help" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Materials for Severe Environments&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Materials for Severe Environments&#039;">Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material...</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Initiative will initially focus on challenges facing industry as they work to develop new or improved materials that can sustain extreme conditions. </div>
+                  </div>
+      </div>
+<div class="date">September 19, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-high-performance-computing-materials-program-help" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material...&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces High Performance Computing for Materials Program to Help Industry Develop New, Improved Material...&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/department-energy-announces-18-new-projects-accelerate-production-macroalgae-energy-and" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/department-energy-announces-18-new-projects-accelerate-production-macroalgae-energy-and" class="title-link" aria-label="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;" title="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;">Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">New projects will develop the tools to enable the United States to become a leading producer of seaweed, helping to improve U.S. energy security. </div>
+                  </div>
+      </div>
+<div class="date">September 19, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/department-energy-announces-18-new-projects-accelerate-production-macroalgae-energy-and" class="view-more" title="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;" aria-label="Read more about &#039;Department of Energy Announces 18 New Projects to Accelerate Production of Macroalgae for Energy and Other Uses&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/department-energy-national-labs-recognized-international-rd-hub-international-atomic-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Department of Energy National Labs Recognized as International R&amp;D Hub by International Atomic Energy Agency" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/department-energy-national-labs-recognized-international-rd-hub-international-atomic-energy" class="title-link" aria-label="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;" title="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;">Department of Energy National Labs Recognized as International R&amp;D Hub by International Atomic Energy Agency</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">The IAEA designation makes the United States one of only three countries identified for unique capabilities and excellence in nuclear research. </div>
+                  </div>
+      </div>
+<div class="date">September 18, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/department-energy-national-labs-recognized-international-rd-hub-international-atomic-energy" class="view-more" title="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;" aria-label="Read more about &#039;Department of Energy National Labs Recognized as International R&amp;amp;D Hub by International Atomic Energy Agency&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/us-department-energy-authorizes-eagle-maxville-small-scale-liquefied-natural-gas-exports" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/us-department-energy-authorizes-eagle-maxville-small-scale-liquefied-natural-gas-exports" class="title-link" aria-label="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;" title="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;">U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Eagle Maxville authorized to export domestically produced LNG in ISO containers loaded at the Maxville Facility located in Jacksonville. </div>
+                  </div>
+      </div>
+<div class="date">September 15, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/us-department-energy-authorizes-eagle-maxville-small-scale-liquefied-natural-gas-exports" class="view-more" title="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;" aria-label="Read more about &#039;U.S. Department of Energy Authorizes Eagle Maxville Small-Scale Liquefied Natural Gas Exports&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/secretary-energy-rick-perry-announces-nearly-20-million-help-commercialize-promising-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-energy-rick-perry-announces-nearly-20-million-help-commercialize-promising-energy" class="title-link" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;" title="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;">Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">This second Department-wide round of funding through the Office of Technology Transitionâs Technology Commercialization Fund will support 54 projects.</div>
+                  </div>
+      </div>
+<div class="date">September 13, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/secretary-energy-rick-perry-announces-nearly-20-million-help-commercialize-promising-energy" class="view-more" title="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;" aria-label="Read more about &#039;Secretary of Energy Rick Perry Announces Nearly $20 Million To Help Commercialize Promising Energy Technologies&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/energy-department-announces-achievement-sunshot-goal-new-focus-solar-energy-office" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/energy-department-announces-achievement-sunshot-goal-new-focus-solar-energy-office" class="title-link" aria-label="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;" title="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;">Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Average price of utility-scale solar is now 6 cents per kilowatt-hour (kWh).</div>
+                  </div>
+      </div>
+<div class="date">September 12, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/energy-department-announces-achievement-sunshot-goal-new-focus-solar-energy-office" class="view-more" title="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;" aria-label="Read more about &#039;Energy Department Announces Achievement of SunShot Goal, New Focus for Solar Energy Office&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article clearfix" about="/articles/energy-department-invests-50-million-improve-resilience-and-security-nation-s-critical" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="Energy Department Invests Up to $50 Million to Improve the Resilience and Security of the Nationâs Critical Energy Infrastructure" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/energy-department-invests-50-million-improve-resilience-and-security-nation-s-critical" class="title-link" aria-label="Read more about &#039;Energy Department Invests Up to $50 Million to Improve the Resilience and Security of the Nationâs Critical Energy Infrastructure&#039;" title="Read more about &#039;Energy Department Invests Up to $50 Million to Improve the Resilience and Security of the Nationâs Critical Energy Infrastructure&#039;">Energy Department Invests Up to $50 Million to Improve the Resilience and Security of the Nationâs Critical Energy Infrastructure</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Projects to improve the resilience of the Nation&#039;s critical energy infrastructure, including the electric grid and oil and natural gas infrastructure.</div>
+                  </div>
+      </div>
+<div class="date">September 12, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/energy-department-invests-50-million-improve-resilience-and-security-nation-s-critical" class="view-more" title="Read more about &#039;Energy Department Invests Up to $50 Million to Improve the Resilience and Security of the Nationâs Critical Energy Infrastructure&#039;" aria-label="Read more about &#039;Energy Department Invests Up to $50 Million to Improve the Resilience and Security of the Nationâs Critical Energy Infrastructure&#039;">View Article</a></div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article clearfix" about="/articles/us-department-energy-proposes-expedited-approval-small-scale-natural-gas-exports" typeof="sioc:Item foaf:Document">
+      
+  
+    
+    <span property="dc:title" content="U.S. Department of Energy Proposes Expedited Approval for Small-Scale Natural Gas Exports" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/us-department-energy-proposes-expedited-approval-small-scale-natural-gas-exports" class="title-link" aria-label="Read more about &#039;U.S. Department of Energy Proposes Expedited Approval for Small-Scale Natural Gas Exports&#039;" title="Read more about &#039;U.S. Department of Energy Proposes Expedited Approval for Small-Scale Natural Gas Exports&#039;">U.S. Department of Energy Proposes Expedited Approval for Small-Scale Natural Gas Exports</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">A proposed rule aims to provide faster approval of small-scale exports of natural gas, including liquefied natural gas (LNG), from export facilities.</div>
+                  </div>
+      </div>
+<div class="date">September 1, 2017</div>
+  </div>
+  
+    
+  
+  
+</div>
+<a href="/articles/us-department-energy-proposes-expedited-approval-small-scale-natural-gas-exports" class="view-more" title="Read more about &#039;U.S. Department of Energy Proposes Expedited Approval for Small-Scale Natural Gas Exports&#039;" aria-label="Read more about &#039;U.S. Department of Energy Proposes Expedited Approval for Small-Scale Natural Gas Exports&#039;">View Article</a></div>
+            </div>
+  </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading psp listing-horizontal psp listing listing-title-summary-image"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 classes="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading">ENERGY BLOG </h2>
+</div>
+                  </div>
+      </div>
+<div class="energy-listing-readmore field_para_energy_listing_ref-readmore"><a href="/listings/blog-archive" aria-label="View all related pages." title="View all related pages.">View All</a></div>  <div class="field field-name-field-para-energy-listing-ref field-type-entityreference field-label-hidden">
+            
+      <div class="field-items energy-listing">
+                    <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2816100 clearfix" about="/articles/solar-decathlon-3-stem-resources-teachers" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Solar Decathlon: 3 STEM Resources for Teachers" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/solar-decathlon-3-stem-resources-teachers" class="title-link" aria-label="Read more about &#039;Solar Decathlon: 3 STEM Resources for Teachers&#039;" title="Read more about &#039;Solar Decathlon: 3 STEM Resources for Teachers&#039;">Solar Decathlon: 3 STEM Resources for Teachers</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Solar Decathlon can serve as a teaching tool for educators interested in teaching science, engineering, technology and math â or STEM.</div>
+                  </div>
+      </div>
+<a href="/articles/solar-decathlon-3-stem-resources-teachers" class="more-link" aria-label="Learn More about &quot;Solar Decathlon: 3 STEM Resources for Teachers&quot;" title="Learn More about &quot;Solar Decathlon: 3 STEM Resources for Teachers&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2788803 clearfix" about="/indianenergy/articles/doe-joins-american-indian-science-and-engineering-society-pledge-encourage" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="DOE Joins AISES Pledge to Encourage Natives in STEM" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/indianenergy/articles/doe-joins-american-indian-science-and-engineering-society-pledge-encourage" class="title-link" aria-label="Read more about &#039;DOE Joins AISES Pledge to Encourage Natives in STEM&#039;" title="Read more about &#039;DOE Joins AISES Pledge to Encourage Natives in STEM&#039;">DOE Joins AISES Pledge to Encourage Natives in STEM</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">DOE has joined AISES in its #PledgeNativesInSTEM campaign, an effort to raise awareness and facilitate dialogue on the importance of STEM for natives.</div>
+                  </div>
+      </div>
+<a href="/indianenergy/articles/doe-joins-american-indian-science-and-engineering-society-pledge-encourage" class="more-link" aria-label="Learn More about &quot;DOE Joins AISES Pledge to Encourage Natives in STEM&quot;" title="Learn More about &quot;DOE Joins AISES Pledge to Encourage Natives in STEM&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2788173 clearfix" about="/articles/nuclear-heart-cassini" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="The Nuclear Heart of Cassini" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/nuclear-heart-cassini" class="title-link" aria-label="Read more about &#039;The Nuclear Heart of Cassini&#039;" title="Read more about &#039;The Nuclear Heart of Cassini&#039;">The Nuclear Heart of Cassini</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">A farewell tribute to NASA&#039;s Cassini spacecraft, which was powered by plutonium from the Department of Energy.</div>
+                  </div>
+      </div>
+<a href="/articles/nuclear-heart-cassini" class="more-link" aria-label="Learn More about &quot;The Nuclear Heart of Cassini&quot;" title="Learn More about &quot;The Nuclear Heart of Cassini&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2788041 clearfix" about="/articles/working-together-restore-power-after-hurricane-irma" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Restoring Power After Irma" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/working-together-restore-power-after-hurricane-irma" class="title-link" aria-label="Read more about &#039;Restoring Power After Irma&#039;" title="Read more about &#039;Restoring Power After Irma&#039;">Restoring Power After Irma</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">The Department of Energy came together with public and private sector partners to respond and rebuild in the wake of Hurricane Irma.</div>
+                  </div>
+      </div>
+<a href="/articles/working-together-restore-power-after-hurricane-irma" class="more-link" aria-label="Learn More about &quot;Restoring Power After Irma&quot;" title="Learn More about &quot;Restoring Power After Irma&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2731185 clearfix" about="/articles/secretary-perry-statement-womens-equality-day" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Women&#039;s Equality Day" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/secretary-perry-statement-womens-equality-day" class="title-link" aria-label="Read more about &#039;Women&amp;#039;s Equality Day&#039;" title="Read more about &#039;Women&amp;#039;s Equality Day&#039;">Women&#039;s Equality Day</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Secretary Perry&#039;s statement on Womenâs Equality Day, Aug. 26, 2017, marking the 97th anniversary of the 19th Amendment securing womenâs right to vote.</div>
+                  </div>
+      </div>
+<a href="/articles/secretary-perry-statement-womens-equality-day" class="more-link" aria-label="Learn More about &quot;Women&#039;s Equality Day&quot;" title="Learn More about &quot;Women&#039;s Equality Day&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2714185 clearfix" about="/articles/throwing-shade-3-things-know-about-solar-eclipse" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Throwing Shade: 3 Things to Know About the Solar Eclipse" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/throwing-shade-3-things-know-about-solar-eclipse" class="title-link" aria-label="Read more about &#039;Throwing Shade: 3 Things to Know About the Solar Eclipse&#039;" title="Read more about &#039;Throwing Shade: 3 Things to Know About the Solar Eclipse&#039;">Throwing Shade: 3 Things to Know About the Solar Eclipse</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Solar eclipse mania is sweeping across America and for good reason. Here are a few things to keep in mind as the big day approaches. </div>
+                  </div>
+      </div>
+<a href="/articles/throwing-shade-3-things-know-about-solar-eclipse" class="more-link" aria-label="Learn More about &quot;Throwing Shade: 3 Things to Know About the Solar Eclipse&quot;" title="Learn More about &quot;Throwing Shade: 3 Things to Know About the Solar Eclipse&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-908796 clearfix" about="/eere/wind/articles/top-10-things-you-didn-t-know-about-offshore-wind-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Top 10 Things You Didnât Know About Offshore Wind Energy " class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-offshore-wind-energy" class="title-link" aria-label="Read more about &#039;Top 10 Things You Didnât Know About Offshore Wind Energy &#039;" title="Read more about &#039;Top 10 Things You Didnât Know About Offshore Wind Energy &#039;">Top 10 Things You Didnât Know About Offshore Wind Energy </a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Learn more about efforts to develop America&#039;s vast offshore wind resources. </div>
+                  </div>
+      </div>
+<a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-offshore-wind-energy" class="more-link" aria-label="Learn More about &quot;Top 10 Things You Didnât Know About Offshore Wind Energy &quot;" title="Learn More about &quot;Top 10 Things You Didnât Know About Offshore Wind Energy &quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-714436 clearfix" about="/eere/wind/articles/top-10-things-you-didn-t-know-about-distributed-wind-power" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Top 10 Things You Didnât Know About Distributed Wind Power" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-distributed-wind-power" class="title-link" aria-label="Read more about &#039;Top 10 Things You Didnât Know About Distributed Wind Power&#039;" title="Read more about &#039;Top 10 Things You Didnât Know About Distributed Wind Power&#039;">Top 10 Things You Didnât Know About Distributed Wind Power</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Learn about key facts related to wind turbines used in distributed applications. </div>
+                  </div>
+      </div>
+<a href="/eere/wind/articles/top-10-things-you-didn-t-know-about-distributed-wind-power" class="more-link" aria-label="Learn More about &quot;Top 10 Things You Didnât Know About Distributed Wind Power&quot;" title="Learn More about &quot;Top 10 Things You Didnât Know About Distributed Wind Power&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2696966 clearfix" about="/articles/5-things-you-should-know-about-wind-energy" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="5 Things You Should Know About Wind Energy" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/5-things-you-should-know-about-wind-energy" class="title-link" aria-label="Read more about &#039;5 Things You Should Know About Wind Energy&#039;" title="Read more about &#039;5 Things You Should Know About Wind Energy&#039;">5 Things You Should Know About Wind Energy</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">From utility-scale wind farms to the nationâs first offshore wind project, the U.S. wind industry continued to grow in 2016.</div>
+                  </div>
+      </div>
+<a href="/articles/5-things-you-should-know-about-wind-energy" class="more-link" aria-label="Learn More about &quot;5 Things You Should Know About Wind Energy&quot;" title="Learn More about &quot;5 Things You Should Know About Wind Energy&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-383293 clearfix" about="/eere/wind/articles/top-10-things-you-didnt-know-about-wind-power" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Top 10 Things You Didn&#039;t Know About Wind Power" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/eere/wind/articles/top-10-things-you-didnt-know-about-wind-power" class="title-link" aria-label="Read more about &#039;Top 10 Things You Didn&amp;#039;t Know About Wind Power&#039;" title="Read more about &#039;Top 10 Things You Didn&amp;#039;t Know About Wind Power&#039;">Top 10 Things You Didn&#039;t Know About Wind Power</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Get the details on a few of the lesser known wind energy facts.</div>
+                  </div>
+      </div>
+<a href="/eere/wind/articles/top-10-things-you-didnt-know-about-wind-power" class="more-link" aria-label="Learn More about &quot;Top 10 Things You Didn&#039;t Know About Wind Power&quot;" title="Learn More about &quot;Top 10 Things You Didn&#039;t Know About Wind Power&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+            </div>
+  </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-multi-column psp emphasis-right"  about="" typeof="">
+  
+    <div class="content" >
+    
+<div class="paragraphs-items paragraphs-items-field-para-energy-layout-col1 paragraphs-items-field-para-energy-layout-col1-full paragraphs-items-full">
+    <div class="field field-name-field-para-energy-layout-col1 field-type-paragraphs field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-heading psp section-heading"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 id="A-Shot-in-the-Dark" classes="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-heading psp section-heading"><a href="/darkmatter">Direct Current: An Energy.gov Podcast</a></h2>
+</div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-rich-text"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-rich-text field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><p>An unknown, invisibleâ¦ somethingâ¦ Itâs one of the most staggering scientific puzzles in the history of human knowledge. A mystery that goes back to the very birth of our universe. Luckily, our detective-producers are on the case.</p></div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+<div class="paragraphs-items paragraphs-items-field-para-energy-layout-col2 paragraphs-items-field-para-energy-layout-col2-full paragraphs-items-full">
+    <div class="field field-name-field-para-energy-layout-col2 field-type-paragraphs field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-paragraphs-sp-image caption"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-img field-type-image field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><a href="/darkmatter"><img class="borealis image-style-photo_gallery_large borealis-js" data-borealis-respondsmall="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondsmall/public/2017/09/f36/ShotintheDark-homepage.png?itok=6GoEjDGD" data-borealis-respondmedium="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondmedium/public/2017/09/f36/ShotintheDark-homepage.png?itok=vmSDe1Yp" data-borealis-respondlarge="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondlarge/public/2017/09/f36/ShotintheDark-homepage.png?itok=5lNiulrt" data-borealis-respondxl="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl/public/2017/09/f36/ShotintheDark-homepage.png?itok=YfZTRRn9" data-borealis-respondxl2="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl2/public/2017/09/f36/ShotintheDark-homepage.png?itok=Fy_a6p1b" data-borealis-respondxl3="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl3/public/2017/09/f36/ShotintheDark-homepage.png?itok=0SmBsIYY" data-borealis-respondxl4="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondxl4/public/2017/09/f36/ShotintheDark-homepage.png?itok=C8HTTBLW" typeof="foaf:Image" src="https://energy.gov/sites/prod/files/styles/borealis_photo_gallery_large_respondsmall/public/2017/09/f36/ShotintheDark-homepage.png?itok=6GoEjDGD" alt="A Shot In The Dark home page"/></a></div>
+                  </div>
+      </div>
+
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item even">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading psp listing-vertical psp listing listing-title-summary-image-date"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-para-sp-heading field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><h2 classes="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-listing-ref psp section-heading">#WomeninSTEM</h2>
+</div>
+                  </div>
+      </div>
+<div class="energy-listing-readmore field_para_energy_listing_ref-readmore"><a href="/listings/womeninstem-blog" aria-label="View all related pages." title="View all related pages.">View All</a></div>  <div class="field field-name-field-para-energy-listing-ref field-type-entityreference field-label-hidden">
+            
+      <div class="field-items energy-listing">
+                  <div class="energy-listing-column">
+                <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2404268 clearfix" about="/articles/five-fast-facts-about-nora-stanton-blatch-barney" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts about Nora Stanton Blatch Barney" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-nora-stanton-blatch-barney" class="title-link" aria-label="Read more about &#039;Five Fast Facts about Nora Stanton Blatch Barney&#039;" title="Read more about &#039;Five Fast Facts about Nora Stanton Blatch Barney&#039;">Five Fast Facts about Nora Stanton Blatch Barney</a>  <div class="field field-name-field-summary field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">Nora Stanton Blatch Barney was the first American woman to become a civil engineer in 1905 and granddaughter of a womenâs rights icon.</div>
+                  </div>
+      </div>
+<div class="date">March 30, 2017</div><a href="/articles/five-fast-facts-about-nora-stanton-blatch-barney" class="more-link" aria-label="Learn More about &quot;Five Fast Facts about Nora Stanton Blatch Barney&quot;" title="Learn More about &quot;Five Fast Facts about Nora Stanton Blatch Barney&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2386276 clearfix" about="/articles/five-fast-facts-about-dr-ruby-hirose" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts about Dr. Ruby Hirose" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-dr-ruby-hirose" class="title-link" aria-label="Read more about &#039;Five Fast Facts about Dr. Ruby Hirose&#039;" title="Read more about &#039;Five Fast Facts about Dr. Ruby Hirose&#039;">Five Fast Facts about Dr. Ruby Hirose</a><div class="date">March 23, 2017</div><p>Dr. Ruby Hirose was a Japanese-American researcher whose research helped lead to vaccines against polio and other diseases.
+</p><a href="/articles/five-fast-facts-about-dr-ruby-hirose" class="more-link" aria-label="Learn More about &quot;Five Fast Facts about Dr. Ruby Hirose&quot;" title="Learn More about &quot;Five Fast Facts about Dr. Ruby Hirose&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+              </div>
+                        <div class="energy-listing-column">
+                <div class="field-item energy-listing-item odd"><div class="node node-article image-background image-background-large-2367988 clearfix" about="/articles/five-fast-facts-about-barbara-mcclintock" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts About Barbara McClintock" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-barbara-mcclintock" class="title-link" aria-label="Read more about &#039;Five Fast Facts About Barbara McClintock&#039;" title="Read more about &#039;Five Fast Facts About Barbara McClintock&#039;">Five Fast Facts About Barbara McClintock</a><div class="date">March 16, 2017</div><p>Barbara McClintock was a pioneer in the field of cytogenetics, the study of the structure and function of cells.
+</p><a href="/articles/five-fast-facts-about-barbara-mcclintock" class="more-link" aria-label="Learn More about &quot;Five Fast Facts About Barbara McClintock&quot;" title="Learn More about &quot;Five Fast Facts About Barbara McClintock&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+                          <div class="field-item energy-listing-item even"><div class="node node-article image-background image-background-large-2366716 clearfix" about="/articles/five-fast-facts-about-evelyn-boyd-granville" typeof="sioc:Item foaf:Document">
+      
+  
+    <div class="background-container image-background"></div>
+    <span property="dc:title" content="Five Fast Facts About Evelyn Boyd Granville" class="rdf-meta element-hidden"></span>
+  
+      
+    <div class="content">
+        
+    
+    <a href="/articles/five-fast-facts-about-evelyn-boyd-granville" class="title-link" aria-label="Read more about &#039;Five Fast Facts About Evelyn Boyd Granville&#039;" title="Read more about &#039;Five Fast Facts About Evelyn Boyd Granville&#039;">Five Fast Facts About Evelyn Boyd Granville</a><div class="date">March 9, 2017</div><p>Dr. Evelyn Boyd Granville was the second African-American woman to earn a Ph.D. in mathematics and worked on early U.S. space missions.
+</p><a href="/articles/five-fast-facts-about-evelyn-boyd-granville" class="more-link" aria-label="Learn More about &quot;Five Fast Facts About Evelyn Boyd Granville&quot;" title="Learn More about &quot;Five Fast Facts About Evelyn Boyd Granville&quot;">Learn More</a>
+  </div>
+  
+    
+  
+  
+</div>
+</div>
+              </div>
+            </div>
+  </div>
+
+  </div>
+  
+</div>
+
+</div>
+                                <div class="field-item odd">
+<div class="entity entity-paragraphs-item paragraphs-item-energy-paragraphs-youtube psp align-center-full caption"  about="" typeof="">
+  
+    <div class="content" >
+      <div class="field field-name-field-energy-youtube-browser field-type-file field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd"><div id="file-1140641" class="file file-video file-video-youtube" >
+
+    
+  
+    
+      
+    <div class="content">
+    
+    <div class="energy-paragraphs-youtube-video youtube-player-6cbaf3815af0c0a90e3b80432ae401d4">
+  <div class="youtube-player" data-id="6njUXBi3HtE"><span class="youtube-title">U.S. Department of Energy: Science for the People</span></div>
+</div>
+
+  </div>
+  
+  
+
+</div>
+</div>
+                  </div>
+      </div>
+<div class="field-group-format group_psp_caption field-group-div group-psp-caption psp-caption speed-fast effect-none">  <div class="field field-name-field-energy-youtube-caption field-type-text-long field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">The challenges that face us now in energy, science, and nuclear security won't wait.Â </div>
+                  </div>
+      </div>
+  <div class="field field-name-field-energy-youtube-attribution field-type-text field-label-hidden">
+            
+        <div class="field-items">
+                        <div class="field-item odd">U.S. Department of Energy</div>
+                  </div>
+      </div>
+</div>
+  </div>
+  
+</div>
+
+</div>
+                  </div>
+      </div>
+</div>
+
+  </div>
+  
+    
+  
+  
+</div>
+
+    </div>
+    
+  </div>
+
+  </div>
+
+
+        </div>
+        
+        <div id="content-bottom">
+          
+        </div>
+      </div>
+
+    </div>
+      </div>
+  
+    <footer id="footer">
+        <div id="footer-admin">
+      
+    </div>
+    
+    <div class="footer-top">
+      <div class="footer-inner">
+        <div class="footer-inner-left">
+              <div id="footer-info" class="footer-primary">
+      <div class="region region-footer-info">
+    
+
+  <div id="block-energy-core-site-name--2" class="block block-energy-core block-site-name block-site-name">
+
+        
+        
+    
+    
+
+<div class="site-name"><a href="/" class="active"><img src="/sites/all/themes/clean_energy/images/logo_footer_white.png" alt="Department of Energy" /></a></div>
+
+
+
+
+
+  </div>
+
+
+
+  <div id="block-energy-core-footer-contact-info" class="block block-energy-core block-footer-contact-info">
+
+        
+        
+    
+        <div class="content">
+      <div class="contact-info">
+  <div class="office-name"></div><p>1000 Independence Ave. SW<br>Washington DC 20585<br>202-586-5000</p>
+</div>
+
+    </div>
+    
+  </div>
+
+
+
+  <div id="block-energy-social-energy-social-email-signup" class="block block-energy-social block-energy-social-email-signup">
+
+        
+        
+    
+        <div class="content">
+      <div class="mc_embed_signup_wrapper"><a href="/exit?url=http%3A//energy.us5.list-manage.com/subscribe/post%3Fu%3Dd8fbb7a1814155cc38f24adeb%26id%3Da6805280ba">Sign Up for Email Updates</a></div>
+    </div>
+    
+  </div>
+
+
+
+  <div id="block-energy-social-energy-gov-social-block" class="block block-energy-social block-energy-gov-social-block">
+
+        
+        
+    
+        <div class="content">
+      <div class="energy-social-widget ">
+<div class="item-list"><ul><li class="first"><a href="/exit?url=https%3A//www.facebook.com/energygov" class="energy-social-link energy-social-link-facebook"><i class="icon-facebook"></i><span class="element-invisible">Link to facebook</span></a></li>
+<li><a href="/exit?url=https%3A//twitter.com/energy" class="energy-social-link energy-social-link-twitter"><i class="icon-twitter"></i><span class="element-invisible">Link to twitter</span></a></li>
+<li><a href="/exit?url=https%3A//www.youtube.com/user/USdepartmentofenergy" class="energy-social-link energy-social-link-youtube"><i class="icon-youtube"></i><span class="element-invisible">Link to youtube</span></a></li>
+<li><a href="/exit?url=https%3A//www.instagram.com/energy" class="energy-social-link energy-social-link-instagram"><i class="icon-instagram"></i><span class="element-invisible">Link to instagram</span></a></li>
+<li class="last"><a href="/exit?url=https%3A//www.linkedin.com/company-beta/5556" class="energy-social-link energy-social-link-linkedin"><i class="icon-linkedin"></i><span class="element-invisible">Link to linkedin</span></a></li>
+</ul></div>
+</div>
+    </div>
+    
+  </div>
+
+  </div>
+
+  </div>
+              <div id="footer-nav" class="footer-primary">
+      <div class="region region-footer-nav">
+    
+
+  <div id="block-energy-core-footer-main-menu" class="block block-energy-core block-footer-main-menu">
+
+        
+        
+    
+        <div class="content">
+      
+<ul class="menu footer-secondary-menu">
+  <li class="first expanded">
+    <a href="/" class="active">About Energy.gov</a>
+    <ul class="menu"><li class="first leaf"><a href="/management/office-management/operational-management/history">History</a></li>
+<li class="leaf"><a href="/leadership">Leadership</a></li>
+<li class="leaf"><a href="/news-blog">News</a></li>
+<li class="leaf"><a href="/science-innovation/stem">Science Education</a></li>
+<li class="leaf"><a href="/jobs/jobs">Work with Us</a></li>
+<li class="leaf"><a href="/jobs/jobs">Careers &amp; Internships</a></li>
+<li class="last leaf"><a href="/contact-us">Contact Us</a></li>
+</ul>
+  </li>
+</ul>
+
+    </div>
+    
+  </div>
+
+  </div>
+
+  </div>
+        </div>
+            <div id="footer-legal" class="footer-primary">
+      <div class="region region-footer-legal">
+    
+
+  <div id="block-menu-menu-footer-secondary-menu" class="block block-menu block-menu-footer-secondary-menu">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first expanded"><a href="/" class="active">Energy.gov Resources</a><ul class="menu"><li class="first leaf"><a href="/budget-performance">Budget &amp; Performance</a></li>
+<li class="leaf"><a href="https://www.directives.doe.gov">Directives, Delegations &amp; Requirements</a></li>
+<li class="leaf"><a href="/management/office-management/operational-management/freedom-information-act">FOIA</a></li>
+<li class="leaf"><a href="/ig/office-inspector-general">Inspector General</a></li>
+<li class="leaf"><a href="/cio/office-chief-information-officer/services/guidance/privacy-program">Privacy Program</a></li>
+<li class="leaf"><a href="/osdbu/office-small-and-disadvantaged-business-utilization">Small Business</a></li>
+<li class="last leaf"><a href="/about-us/staff-and-contractors">Staff &amp; Contractor Resources</a></li>
+</ul></li>
+<li class="last expanded"><a href="/" class="active">Federal Government</a><ul class="menu"><li class="first leaf"><a href="http://www.whitehouse.gov">The White House</a></li>
+<li class="last leaf"><a href="http://www.usa.gov">USA.gov</a></li>
+</ul></li>
+</ul>
+    </div>
+    
+  </div>
+
+  </div>
+
+  </div>
+      </div>
+    </div>
+
+    <div class="footer-bottom">
+      <div class="footer-inner">
+                <div id="footer-utility">
+            <div class="region region-footer-utility">
+    
+
+  <div id="block-menu-menu-footer-utility" class="block block-menu block-menu-footer-utility">
+
+        
+        
+    
+        <div class="content">
+      <ul class="menu"><li class="first leaf"><a href="/about-us/web-policies">Web Policies</a></li>
+<li class="leaf"><a href="/about-us/web-policies/privacy">Privacy</a></li>
+<li class="leaf"><a href="/diversity/services/protecting-civil-rights/no-fear-act">No Fear Act</a></li>
+<li class="leaf"><a href="https://www.osc.gov/Pages/DOW.aspx">Whistleblower Protection</a></li>
+<li class="leaf"><a href="/cio/department-energy-information-quality-guidelines">Information Quality</a></li>
+<li class="leaf"><a href="/open-government">Open Gov</a></li>
+<li class="leaf"><a href="/cio/accessibility-standard-statement">Accessibility</a></li>
+<li class="last leaf"><a href="/data/open-energy-data-old">Data &amp; Developer Tools</a></li>
+</ul>
+    </div>
+    
+  </div>
+
+  </div>
+
+        </div>
+              </div>
+    </div>
+
+  </footer>
+  
+</div>
+
+    <script type="text/javascript" src="/sites/prod/files/advagg_js/js__cCLTChfB28X41VSzdhvWEOHRvLudHi0Jq-Yiy8WS4js__QHMdM4IajNxVPKUuieSV2WKLYOoPGPSQsh0o7nVlINg__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_mediaqueries.js?owz5mc"></script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__2fSLsqMXq9Tq836ak8GSps0-bN2MIXTAPbnPdTRaE2o__lJ5Iv3pIV9rQ9z9k8SyqldVnVEl6FA67UwOspHfVjoU__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_header.js?owz5mc"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_footer.js?owz5mc"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_overlay.js?owz5mc"></script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__KEmQaQ1AHW-FKByVITBadf_xsLxbmuthMs8Z1lWLy-E__IzyZtJVuXOU0zZqAh9XgHUc_fNUW6lHOX67KW4yeMuw__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"clean_energy","theme_token":"sjysCI8NWAvb0-cnfAzmA21dhJZVwQ3GRL4QF96o-SY","css":{"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.button.css":1,"misc\/ui\/jquery.ui.resizable.css":1,"misc\/ui\/jquery.ui.dialog.css":1,"modules\/system\/system.base.css":1,"modules\/system\/system.menus.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/date\/date_api\/date.css":1,"sites\/all\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"sites\/all\/modules\/custom\/energy_media\/sites\/all\/modules\/custom\/energy_media\/styles\/energy.media.css":1,"sites\/all\/modules\/contrib\/environment_indicator\/environment_indicator.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"modules\/search\/search.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/media\/modules\/media_wysiwyg\/css\/media_wysiwyg.base.css":1,"\/\/fast.fonts.com\/t\/1.css?apiType=css\u0026projectid=b893a4ff-9ea3-4ce8-bf77-c8d3e3a3de97":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/custom\/energy_admin\/css\/users_online.css":1,"sites\/all\/modules\/custom\/energy_content\/css\/energy_content_wysiwyg.css":1,"0":1,"1":1,"sites\/all\/modules\/custom\/energy_paragraphs\/modules\/energy_paragraphs_superpack_style\/src\/Plugin\/SuperpackProcessor\/css\/color.css":1,"2":1,"sites\/all\/libraries\/slick\/slick.css":1,"3":1,"4":1,"5":1,"6":1,"7":1,"8":1,"9":1,"10":1,"11":1,"12":1,"sites\/all\/modules\/contrib\/borealis\/borealis_ri\/css\/borealis-ri_images.css":1,"sites\/all\/modules\/contrib\/paragraphs_superpack\/modules\/paragraphs_superpack_style\/src\/Plugin\/SuperpackProcessor\/css\/style.css":1,"13":1,"14":1,"15":1,"sites\/all\/modules\/contrib\/wysiwyg_tools_plus\/css\/wysiwyg_tools_plus.css":1,"16":1,"sites\/all\/modules\/custom\/energy_paragraphs\/modules\/energy_paragraphs_youtube\/css\/energy_paragraphs_youtube.css":1,"sites\/all\/modules\/contrib\/field_group\/field_group.css":1,"sites\/all\/themes\/clean_energy\/style\/clean_energy.css":1},"js":{"sites\/all\/libraries\/slick\/slick.min.js":1,"sites\/all\/modules\/custom\/energy_content\/js\/jquery.dataTables.js":1,"sites\/all\/themes\/clean_energy\/scripts\/enquire\/enquire.min.js":1,"sites\/all\/modules\/custom\/energy_admin\/js\/users_online.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/event_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/related_content_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/breadcrumb_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/context_callout_tracking.js":1,"sites\/all\/modules\/custom\/energy_core\/js\/energy_ext_link_page.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_listings.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.8\/jquery.min.js":1,"misc\/jquery.once.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.button.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.mouse.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.draggable.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.position.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.resizable.min.js":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.dialog.min.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_mediaqueries.js":1,"sites\/all\/modules\/contrib\/environment_indicator\/tinycon.min.js":1,"sites\/all\/modules\/contrib\/environment_indicator\/environment_indicator.js":1,"sites\/all\/modules\/contrib\/environment_indicator\/color.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_header.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_footer.js":1,"sites\/all\/themes\/clean_energy\/scripts\/clean_energy_overlay.js":1,"sites\/all\/modules\/contrib\/ext_link_page\/ext_link_page.js":1,"sites\/all\/modules\/contrib\/image_caption\/image_caption.min.js":1,"sites\/all\/modules\/custom\/energy_social\/js\/eventTracking.js":1,"sites\/all\/modules\/contrib\/borealis\/borealis_ri\/js\/borealis_ri.js":1,"sites\/all\/modules\/contrib\/wysiwyg_tools_plus\/js\/tab_builder.js":1,"sites\/all\/modules\/custom\/energy_paragraphs\/modules\/energy_paragraphs_youtube\/js\/player.js":1,"misc\/form.js":1,"misc\/collapse.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1}},"energy_content":{"nid":"2791","base_url":"https:\/\/energy.gov"},"drupal_ga_accounts":["UA-17192165-1"],"energyCore":{"pageTitle":"Energy.gov"},"ext_link_page":{"pathLinkPage":"\/exit","messageTitle":"You are now leaving Energy.gov","messageBody":"\u003Cstrong\u003EYou will be automatically redirected to:\u003C\/strong\u003E\u003Cbr \/\u003E\n  [link]\u003Cbr \/\u003E\n  in [delay] seconds\u003Cspan class=\u0022ext-link-modal-message\u0022\u003E or you may click \u0022Continue to the Site\u0022\u003C\/span\u003E.\n","extLinkClass":"ext","directDisable":0,"delay":10,"siteName":"Department of Energy"},"urlIsAjaxTrusted":{"\/":true},"heroVertical":{"limitVertical":["961921","1155948","1154396","1153152","1151932"]},"borealis_ri":{"sizes":{"respondsmall":350,"respondmedium":525,"respondlarge":787.5,"respondxl":1181.25,"respondxl2":1771.875,"respondxl3":2657.8125,"respondxl4":3986.71875},"lazyload":false,"aspect_ratio":0.75},"energyParagraphsYoutube":[{"title":"U.S. Department of Energy: Science for the People","thumbnail_url":"https:\/\/i.ytimg.com\/vi\/6njUXBi3HtE\/hqdefault.jpg","data_id":"6njUXBi3HtE","start_time":null,"end_time":null,"fid":0,"md5hash":"6cbaf3815af0c0a90e3b80432ae401d4"}],"field_group":{"div":"full"},"ogContext":{"groupType":"taxonomy_term","gid":"31"}});
+//--><!]]>
+</script>
+
+    <script type="text/javascript" src="/sites/prod/files/advagg_js/js__g7YdHgS5VRw1P5w-qQZhr4w_jNMRiAulRmpRIZj9Tws__YQ8FpSPjSNUGlzHZG_V1-MuEelCwLiBM7yhcJ4b4bqk__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/enquire/enquire.min.js?owz5mc"></script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__1usYMFM4q12UFLhIqQ8IwGGbXx8HlZpStgfU-3zvslk__FSMCFO8o7mJG3kCrbCJ_i6cwLJfnX7SLLQI_vd2S4x4__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+
+var _gaq = _gaq || [];
+_gaq.push(
+  
+  ['_setAccount', 'UA-17192165-1'],
+  ['_trackPageview'],
+  ['_setDomainName', '.energy.gov']
+);
+(function() {
+  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+})();
+//--><!]]>
+</script>
+<script type="text/javascript" src="/sites/prod/files/advagg_js/js__TpZ0d-9GdeYsZGgpmUf71BeemkZXSm9n10iJCjMlqFM__d7PvNjqjzZ0lHiIG3IVa3FGzevl5ey2rwczqvDe1KjQ__dDIbt8ufYXrJppXQKKZmaOn8fGxqGHfBxUr-hMXyu-U.js"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+if (jQuery(".tablefield").length) { jQuery(".tablefield").dataTable(); }
+//--><!]]>
+</script>
+<script type="text/javascript" src="/sites/all/themes/clean_energy/scripts/clean_energy_listings.js?owz5mc"></script>
+
+  <script async type="text/javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOE"></script>
+  </body>
+</html>

--- a/web_monitoring/tests/fixtures/versions/f2d5d701-707a-42e0-8881-653346d01e0a
+++ b/web_monitoring/tests/fixtures/versions/f2d5d701-707a-42e0-8881-653346d01e0a
@@ -1,0 +1,412 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "//www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr">
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="//www.fema.gov/profiles/fema_gov/themes/unicorn/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="description" content="This is the main page for up-to-date resources and information on the federal response to Hurricane Maria.Follow the direction of state, local, and tribal officials. (Español) " />
+<link rel="canonical" href="//www.fema.gov/hurricane-maria" />
+<link rel="shortlink" href="//www.fema.gov/hurricane-maria" />
+  <title>Hurricane Maria | FEMA.gov</title>
+  <link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css__LeQxW73LSYscb1O__H6f-j_jdAzhZBaesGL19KEB6U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_2xIW1IpUWng78091LzPsPXymxLMidts3lbbb9KZibWE.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_g1h7Nl9-p95WQ-MsLSC6s6f4Ihg9aidwnpywdeKBAqQ.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_-w0pbrs7-nruEPQTSwXQ4_9HSkbl3qT-Ex7c5prUQs0.css" media="all" />
+<link href='//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800&subset=latin,cyrillic-ext,vietnamese,latin-ext,greek-ext,cyrillic' rel='stylesheet' type='text/css'>
+  <script language="javascript" type="text/javascript">
+    var ExpandAllSectionsText = "Expand All Sections";
+    var CollapseAllSectionsText = "Collapse All Sections";
+    var NoResultsFoundText = "";
+    var advancedSearchText = "Search for";
+    var NavigationPlaceholderText = "Start typing here to filter…";
+    var SearchPlaceholderText = "Search anything on fema.gov";
+    var closeText = "Close";
+    var downloadAppLabel = "Install the FEMA App";
+    var inThisSectionLabel = "In this Section";
+    var inThisSectionText = "In this Section";
+    var AppAuthSubText = "Remember to plug in your PIV/CAC card.";
+    var PivH2 = "PIV Card Login";
+    //MediaElement variables
+    var playButton = "Play.";
+    var progressBar = "Progress Bar.";
+    var closedCaptionButton = "Closed caption button.";
+    var volumeButton = "Volume button.";
+    var fullScreenButton = "Fullscreen button.";
+  </script>
+    <script src="//www.fema.gov/sites/default/files/js/js_lZ9kpQqrFO9iMOrWRPD2c5I8gI7-sX7TO_pTARrQEMU.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_THcwq4G882w3Eb1HklHrvzGAKa_-1g_0QbuBqjMhaV4.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_NpX2cwCeepkWZZ194B6-ViyVBHleaYLOx5R9EWBOMRU.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_Js4lOJ0_Am6ebnC0EP-psjO8Yu5gmlcOhu72hrxvi2s.js"></script>
+<script>window.CKEDITOR_BASEPATH = '/sites/all/libraries/ckeditor/'</script>
+<script src="//www.fema.gov/sites/default/files/js/js_gPqjYq7fqdMzw8-29XWQIVoDSWTmZCGy9OqaHppNxuQ.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.fema.gov/sites/default/files/googleanalytics/analytics.js?ox9uo3","ga");ga("create", "UA-29391347-1", {"cookieDomain":".fema.gov"});ga("set", "anonymizeIp", true);ga("send", "pageview");</script>
+<script src="//www.fema.gov/sites/default/files/js/js_x1Asg_paR91u1arDvF7gS_xR7fthnVj3L414MbNvdNU.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_7E18bMLOJVTzOcxdValVlyzHz_k7NhhgkX2FcSMA2HA.js"></script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"unicorn","theme_token":"_tXLLu-_5eEhIsoQGQ_MK5sESyWh7eFQxYu2BZ8-2zc","js":{"profiles\/fema_gov\/modules\/contrib\/extlink_extra\/extlink_extra.js":1,"profiles\/fema_gov\/themes\/bootstrap\/js\/bootstrap.js":1,"sites\/all\/modules\/jquery_update\/replace\/jquery\/1.9\/jquery.min.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/jquery_update\/replace\/ui\/external\/jquery.cookie.js":1,"sites\/all\/modules\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"sites\/all\/modules\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/fema_gov\/modules\/contrib\/extlink\/extlink.js":1,"profiles\/fema_gov\/libraries\/colorbox\/jquery.colorbox-min.js":1,"sites\/all\/modules\/colorbox\/js\/colorbox.js":1,"sites\/all\/modules\/colorbox\/styles\/default\/colorbox_style.js":1,"sites\/all\/modules\/colorbox\/js\/colorbox_load.js":1,"sites\/all\/modules\/colorbox\/js\/colorbox_inline.js":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/js\/wcm_survey.js":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/js\/json3.min.js":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/js\/jquery.cookie.js":1,"0":1,"sites\/all\/modules\/google_analytics\/googleanalytics.js":1,"1":1,"profiles\/fema_gov\/themes\/unicorn\/js\/mediaelement\/build\/mediaelement-and-player.min.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_mediaelement_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_image_rotator.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/affix.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/alert.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/button.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/carousel.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/collapse.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/dropdown.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/modal.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/tooltip.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/popover.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/scrollspy.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/tab.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/transition.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_content_collapse.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_nav_filter.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_site_wide_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_social_images.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_download_app.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/tablesorter.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_tables.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/stacktable.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_mobile_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/left_menu_collapse.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_is_useful_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/jquery.dataTables.min.js":1},"css":{"modules\/system\/system.base.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"profiles\/fema_gov\/modules\/features\/fema_diamond\/fema_diamond.css":1,"sites\/all\/modules\/date\/date_api\/date.css":1,"sites\/all\/modules\/date\/date_popup\/themes\/datepicker.1.7.css":1,"sites\/all\/modules\/date\/date_repeat_field\/date_repeat_field.css":1,"profiles\/fema_gov\/modules\/custom\/diamond\/diamond.css":1,"profiles\/fema_gov\/modules\/custom\/fema_faq\/css\/fema_faq.css":1,"modules\/field\/theme\/field.css":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/wcm_survey.css":1,"profiles\/fema_gov\/modules\/custom\/workbench_notification\/workbench_notification.css":1,"profiles\/fema_gov\/modules\/custom\/diamond\/diamond_medialibrary\/diamond_medialibrary.css":1,"profiles\/fema_gov\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/views\/css\/views.css":1,"sites\/all\/modules\/colorbox\/styles\/default\/colorbox_style.css":1,"sites\/all\/modules\/ctools\/css\/ctools.css":1,"profiles\/fema_gov\/modules\/contrib\/extlink_extra\/extlink_extra.508.css":1,"profiles\/fema_gov\/themes\/unicorn\/js\/mediaelement\/build\/mediaelementplayer.css":1,"profiles\/fema_gov\/themes\/unicorn\/css\/style.css":1,"profiles\/fema_gov\/themes\/unicorn\/css\/jquery.dataTables.min.css":1}},"colorbox":{"opacity":"0.85","current":"{current} of {total}","previous":"\u00ab Prev","next":"Next \u00bb","close":"Close","maxWidth":"98%","maxHeight":"98%","fixed":true,"mobiledetect":true,"mobiledevicewidth":"480px"},"wcmSurvey":{"userPercentage":"25","pageDepth":"4","url":"\/\/www.surveymonkey.com\/s\/FEMAgov","force":false,"surveyRetakeTimeout":"90","surveyPopup":"\u003Cdiv id=\u0022wcm-survey-popup\u0022 class=\u0022unicorn\u0022\u003E\n  \u003Cdiv class=\u0022logo\u0022\u003E\n    \u003Cimg alt=\u0022Federal Emergency Management Agency Seal\u0022 src=\u0022\/\/www.fema.gov\/sites\/default\/files\/images\/fema_surveypopup.png\u0022\/\u003E\n  \u003C\/div\u003E\n  \u003Cdiv class=\u0022message\u0022\u003E\n    \u003Cp\u003EYou have been selected to participate in a brief survey about your experience today with FEMA.gov.\u003C\/p\u003E  \u003C\/div\u003E\n  \u003Cdiv class=\u0022choices\u0022\u003E\n    \u003Cspan class=\u0022button yes\u0022\u003E\u003Ca title=\u0022Yes, I\u0027ll give feedback\u0022 href=\u0022\/\/www.surveymonkey.com\/s\/FEMAgov\u0022 class=\u0022accept\u0022 target=\u0022_blank\u0022 id=\u0022external_link\u0022\u003EYes, I\u0027ll give feedback\u003C\/a\u003E\u003C\/span\u003E\n    \u003Cspan class=\u0022button no\u0022\u003E\u003Ca title=\u0022No Thanks, I do not want to give feedback\u0022 href=\u0022#\u0022 class=\u0022decline\u0022\u003ENo, thanks\u003C\/a\u003E\u003C\/span\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E\n","debugMode":1,"position":"top","offset":"65px","height":"250px","width":"631px","maxHeight":"75%","maxWidth":"75%"},"diamondMedialibrary":{"path":"media-library"},"extlink":{"extTarget":0,"extClass":0,"extLabel":"(link is external)","extImgClass":0,"extSubdomains":1,"extExclude":"(.*\\.gov)|(.*\\.mil)|(\\.addthis.com)|(.*\\.fema.net)|(s3-us-gov-west-1\\.amazonaws\\.com)|(surveymonkey\\.com)","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":{"value":"You are now leaving an official website of the Federal Emergency Management Agency. Links to non-FEMA sites are provided for the visitor\u0027s convenience and do not represent an endorsement by FEMA of any commercial or private issues, products or services. Note that the privacy policy of the linked site may differ from that of FEMA.","format":"untouched_html"},"mailtoClass":0,"mailtoLabel":"(link sends e-mail)"},"extlink_extra":{"extlink_alert_type":"confirm","extlink_alert_timer":"0","extlink_alert_url":"\/now-leaving","extlink_cache_fix":0,"extlink_exclude_warning":"","extlink_508_fix":1,"extlink_508_text":" [external link]","extlink_url_override":0,"extlink_url_params":{"external_url":null,"back_url":null}},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m)?|xml|z|zip","trackColorbox":1,"trackDomainMode":"1"},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+  <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEMA" id="_fed_an_ua_tag"></script>
+<!--[if lt IE 9]>
+	  <link rel="stylesheet" href="/profiles/fema_gov/themes/unicorn/css/ie8.css">
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in one-sidebar sidebar-first page-node page-node- page-node-315781 node-type-site-page i18n-en unicorn" >
+<div id="skip-link">
+  <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+</div>
+
+
+
+<!-- this holds the mobile nag in desktop view -->
+<div id="dialog-download-app"></div>
+
+<div class="main-container container">
+  <div class="dg-bg"></div>
+  <div class="block-left">
+    <div class="global-nav-wrapper">
+      <div class="logo">
+
+                <a class="logo" href="/"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/fema-logo-main.png" alt="US Department of Homeland Security - Federal Emergency Management Agency" lang="en" /></a>
+      </div><!-- .logo -->
+
+      <div class="global-nav">
+
+        <!-- Global Navigation -->
+        <div type="" class="global-nav-modal" data-toggle="modal" data-target="#navigation" tabindex="0">
+          Navigation        </div>
+
+        <div class="modal fade" id="navigation" tabindex="-1" role="dialog" aria-labelledby="navigationLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                  <span aria-hidden="true"><div class="close-icon">&times;</div></span>
+                  <div class="close-text">Close</div>
+                </button>
+                <div class="modal-title" id="navigationLabel">Navigation</div>
+                <label for="unicornNavSearchBox">Enter Search Term(s):</label>
+                <input placeholder="Start typing here to filter…" id="unicornNavSearchBox" type="text" size="31" />
+              </div><!-- .modal-header -->
+              <div class="modal-body">
+                <div id="navigationItems">
+                  <div id="noResults"> </div>
+                  <ul id="unicornNavFilter"><li class="first collapsed"><a href="/about-agency">About the Agency</a></li>
+<li class="leaf"><a href="/volunteer-donate-responsibly">Volunteer &amp; Donate Responsibly</a></li>
+<li class="collapsed"><a href="/apply-assistance">Apply for Assistance</a></li>
+<li class="collapsed"><a href="/welcome-assistance-firefighters-grant-program" title="Assistance To Firefighters Grant Program">Assistance To Firefighters Grant Program</a></li>
+<li class="leaf"><a href="/authorized-equipment-list" title="">Authorized Equipment List</a></li>
+<li class="collapsed"><a href="/blog">Blog</a></li>
+<li class="leaf"><a href="https://careers.fema.gov" title="">Careers</a></li>
+<li class="collapsed"><a href="/faith">Center for Faith-Based &amp; Neighborhood Partnerships</a></li>
+<li class="leaf"><a href="/children-and-disasters">Children and Disasters</a></li>
+<li class="leaf"><a href="/climate-change">Climate Change</a></li>
+<li class="collapsed"><a href="/community-resilience-indicators">Community Resilience Indicators and National-Level Measures: A Draft Interagency Concept</a></li>
+<li class="collapsed"><a href="/contact-us">Contact Us</a></li>
+<li class="collapsed"><a href="/dam-safety">Dam Safety</a></li>
+<li class="collapsed"><a href="/data-visualization">Data Visualization</a></li>
+<li class="collapsed"><a href="/disability" title="">Disability</a></li>
+<li class="collapsed"><a href="/disaster-assistance-reports">Disaster Assistance Reports</a></li>
+<li class="collapsed"><a href="/disasters" title="">Disaster Declarations</a></li>
+<li class="collapsed"><a href="/disaster-emergency-communications">Disaster Emergency Communications</a></li>
+<li class="leaf"><a href="/disaster-recovery-centers">Disaster Recovery Centers</a></li>
+<li class="leaf"><a href="/media-library/resources-documents" title="">Document and Resource Library</a></li>
+<li class="collapsed"><a href="/email">Email Updates</a></li>
+<li class="leaf"><a href="/emergency-management-agencies">Emergency Management Agencies</a></li>
+<li class="leaf"><a href="//training.fema.gov/emi" title="">Emergency Management Institute</a></li>
+<li class="leaf"><a href="/el-nino" title="">El Niño</a></li>
+<li class="collapsed"><a href="/office-environmental-planning-and-historic-preservation">Environmental Planning and Historic Preservation Program</a></li>
+<li class="collapsed"><a href="/ned">Exercise</a></li>
+<li class="leaf"><a href="/fact-sheets">Fact Sheets</a></li>
+<li class="collapsed"><a href="/finance-center">Finance Center</a></li>
+<li class="collapsed"><a href="/national-flood-insurance-program-flood-hazard-mapping">Flood Hazard Mapping</a></li>
+<li class="collapsed"><a href="/national-flood-insurance-program">Flood Insurance</a></li>
+<li class="leaf"><a href="//msc.fema.gov/portal/" title="">Flood Map Service Center</a></li>
+<li class="leaf"><a href="/faq/" title="">Frequently Asked Questions (FAQs)</a></li>
+<li class="collapsed"><a href="/grants" title="Grants">Grants</a></li>
+<li class="collapsed"><a href="/grants-management-modernization-program">Grants Management Modernization Program</a></li>
+<li class="collapsed"><a href="/hazard-mitigation-assistance">Hazard Mitigation Assistance</a></li>
+<li class="collapsed"><a href="/hazard-mitigation-planning">Hazard Mitigation Planning</a></li>
+<li class="collapsed"><a href="/hazus">Hazus</a></li>
+<li class="collapsed"><a href="/high-water-mark-initiative">High Water Mark Initiative</a></li>
+<li class="leaf"><a href="https://www.fema.gov" title="">Home</a></li>
+<li class="leaf"><a href="/how-make-payment-fema" title="">How to Make a Payment to FEMA</a></li>
+<li class="collapsed"><a href="/hurricane-harvey">Hurricane Harvey</a></li>
+<li class="collapsed"><a href="/hurricane-irma">Hurricane Irma</a></li>
+<li class="collapsed"><a href="/hurricane-maria" class="active">Hurricane Maria</a></li>
+<li class="collapsed"><a href="/hurricane-katrina-decade-progress-through-partnerships">Hurricane Katrina</a></li>
+<li class="leaf"><a href="/incident-management-assistance-teams" title="">Incident  Management Assistance Teams</a></li>
+<li class="leaf"><a href="https://training.fema.gov/is/" title="">Independent Study Program</a></li>
+<li class="leaf"><a href="/individual-and-community-preparedness-division">Individual and Community Preparedness Division</a></li>
+<li class="collapsed"><a href="/individual-assistance-program-tools">Individual Assistance Program Tools</a></li>
+<li class="collapsed"><a href="/individual-disaster-assistance">Individual Disaster Assistance</a></li>
+<li class="collapsed"><a href="/integrated-public-alert-warning-system">Integrated Public Alert &amp; Warning System</a></li>
+<li class="collapsed"><a href="/international-affairs">International Affairs</a></li>
+<li class="collapsed"><a href="/mobile-app">Mobile App</a></li>
+<li class="collapsed"><a href="/mississippi-recovery-office" title="">Mississippi Recovery</a></li>
+<li class="leaf"><a href="/media-library/multimedia/list" title="">Multimedia Library (Photos, Video, and Audio)</a></li>
+<li class="collapsed"><a href="/national-exercise-program">National Exercise Program</a></li>
+<li class="collapsed"><a href="/national-continuity-programs">National Continuity Programs</a></li>
+<li class="collapsed"><a href="/national-disaster-recovery-framework">National Disaster Recovery Framework</a></li>
+<li class="collapsed"><a href="/national-incident-management-system">National Incident Management System</a></li>
+<li class="collapsed"><a href="/national-preparedness">National Preparedness</a></li>
+<li class="leaf"><a href="/media-contacts">News Desk Contacts</a></li>
+<li class="collapsed"><a href="/news-releases" title="">News Releases</a></li>
+<li class="leaf"><a href="/official-accounts">Official Accounts</a></li>
+<li class="collapsed"><a href="/openfema">OpenFEMA</a></li>
+<li class="leaf"><a href="/preliminary-damage-assessment-reports" title="Preliminary Damage Assessments Reports">Preliminary Damage Assessment Reports</a></li>
+<li class="collapsed"><a href="/preparedness-non-disaster-grants">Preparedness (Non-Disaster) Grants</a></li>
+<li class="collapsed"><a href="/private-sector">Private Sector</a></li>
+<li class="collapsed"><a href="/protecting-homes">Protecting Homes</a></li>
+<li class="collapsed"><a href="/protecting-our-communities">Protecting Our Communities</a></li>
+<li class="collapsed"><a href="/protecting-your-businesses">Protecting Your Businesses</a></li>
+<li class="collapsed"><a href="/appeals" title="">Public Assistance Appeals Database</a></li>
+<li class="collapsed"><a href="/public-assistance-local-state-tribal-and-non-profit">Public Assistance: Local, State, Tribal and Non-Profit</a></li>
+<li class="collapsed"><a href="/recovery-resources">Recovery Resources</a></li>
+<li class="collapsed"><a href="/region-i-ct-me-ma-nh-ri-vt">Region I</a></li>
+<li class="collapsed"><a href="/region-ii-nj-ny-pr-vi-0">Region II</a></li>
+<li class="collapsed"><a href="/region-iii-dc-de-md-pa-va-wv">Region III</a></li>
+<li class="collapsed"><a href="/region-iv-al-fl-ga-ky-ms-nc-sc-tn">Region IV</a></li>
+<li class="collapsed"><a href="/region-v-il-mi-mn-oh-wi">Region V</a></li>
+<li class="collapsed"><a href="/region-vi-arkansas-louisiana-new-mexico-oklahoma-texas">Region VI</a></li>
+<li class="collapsed"><a href="/region-vii-ia-ks-mo-ne">Region VII</a></li>
+<li class="collapsed"><a href="/region-viii-co-mt-nd-sd-ut-wy">Region VIII</a></li>
+<li class="collapsed"><a href="/fema-region-ix-arizona-california-hawaii-nevada-pacific-islands">Region IX</a></li>
+<li class="collapsed"><a href="/region-x-ak-id-or-wa">Region X</a></li>
+<li class="collapsed"><a href="/required-notices">Required Notices</a></li>
+<li class="collapsed"><a href="/reservist-program" title="Reservist Program">Reservist Program</a></li>
+<li class="collapsed"><a href="/safer-stronger-protected-homes-communities">Safer, Stronger, Protected Homes &amp; Communities</a></li>
+<li class="collapsed"><a href="/social-media">Social Media</a></li>
+<li class="leaf"><a href="/states" title="">States</a></li>
+<li class="leaf"><a href="/testimony-and-speeches">Testimony &amp; Speeches</a></li>
+<li class="leaf"><a href="/text-messages">Text Messages</a></li>
+<li class="collapsed"><a href="/fema-tribal-affairs">Tribal</a></li>
+<li class="collapsed"><a href="/unified-federal-environmental-and-historic-preservation-review-presidentially-declared-disasters">Unified Federal Environmental and Historic Preservation Review</a></li>
+<li class="collapsed"><a href="/urban-search-rescue">Urban Search and Rescue</a></li>
+<li class="leaf"><a href="/us-coast-guard-retiree-fema-reservist-initiative">U.S. Coast Guard Retiree to FEMA Reservist Initiative</a></li>
+<li class="last collapsed"><a href="/voluntary-faith-based-community-based-organizations">Voluntary, Faith-Based, &amp; Community-Based Organizations</a></li>
+</ul>                </div><!-- .navigationItems -->
+              </div><!-- .modal-body -->
+            </div><!-- .modal-content -->
+          </div><!-- .modal-dialog -->
+        </div><!-- .modal -->
+
+        <!-- Global Search -->
+        <div type="" class="global-search" data-toggle="modal" data-target="#uniSearch" tabindex="0">
+          Search        </div>
+
+        <div class="modal fade search-modal" id="uniSearch" tabindex="-1" role="dialog" aria-labelledby="uniSearchLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                  <span aria-hidden="true"><div class="close-icon">&times;</div></span>
+                  <div class="close-text">Close</div>
+                </button>
+                <div class="modal-title" id="uniSearchLabel">Search</div>
+              </div><!-- .modal-header -->
+              <div class="modal-body">
+                <form accept-charset="UTF-8" action="//search.usa.gov/search" id="search_form" method="get">
+                  <div style="margin:0;padding:0;display:inline">
+                    <input name="utf8" type="hidden" value="&#x2713;" />
+                  </div>
+                  <input id="affiliate" name="affiliate" type="hidden" value="fema" />
+                  <label for="query">Enter Search Term(s):</label>
+                  <input placeholder="Search anything on fema.gov" autocomplete="off" class="usagov-search-autocomplete" id="query" name="query" type="text" size="31" />
+                  <input class="search-submit" name="commit" type="submit" value="GO" />
+                </form>
+              </div><!-- .modal-body -->
+            </div><!-- .modal-content -->
+          </div><!-- .modal-dialog -->
+        </div><!-- .modal -->
+
+        <!-- Global Languages -->
+        <div type="" class="language-modal" data-toggle="modal" data-target="#language" tabindex="0">
+          Languages        </div>
+
+        <div class="modal fade language" id="language" tabindex="-1" role="dialog" aria-labelledby="navigationLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                  <span aria-hidden="true"><div class="close-icon">&times;</div></span>
+                  <div class="close-text">Close</div>
+                </button>
+                <div class="modal-title" id="navigationLabel">Languages</div>
+              </div><!-- .modal-header -->
+              <div class="modal-body">
+                <ul><li><a href="/" lang="en">English</a></li><li><a href="/es" lang="es">Español</a></li><li><a href="/fr" lang="fr">Français</a></li><li><a href="/el" lang="el">Ελληνικά</a></li><li><a href="/ar" lang="ar">العربية</a></li><li><a href="/zh-hans" lang="zh-hans">简体中文</a></li><li><a href="/de" lang="de">Deutsch</a></li><li><a href="/ht" lang="ht">Haitian Creole</a></li><li><a href="/he" lang="he">עברית</a></li><li><a href="/hi" lang="hi">हिन्दी</a></li><li><a href="/it" lang="it">Italiano</a></li><li><a href="/ja" lang="ja">日本語</a></li><li><a href="/ko" lang="ko">한국어</a></li><li><a href="/pl" lang="pl">Polski</a></li><li><a href="/pt-br" lang="pt-br">Português</a></li><li><a href="/ru" lang="ru">Русский</a></li><li><a href="/tl" lang="tl">Tagalog</a></li><li><a href="/th" lang="th">ภาษาไทย</a></li><li><a href="/ur" lang="ur">اردو</a></li><li><a href="/vi" lang="vi">Tiếng Việt</a></li><li><a href="/yi" lang="yi">Yiddish</a></li></ul>              </div><!-- .modal-body -->
+            </div><!-- .modal-content -->
+          </div><!-- .modal-dialog -->
+        </div><!-- .modal -->
+
+      </div><!-- .global-nav -->
+
+      <!-- Left Sidebar (Rendered) -->
+      <div class="contextual-nav-desktop"></div>
+        <div class="region region-sidebar-first">
+    <div class="menu-block-wrapper menu-block-8 menu-name-menu-left-menu parent-mlid-0 menu-level-1">
+  <ul><li class="first last expanded active-trail active menu-mlid-45013"><a href="/hurricane-maria" class="active-trail active">Hurricane Maria</a><ul><li class="first leaf menu-mlid-45042"><a href="/disaster/updates/hurricane-maria-rumor-control" title="">Rumor Control</a></li>
+<li class="leaf menu-mlid-45019"><a href="/disaster/updates/hurricane-maria-news-graphics-and-social-media" title="">News, Graphics, &amp; Social Media</a></li>
+<li class="leaf menu-mlid-45031"><a href="/resources-people-disabilities-access-functional-needs" title="">Accessible ASL Videos</a></li>
+<li class="leaf menu-mlid-45035"><a href="https://www.fema.gov/disaster/4339" title="">Puerto Rico | DR-4339</a></li>
+<li class="last leaf menu-mlid-45032"><a href="https://www.fema.gov/disaster/4340" title="">Virgin Islands | DR-4340</a></li>
+</ul></li>
+</ul></div>
+  </div>
+
+    </div><!-- .global-nav-wrapper-->
+  </div><!-- .block-left -->
+
+  <!-- Skip Nav for Main Content -->
+  <a id="main-content" name="main-content" href="#" class="element-invisible element-focusable">Main Content</a>
+  <div class="block-right">
+
+    <div class="content-wrapper">
+      <section>
+                                  <h1 class="page-header">Hurricane Maria</h1>
+                                                                                                      <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+      
+  <div id="node-315781" class="node node-site-page clearfix">
+
+    
+            
+    
+    <div class="content">
+        <div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even"><p><img alt="" height="133" src="/sites/default/files/images/maria_updates_web.png" style="margin:0px 15px; float:right" width="295" />This is the main page for up-to-date resources and information on the federal response to Hurricane Maria.</p><p>Follow the direction of state, local, and tribal officials. (<a href="/es/huracan-maria">Español</a>)<br /> </p><div class="row row"><div class="col-sm-4"><strong>Puerto Rico | DR-4339</strong><ul><li><a href="/es/disaster/4339">Español | Spanish</a></li><li><a href="/disaster/4339">English</a></li></ul></div><div class="col-sm-4"><strong>U.S. Virgin Islands | DR-4340</strong><ul><li><a href="/es/disaster/4340">Español | Spanish</a></li><li><a href="/ht/disaster/4340">kreyòl ayisyen | Haitian Creole</a></li><li><a href="/disaster/4340">English</a></li></ul></div></div><h2>Cell Phones: No Cost Roaming Charges</h2><p>All Cellular Service customers, in both Puerto Rico and the U.S Virgin Islands will have service upon the first roaming partners availability.</p><p>Service providers will not be charging additional roaming charges in the areas <strong>at this time</strong>. Please check with your service provider for the date “roaming” charges will be reinstated.</p><p>If you are having difficulties “roaming” on your cellular device simply “reset” the phone by turning it all the way off for a few seconds. Once you turn your device back on, you should be able to “roam” freely.</p><h2>How to Find or Reunite with Loved Ones</h2><p>Following events like Hurricane Maria, we understand that communications networks are not always operational. As communications are restored, there are numerous options for survivors, friends, and family members to search for loved ones. </p><p>Survivors with internet access are encouraged to connect with friends and family members via social media platforms. Additional resources below are suggested for those both outside and inside the impacted areas.</p><p><strong>American Red Cross</strong><img alt=" Check in yourself or check on loved ones. To register so people know you're safe and well, use the thumbs up icon in the Emergency App or register at redcross.org/safeandwell. Search for a loved one by name and phone number or name and home address at redcross.org/safeandwell. Download the Red Cross Emergency App for free from your app store, or text GETEMERGENCY to 90999." src="/sites/default/files/images/redcrosssafewell.jpg" style="margin:10px 20px; width:582px; height:288px; float:right" /></p><p>The American Red Cross <a href="https://safeandwell.communityos.org/cms/index.php" target="_blank">Safe and Well website</a> allows individuals to register themselves as safe or search for loved ones. The site is always available, open to the public, and available in <a href="https://safeandwell.communityos.org/cms/index.php">English</a> and <a href="https://safeandwell-es.communityos.org/cms/">Spanish</a>. There are a number of ways to use this service:</p><ul><li>Registrations and searches can be done <strong>directly on the </strong><a href="https://safeandwell.communityos.org/cms/index.php"><strong>website</strong></a>.</li><li>Registrations can also be completed by <strong>texting SAFE to 78876</strong>. Messages exist in both Spanish and English.</li><li>To speak with someone at the American Red Cross concerning a missing friend or relative who has a serious, pre-existing health or mental health condition, please contact <strong>1-800 Red Cross (1-800-733-2767)</strong>.</li></ul><p>The American Red Cross <a href="http://www.redcross.org/get-help/how-to-prepare-for-emergencies/mobile-apps">Emergency App</a> features an “I’m Safe” button that allows users to post a message to their social accounts, letting friends and family know they are out of harm’s way. The app can be downloaded for free in app stores by searching for “American Red Cross” or by texting ‘GETEMERGENCY’ to 90999.</p><p><strong>National Center for Missing &amp; Exploited Children </strong></p><p>Anyone who finds a child who may be separated from parents or caregivers, please contact the local police and enter basic information and/or a photo into the National Center for Missing &amp; Exploited Children's <a href="https://umr.missingkids.org/umr/reportUMR;jsessionid=91503C5C16CA4B963605DEBBF62F28CF?execution=e1s1" target="_blank">Unaccompanied Minors Registry</a>. If you find an unaccompanied child, please indicate whether the child has a disability or has access and functional needs in the appropriate field in the <a href="https://umr.missingkids.org/umr/reportUMR?execution=e1s1" target="_blank">Unaccompanied Minors Registry</a>. If you do not have access to the internet, please call 1-866-908-9570.</p><p><strong>Information for Tourists</strong></p><p>Any tourists requiring transport off the islands should contact the U.S. Virgin Islands Department of Tourism at (340) 772-0357 or visit <a href="http://www.usviupdate.com/">www.usviupdate.com/</a> for additional information.</p><p>The Puerto Rico Tourism Company has set up a hotline at 877-976-2400 for people staying at hotels.</p><p><strong>Local Resources</strong></p><p>The <a href="http://prfaa.pr.gov/">Puerto Rico Federal Affairs Administration</a> directed those seeking information or assistance to call 202-800-3133 or email <a href="mailto:maria1@prfaa.pr.gov">maria1@prfaa.pr.gov</a>.</p><p>Additional information for the U.S. Virgin Islands is available at the following locations:</p><ul><li><a href="http://VIalert.gov">VIalert.gov</a></li><li><a href="http://USVIupdate.com">USVIupdate.com</a></li><li><a href="http://www.informusvi.com/">InformUSVI.com</a></li></ul><h2>Federal Response Updates</h2><p></p><p><em>All figures as of October 3, 2017, 10 am EDT</em></p><p><strong>Federal Force Laydown</strong></p><ul><li>There are <strong>more than 12,300 federal staff</strong> representing <strong>36 departments and agencies </strong>and including <strong>more than 800 FEMA personnel</strong>, on the ground in Puerto Rico and the U.S. Virgin Islands engaged in response and recovery operations from Hurricanes Maria and Irma.</li><li><strong>18 states</strong> supporting <strong>62</strong> <strong>requests </strong>for mutual aid</li><li><strong>USS Wasp </strong>scheduled to arrive Tuesday Oct 3 with 13 helicopters</li></ul><p><img alt="Logistics Snapshot for Hurricane Maria. 9/30/2017 at 12 PM. Maps showing open airports, open ports, and ports open with restrictions in Puerto Rico and the U.S. Virgin Islands. Image of ship. 14 Sea Vessels: providing water, lift, search and rescue, and commodities delivery capabilities. Image of airplane: 7 commodity flights to Puerto Rico and 3 commodity flights to U.S. Virgin Islands. Flights scheduled for 9/29. Flights continue daily to bring food, water, and other supplies. Image of a water bottle and bag of grain, symbolizing food: 11 regional staging areas in Puerto Rico serving 78 communities. 6 points of distribution in U.S. Virgin Islands. Millions of meals and millions of liters of water delivered. Additional meals and water delivered daily. Additional points of distribution will open as areas become accessible. FEMA logo in bottom right corner." src="https://www.fema.gov/media-library-data/1506789056089-8a75843965699c0046117a25cf02286d/Maria_LogisticsSnapshot_medium.jpg" style="float:right; width:431px; height:493px; margin:10px 15px" /><strong>Survivor Impacts</strong></p><ul><li>More than<strong> 240</strong> patients seen by U.S. Health and Human Services medical teams</li><li>More than<strong> 65%</strong> (+15%) of grocery and big-box stores open</li><li>More than<strong> 78%</strong> (101 of 128) USPS post offices providing mail for pick up or delivery to P.O. boxes</li><li><strong>24 municipalities</strong> added for Individual Assistance</li></ul><p><strong>Power Restoration and Fuel Impacts</strong></p><ul><li>San Juan financial district is back on the electrical grid – 5.4% (+0.4) customers have electricity</li><li>Roughly<strong> 70% retail gas stations</strong> are operational</li><li><strong>17 </strong>(+7) generators installed by the USACE for critical infrastructure</li></ul><p><strong>Transportation Impacts</strong></p><ul><li>More than<strong> 20 miles</strong> <strong>of roadway cleared</strong>; <strong>12 </strong>major highways open;<strong> 5 </strong>(+2) state roads open</li><li><strong>92% </strong>(13 of 14) deep-water ports are fully open, or open with restrictions</li><li><strong>100% airports</strong> are open</li><li><strong>147 </strong>arrivals and <strong>141</strong> departures from Luis Muñoz Marín International Airport (SJU) in San Juan on October 2.</li></ul><p><strong>Water/Wastewater Impacts</strong></p><ul><li><strong>50% </strong>Puerto Rico residents have <strong>access to drinking water</strong> (*based on Puerto Rico Aqueduct and Sewer Authority clientele)</li><li><strong>17% </strong>waste water treatment plants operational</li><li><strong>900</strong> sandbags on-hand to stabilize Guajataca Dam spillway</li></ul><p><strong>Hospitals and Medical Care Impacts</strong></p><ul><li>To provide additional surge capacity if needed, the Department of Defense hospital ship <strong>USNS COMFORT</strong> is arriving in Puerto Rico today (October 3).<ul style="list-style-type:circle"><li>The ship offers the <strong>full range of medical care</strong> with surgical, obstetric and pediatric capability and is equivalent to a level-two trauma center in the United States. The ship is staffed by more than <strong>500 medical personnel </strong>and support staff and holds <strong>250 hospital beds</strong>.</li></ul></li><li><strong>94% </strong>(64/68) hospitals are open</li><li><strong>8 </strong>VA hospitals are open<strong>; 14</strong> hospitals are on the electrical grid</li><li><strong>96% </strong> (46/48) Dialysis Centers open</li><li><strong>11 </strong>Disaster Medical Assistance Support Teams on site, as part of the National Disaster Medical Support Team activation</li></ul><p><strong>Commodity Distribution</strong></p><ul><li>FEMA, working in coordination with federal partners, has provided <strong>millions of meals</strong> and <strong>millions of liters of water</strong> to Puerto Rico and U.S. Virgin Islands. Additional meals and water continue to arrive to the islands regularly via air and sea.</li><li>As of October 1, the Governor of Puerto Rico established <strong>11 Regional Staging Areas</strong> around the island, serving all <strong>78 municipalities</strong>. The National Guard is delivering supplies to the regional staging areas around the island.</li></ul><p><strong>To see more photos of the federal response to Hurricane Maria, visit the following collections from our federal partners:</strong></p><ul><li><a href="https://www.dvidshub.net/feature/HurricaneMaria">U.S. Department of Defense Photos and Videos</a></li><li><a href="https://www.dvidshub.net/search/?q=HURRICANE+MARIA&amp;filter%5Bbranch%5D=Coast+Guard&amp;view=list&amp;sort=publishdate">U.S. Coast Guard Videos and Photos</a></li><li><div><div><div><div><div><div><div><p><a href="https://www.flickr.com/photos/cbpphotos/with/36563957134/">U.S. Customs and Border Protection Photos</a></p></div></div></div></div></div></div></div></li></ul><p><strong>On Social Media</strong></p><blockquote><p dir="ltr">Our Joint Field Office in Puerto Rico--where hundreds of FEMA staff &amp; teams from other agencies work together to support <a href="https://twitter.com/hashtag/Maria?src=hash&amp;ref_src=twsrc%5Etfw">#Maria</a> recovery. <a href="https://t.co/nL3CQCpH8X">pic.twitter.com/nL3CQCpH8X</a></p>— FEMA (@fema) <a href="https://twitter.com/fema/status/914974627864236034?ref_src=twsrc%5Etfw">October 2, 2017</a></blockquote><blockquote><p dir="ltr">.<a href="https://twitter.com/FEMA_Brock?ref_src=twsrc%5Etfw">@fema_brock</a> met w/ officials &amp; federal partners in PR today, as <a href="https://twitter.com/hashtag/Maria?src=hash&amp;ref_src=twsrc%5Etfw">#Maria</a> response/recovery efforts continue. Updates: <a href="https://t.co/NwKCXQh1OX">https://t.co/NwKCXQh1OX</a> <a href="https://t.co/GwgAErA0vw">pic.twitter.com/GwgAErA0vw</a></p>— FEMA (@fema) <a href="https://twitter.com/fema/status/914963948230922240?ref_src=twsrc%5Etfw">October 2, 2017</a></blockquote><blockquote><p dir="ltr">FEMA search &amp; rescue teams &amp; an <a href="https://twitter.com/HHSGov?ref_src=twsrc%5Etfw">@HHSGov</a> health &amp; medical team reached a community near Utuado, PR yesterday that was cut off due to <a href="https://twitter.com/hashtag/Maria?src=hash&amp;ref_src=twsrc%5Etfw">#Maria</a>. <a href="https://t.co/bQhAJovJ63">pic.twitter.com/bQhAJovJ63</a></p>— FEMA (@fema) <a href="https://twitter.com/fema/status/914886047632371712?ref_src=twsrc%5Etfw">October 2, 2017</a></blockquote><h2>Point of Distribution Locations</h2><p>Points of distribution are open in Puerto Rico and the U.S. Virgin Islands for survivors to get meals, water, and other commodities.</p><p><strong>U.S. Virgin Islands</strong></p><ul><li>Curfew 6 pm to 8 am on St. Thomas / St. John</li><li><strong>POD</strong>s on St. Thomas / St. John will be closed until Monday (10/02)<br /> </li><li>Permanent suspension of curfew from 11am to 6pm daily on St. Croix</li><li><strong>POD</strong>s will reopen on St. Croix for service Friday, September 29th and Saturday, September 30th.<ul><li><p><strong>Open from 12pm to 4pm</strong></p><ul><li><p>Alexander Henderson School</p></li><li><p>Juanita Gardine Elementary School</p></li><li><p>Cotton Valley Fire Station</p></li><li><p>Educational Complex </p></li><li><p>Eulalie Rivera School<br /> </p></li></ul></li><li><p><strong>Open Saturday, September 30th</strong></p><ul><li><p>Theodora Dunbavin Alternative Education</p></li></ul></li></ul></li></ul><p><strong>Puerto Rico</strong> - This list is as of 9/28/2017.</p><ul><li>More locations will be added to this list as they open.</li></ul><p>Please search below for your municipality and/or community.</p><table class="datatable"><thead><tr align="center"><th scope="col" style="width:50%">Community</th><th scope="col" style="width:50%">Municipality</th></tr></thead><tbody><tr><td>Arecibo I, II</td><td>Arecibo</td></tr><tr><td>Barceloneta</td><td>Arecibo</td></tr><tr><td>Hatillo</td><td>Arecibo</td></tr><tr><td>Camuy</td><td>Arecibo</td></tr><tr><td>Quebradilla</td><td>Arecibo</td></tr><tr><td>Florida</td><td>Arecibo</td></tr><tr><td>Manati</td><td>Arecibo</td></tr><tr><td>Lares</td><td>Arecibo</td></tr><tr><td>Ciales</td><td>Arecibo</td></tr><tr><td>Aguadilla</td><td>Aguadilla</td></tr><tr><td>Aguada</td><td>Aguadilla</td></tr><tr><td>Rincón</td><td>Aguadilla</td></tr><tr><td>Añasco</td><td>Aguadilla</td></tr><tr><td>Moca</td><td>Aguadilla</td></tr><tr><td>San Sebastian</td><td>Aguadilla</td></tr><tr><td>Isabela</td><td>Aguadilla</td></tr><tr><td>Guaynabo</td><td>Bayamon</td></tr><tr><td>Toa Baja</td><td>Bayamon</td></tr><tr><td>Cataño</td><td>Bayamon</td></tr><tr><td>Toa Alta</td><td>Bayamon</td></tr><tr><td>Vega Alta</td><td>Bayamon</td></tr><tr><td>Dorado</td><td>Bayamon</td></tr><tr><td>Vega Baja</td><td>Bayamon</td></tr><tr><td>Comerio</td><td>Bayamon</td></tr><tr><td>Orocovis</td><td>Bayamon</td></tr><tr><td>Naranjito</td><td>Bayamon</td></tr><tr><td>Morovia</td><td>Bayamon</td></tr><tr><td>Corozal</td><td>Bayamon</td></tr><tr><td>Barranquitas</td><td>Bayamon</td></tr><tr><td>Canovanas</td><td>Canóvanas</td></tr><tr><td>Carolina</td><td>Canóvanas</td></tr><tr><td>San Juan</td><td>Canóvanas</td></tr><tr><td>Trujillo Alto</td><td>Canóvanas</td></tr><tr><td>Loisa</td><td>Canóvanas</td></tr><tr><td>Rio Grande</td><td>Canóvanas</td></tr><tr><td>Ceiba</td><td>Ceiba</td></tr><tr><td>Fajardo</td><td>Ceiba</td></tr><tr><td>Luquillo</td><td>Ceiba</td></tr><tr><td>Culebra</td><td>Ceiba</td></tr><tr><td>Vieques</td><td>Ceiba</td></tr><tr><td>Naguabo</td><td>Ceiba</td></tr><tr><td>Yabucoa</td><td>Ceiba</td></tr><tr><td>Maunabo</td><td>Ceiba</td></tr><tr><td>Humacao</td><td>Ceiba</td></tr><tr><td>Caguas</td><td>Caguas</td></tr><tr><td>Cidra</td><td>Caguas</td></tr><tr><td>Cayey</td><td>Caguas</td></tr><tr><td>Aibonito</td><td>Caguas</td></tr><tr><td>Aguas Buenas</td><td>Caguas</td></tr><tr><td>Gurabo</td><td>Caguas</td></tr><tr><td>Juncos</td><td>Caguas</td></tr><tr><td>San Lorenzo</td><td>Caguas</td></tr><tr><td>Las Piedras</td><td>Caguas</td></tr><tr><td>Guayama</td><td>Guayama</td></tr><tr><td>Arroyo</td><td>Guayama</td></tr><tr><td>Patillas</td><td>Guayama</td></tr><tr><td>Salinas</td><td>Guayama</td></tr><tr><td>Coamo</td><td>Guayama</td></tr><tr><td>Santa Isabel</td><td>Guayama</td></tr><tr><td>Mayagüez</td><td>Mayagüez</td></tr><tr><td>Las Marias</td><td>Mayagüez</td></tr><tr><td>Maricao</td><td>Mayagüez</td></tr><tr><td>Hormigueros</td><td>Mayagüez</td></tr><tr><td>Cabo Rojo</td><td>Mayagüez</td></tr><tr><td>San German</td><td>Mayagüez</td></tr><tr><td>Sabana Grande</td><td>Mayagüez</td></tr><tr><td>Lajas</td><td>Mayagüez</td></tr><tr><td>Ponce</td><td>Ponce</td></tr><tr><td>Penuelas</td><td>Ponce</td></tr><tr><td>Guayanilla</td><td>Ponce</td></tr><tr><td>Yauco</td><td>Ponce</td></tr><tr><td>Guanica</td><td>Ponce</td></tr><tr><td>Juana Diaz</td><td>Ponce</td></tr><tr><td>Villalba</td><td>Ponce</td></tr><tr><td>Adjuntas</td><td>Ponce</td></tr><tr><td>Utuado</td><td>Utuado</td></tr></tbody></table><h2>How to Help</h2><div><ul></ul><p><img alt=" How to help after a disaster. The best way to help is with cash donations to trusted organizations. Cash is efficient, flexible to use, and requires no packaging or transport. Trusted organizations will ensure your money goes to help those in need." src="https://www.fema.gov/media-library-data/1476464381286-7e0b131f31391ddac73f3bdf11f69d2e/donations_medium.png" style="margin:10px 15px; width:400px; height:283px; float:right" /></p><p>For Hurricane Maria, there are three ways that the public can most effectively and efficiently help provide support for survivors in Puerto Rico and the U.S. Virgin Islands.</p><p><strong><em>The fastest way to help – cash is best</em></strong></p><p>The most effective means to support recovery of communities affected by Hurricane Maria is to donate money to trusted voluntary-, faith- and community-based charitable organizations. This gives these organizations the ability to purchase what survivors need right now. In addition, when these organizations purchase goods or services locally, they pump money back into the local and regional economy, helping businesses recover faster.</p><ul><li>To make a cash donation directly to the Commonwealth of Puerto Rico, visit <a href="http://www.unitedforpuertorico.com">www.unitedforpuertorico.com</a>. </li></ul><p><strong><em>Donating Goods</em></strong></p><p>It is important to remember unsolicited donated goods (e.g., clothing, miscellaneous household items, and mixed or perishable foodstuffs) require voluntary agencies to redirect valuable resources away from providing services to sort, package, transport, warehouse, and distribute items that may not meet the needs of disaster survivors.  </p><ul><li>To responsibly donate goods, the <a href="https://www.nvoad.org/howtohelp/donate/">NVOAD website</a> has information on non-profit organizations accepting or registering individual and corporate in-kind donations.</li><li>If you would like to give in-kind donations, coordinate with NVOAD organizations to identify the best ways to pick up and drop off your donations.</li></ul><p><strong><em>Volunteering</em></strong></p><p>Anyone seeking an opportunity to get involved in response and recovery operations underway is encouraged to volunteer with local and nationally known organizations.</p><ul><li>To register as an affiliated volunteer with a voluntary or charitable organization, visit the <a href="https://www.nvoad.org/voad-members/">National VOAD</a> for a list of partners active in disaster.</li></ul><p>Thank you for your interest in helping the survivors of Hurricane Maria. When disaster strikes, America looks to FEMA to support survivors and first responders in communities all across the country. We are <a href="http://careers.fema.gov/hurricane-workforce">currently seeking talented and hard-working people</a> to help support the hurricane response and recovery efforts.</p><h2>Urban Search &amp; Rescue Operations</h2><p>Urban Search &amp; Rescue teams have reached all municipalities. Teams have saved or assisted 843 individuals and searched over 2,600 structures.</p><h2>Puerto Rico Road Status</h2><p><img alt=" Inaccessible due to mudslide at 140 km in the direction of Mayaguez towards Arecibo. Lanes towards Mayaguez being used in both directions. Inaccessible from 148.7 km to 142.8 km due to flooding in both directions. Inaccessible due to mudslide and detachment of road at 54.4 km. Detour by PR-603 and PR-6103. Signage, lightning, and fallen trees. Accessible in both directions. Inaccessible at 22.6 km due to structural concerns in both directions. Inaccessible at 4.1 km due to flooding in both directions. Inaccessible in three segments in San Juan direction. Lanes toward Fajardo being used in both directions. Inaccessible in three segments in San Juan direction. Lanes towards Fajardo being used in both directions. Closed in direction to Caguas. Lanes towards Fajardo used in both direction. Inaccessible at 93.9 km towards Ponce. Emergency lane towards Caguas being used in opposite direction. Inaccessible due to structural damage of bridge at 1 km. Inaccessible at 200 km in both directions due to flood. Lanes towards Mayaguez being used in both directions. Inaccessible due to mudslide at 12.6 km. Inaccessible from 148.7 km to 142.km due to flooding in both directions." src="/sites/default/files/images/maria_leadershipmapbook_20170928_0800v2_withlogo.png" style="height:711px" /></p><h2>Safety Tips</h2><ul><li>If you encounter flood waters, remember – <strong>turn around, don’t drown</strong>. Don't drive through a flooded area.</li><li><strong>Avoid debris, downed power lines, and flood water,</strong> which may be electrically charged and hide dangerous debris or places where the ground is washed away. Avoid downed power or utility lines as they may be live with deadly voltage. Stay away and report them immediately to your power or utility company.</li><li>Emergency workers may be assisting people in flooded areas or cleaning up debris. You can help them by <strong>staying off the roads and out of the way as much as possible</strong>.</li><li>If your home has flood water inside or around it, don’t walk or wade in it.The water may be contaminated by oil, gasoline, or raw sewage.</li><li>If you have a flooded basement in your home, never attempt to turn off power or operate circuit breakers while standing in water.</li><li>If your power is out, safely use a generator or battery-operated flashlights.</li><li><strong>Never use a generator inside a home, basement, shed or garage</strong> even if doors and windows are open.</li><li>Keep generators outside and far away from windows, doors and vents. Read both the label on your generator and the owner's manual and follow the instructions.</li><li><strong>Avoid plugging emergency generators into electric outlets</strong> or hooking them directly to your home's electrical system – they can feed electricity back into the power lines, putting you and line workers in danger.<p style="text-align:center"><img alt=" Listen to local officials for updates and instructions. Use texts or social media to check in with friends and family. Watch out for debris and downed power lines. Stay out of damaged buildings and homes until local authorities say it's safe. Photograph the damage to your property to assist in filing an insurance claim." src="https://www.fema.gov/media-library-data/1490804363803-8b43ce0fe9b98b8c000069ab9162a265/NeighborCheck10_medium.jpg" style="margin:10px 15px; width:724px; height:617px" /></p></li></ul></div><h2>Beware of Fraud &amp; Price Gouging</h2><p>After a disaster scam artists, identity thieves and other criminals may attempt to prey on vulnerable survivors. The most common post-disaster fraud practices include phony housing inspectors, fraudulent building contractors, bogus pleas for disaster donations and fake offers of state or federal aid.</p><p><strong>Survivors should keep in mind</strong>:</p><ul><li>FEMA does not authorize individual contractors to solicit on its behalf.  Beware of any individual contractors contacting you directly on behalf of FEMA to sign you up for debris removal or remediation services.</li><li>If you have any concerns about individuals representing themselves as FEMA or would like to report fraud, please contact the National Center for Disaster Fraud at (866) 720-5721 or via email at <a href="mailto:disaster@leo.gov"><strong>disaster@leo.gov</strong></a>. </li><li>Federal and state workers never ask for, or accept money, and always carry identification badges</li><li>There is <strong>NO FEE </strong>required to apply for or to get disaster assistance from FEMA, the U.S. Small Business Administration or the state</li><li>Scam attempts can be made over the phone, by mail or email, text or in person</li></ul><p><strong>Price Gouging </strong></p><p>Price gouging occurs when a supplier marks up the price of an item more than is justified by his actual costs. Survivors are particularly susceptible because their needs are immediate, and have few alternatives to choose from. If you find price gouging report below:</p><p><strong>Report Price Gouging</strong></p><p><strong>Puerto Rico</strong>:<br />United States Attorney's Office<br />Torre Chardón, Suite 1201<br />350 Carlos Chardón Street<br />San Juan, PR 00918</p><ul><li>Main Phone: (787) 766-5656</li><li>Toll Free Phone: 1‐877‐USA‐5656 (1-877‐872‐5656)</li></ul><p> <br /><strong>U.S. Virgin Islands</strong>:<br />United States Attorney's Office<br />Federal Building &amp; U.S. Courthouse<br />Room 260<br />5500 Veterans Drive<br />St. Thomas, VI 00802-6424</p><ul><li>St. Thomas Main Phone: 340-774-5757</li><li>St. Croix Main Phone: 340-773-3920</li></ul><p><strong>Dealing with Contractors</strong>:</p><p>Survivors should take steps to protect themselves and avoid fraud when hiring contractors to clean property, remove debris or make repairs.</p><p><strong>Simple rules to avoid becoming a victim of fraud</strong>:</p><ul><li>Only use contractors licensed by your state</li><li>Get a written estimate and get more than one estimate</li><li>Demand and check references</li><li>Ask for proof of insurance<ul><li>i.e., liability and Workmen's Compensation</li></ul></li><li>Insist on a written contract and refuse to sign a contract with blank spaces</li><li>Get any guarantees in writing</li><li>Make final payments only after the work is completed</li><li>Pay by check.</li></ul><p>The best way to avoid fraud is to arm yourself against it by having a checklist to remind you of what you need to demand when hiring a contractor.</p><ul></ul><h2>Helping Children Cope</h2><div><p>To talk to a professional who can help you cope with emotional distress from the storm: Call the <a href="https://twitter.com/distressline">@disasterdistressline</a> at <strong>(800) 985-5990</strong> crisis support services are available <strong>24/7</strong>.</p><p>Children may cope more effectively with a disaster when they feel they understand what is happening and what they can do to help protect themselves, their family, and friends. Here’s how you can help them cope and a <a href="/media-library/assets/documents/138687">Fact Sheet</a>:</p><ul><li>Talk about the concerns about the storm with your children. To not talk about it makes it even more threatening in your children's mind. Start by asking what your children have already heard and what understanding they have. As your children explain, listen for misinformation, misconceptions, and underlying fears or concerns, and then address these.</li><li>Explain - as simply and directly as possible - what is happening or likely to happen. The amount of information that will be helpful to children depends on their age and developmental level, as well as their coping style. For example, older children generally want and will benefit from more detailed information than younger children. Because every child is different, take cues from your own children as to how much information to provide.</li><li>Encourage your children to ask questions, and answer those questions directly. Like adults, children are better able to cope with a crisis if they feel they understand it. Question-and-answer exchanges help to ensure ongoing support as your children begin to understand the crisis and the response to it.</li><li>Limit television viewing of disasters and other crisis events, especially for younger children. Consider coverage on all media, including the internet and social media. When older children watch television, try to watch with them and use the opportunity to discuss what is being seen and how it makes you and your children feel.</li><li>Reassure children of the steps that are being taken to keep them safe. Disasters and other crises remind us that we are never completely safe from harm. Now more than ever it is important to reassure children that, in reality, they should feel safe in their schools, homes, and communities.</li><li>Consider sharing your feelings about a crisis with your children. This is an opportunity for you to role model how to cope and how to plan for the future. Before you reach out, however, be sure that you are able to express a positive or hopeful plan.</li><li>Help your children to identify concrete actions they can take to help those affected by recent events. Rather than focus on what could have been done to prevent a disaster or other crisis, concentrate on what can be done now to help those affected by the event.</li><li>Play games and do activities together to create meaningful dialogue and offer a distraction.</li><li>If you have concerns about your children's behavior, contact your children's pediatrician, other primary care provider, or a qualified mental health professional.</li></ul></div></div></div></div><div class="field field-name-field-updated-date field-type-entity-property-field field-label-inline clearfix"><div class="field-label">Last Updated:&nbsp;</div><div class="field-items"><div class="field-item even">10/03/2017 - 08:59</div></div></div>    </div>
+
+    
+    
+
+</div>
+
+
+</section> <!-- /.block -->
+<section id="block-block-5" class="block block-block clearfix">
+
+      
+  <script></script>
+<style type="text/css">
+body.page-taxonomy img.gis_image {
+   border: none;
+    height: 153px !important;
+    margin-right: 0;
+    max-width: 100% !important;
+    width: 198px !important;
+}
+
+div.leadership  {
+margin-bottom: 22px;
+}
+
+div.leadership div.col-md-9 {
+padding-left:0;
+margin-left:35px;
+}
+
+div.leadership-main div.col-md-2 {
+text-align:center;
+overflow: hidden;
+}
+
+div.headshot-wrapper-big {
+width:140px; 
+height: 175px; 
+text-align:center;
+overflow: hidden; 
+margin-top: 7px;
+}
+
+div.content img.leader-headshot-big {
+margin-left: -25px; 
+height:175px !important; 
+width:175px !important; 
+max-width: inherit !important; 
+text-align:center;
+}
+
+div.headshot-wrapper {
+height: 113px; 
+width:100px; 
+overflow:hidden; 
+text-align:center;
+}
+
+div.content img.leader-headshot-small {
+margin-left:-8px; 
+width:115px !important;
+height:115px !important;
+max-width: inherit !important; 
+}
+
+</style>
+</section> <!-- /.block -->
+  </div>
+        <div class="contextual-nav-mobile"></div>
+        <footer class="content-footer">
+          <a href="#footer-bottom" id="skipNavLink" class="element-invisible element-focusable">Skip footer content.</a>
+          <div class="clear"></div>
+            <div class="region region-footer">
+    <section id="block-unicorn-social-links-unicorn-social-links" class="block block-unicorn-social-links clearfix">
+
+      
+  <div class="socialImagesDiv">
+        <a id="showThisPageSpan" href="#"><span class="icon-show"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_share.png"  alt="Click to expand and share this page on social networks"></span><span id="showText">Share This Page.</span></a>
+        <div class="social-images">
+        <a href="https://www.facebook.com/sharer/sharer.php?u=UNIURL" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_facebook.png" alt="Facebook Icon"></a>
+        <a href="https://twitter.com/intent/tweet?text=Hurricane+Maria&url=UNIURL&via=fema" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_twitter.png" alt="Twitter Icon"></a>
+        <a href="https://www.linkedin.com/shareArticle?mini=true&url=UNIURL&title=Hurricane Maria&summary=&source=" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_linkedin.png" alt="LinkedIn Icon"></a>
+        <a href="https://plus.google.com/share?url=UNIURL" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_googleplus.png" alt="Google Plus Icon"></a>
+        <a href="http://www.tumblr.com/share/link?url=UNIURL&name=Hurricane Maria&description=" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_tumblr.png" alt="Tumblr Icon"></a>
+
+        </div>
+    </div>
+</section> <!-- /.block -->
+<section id="block-menu-menu-unicorn-footer-menu" class="block block-menu clearfix">
+
+      
+  <ul><li class="first leaf"><a href="/" title="">Home</a></li>
+<li class="leaf"><a href="/download-plug-ins" title="">Download Plug-ins</a></li>
+<li class="leaf"><a href="/about-agency" title="">About Us</a></li>
+<li class="leaf"><a href="/privacy-policy" title="">Privacy Policy</a></li>
+<li class="leaf"><a href="//www.oig.dhs.gov/" title="">Office of the Inspector General</a></li>
+<li class="leaf"><a href="/fema-strategic-plan" title="">Strategic Plan</a></li>
+<li class="leaf"><a href="//www.whitehouse.gov" title="">Whitehouse.gov</a></li>
+<li class="leaf"><a href="//www.dhs.gov" title="">DHS.gov</a></li>
+<li class="leaf"><a href="//www.ready.gov" title="">Ready.gov</a></li>
+<li class="leaf"><a href="//www.usa.gov" title="">USA.gov</a></li>
+<li class="last leaf"><a href="//www.disasterassistance.gov/" title="">DisasterAssistance.gov</a></li>
+</ul>
+</section> <!-- /.block -->
+<section id="block-boxes-unicorn-footer-dhs-text" class="block block-boxes block-boxes-simple clearfix">
+
+      
+  <div id='boxes-box-unicorn_footer_dhs_text' class='boxes-box'><div class="boxes-box-content"><p><a href="https://www.oig.dhs.gov/hotline"><img src="https://www.oig.dhs.gov/sites/default/files/img/oig-hotline.png" alt="OIG Hotline to report waste and abuse" /></a></p>
+<p lang="en"><img lang="en" src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/icon_usflag.gif" alt="US flag signifying that this is a United States Federal Government website"> Official website of the Department of Homeland Security</p></div></div>
+</section> <!-- /.block -->
+  </div>
+          <a id="footer-bottom" name="footer-bottom" href="#" class="element-invisible element-focusable">End of web page.</a>
+        </footer>
+      </section>
+      <div class="clearfix"></div>
+    </div><!-- .content-wrapper -->
+  </div><!-- .block-right -->
+</div><!-- main container -->
+
+<div class="container unicorn-home-page-secondary-content">
+  <div class="secondary-content">
+    <!-- use JS to inject content here from div.views-field-field-also-featured-content -->
+  </div><!-- .secondary-content -->
+
+  <div class="secondary-footer">
+    <!-- use JS to insert footer content here -->
+  </div><!-- .secondary-footer -->
+
+</div><!-- .unicorn-home-page-secondary-content -->
+<script src="//www.fema.gov/sites/default/files/js/js_AZ9y0PShar4GyPuQUcAgecHmIwX4TUOo0HFPa06mnF0.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_x7i9_K8_u7Lf_Pr4XToSxjCDPT7-3IXdc15I1723_SU.js"></script>
+</body>
+</html>

--- a/web_monitoring/tests/fixtures/versions/fc74d750-c651-46b7-bf74-434ad8c62e04
+++ b/web_monitoring/tests/fixtures/versions/fc74d750-c651-46b7-bf74-434ad8c62e04
@@ -1,0 +1,419 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "//www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html lang="en" dir="ltr">
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="//www.fema.gov/profiles/fema_gov/themes/unicorn/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="description" content="This is the main page for up-to-date resources and information on the federal response to Hurricane Maria.Follow the direction of state, local, and tribal officials. (EspaÃ±ol)Â " />
+<link rel="canonical" href="//www.fema.gov/hurricane-maria" />
+<link rel="shortlink" href="//www.fema.gov/hurricane-maria" />
+  <title>Hurricane Maria | FEMA.gov</title>
+  <link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css__LeQxW73LSYscb1O__H6f-j_jdAzhZBaesGL19KEB6U.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_2xIW1IpUWng78091LzPsPXymxLMidts3lbbb9KZibWE.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_g1h7Nl9-p95WQ-MsLSC6s6f4Ihg9aidwnpywdeKBAqQ.css" media="all" />
+<link type="text/css" rel="stylesheet" href="//www.fema.gov/sites/default/files/css/css_-w0pbrs7-nruEPQTSwXQ4_9HSkbl3qT-Ex7c5prUQs0.css" media="all" />
+<link href='//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800&subset=latin,cyrillic-ext,vietnamese,latin-ext,greek-ext,cyrillic' rel='stylesheet' type='text/css'>
+  <script language="javascript" type="text/javascript">
+    var ExpandAllSectionsText = "Expand All Sections";
+    var CollapseAllSectionsText = "Collapse All Sections";
+    var NoResultsFoundText = "";
+    var advancedSearchText = "Search for";
+    var NavigationPlaceholderText = "Start typing here to filterâ¦";
+    var SearchPlaceholderText = "Search anything on fema.gov";
+    var closeText = "Close";
+    var downloadAppLabel = "Install the FEMA App";
+    var inThisSectionLabel = "In this Section";
+    var inThisSectionText = "In this Section";
+    var AppAuthSubText = "Remember to plug in your PIV/CAC card.";
+    var PivH2 = "PIV Card Login";
+    //MediaElement variables
+    var playButton = "Play.";
+    var progressBar = "Progress Bar.";
+    var closedCaptionButton = "Closed caption button.";
+    var volumeButton = "Volume button.";
+    var fullScreenButton = "Fullscreen button.";
+  </script>
+    <script src="//www.fema.gov/sites/default/files/js/js_lZ9kpQqrFO9iMOrWRPD2c5I8gI7-sX7TO_pTARrQEMU.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_THcwq4G882w3Eb1HklHrvzGAKa_-1g_0QbuBqjMhaV4.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_NpX2cwCeepkWZZ194B6-ViyVBHleaYLOx5R9EWBOMRU.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_Js4lOJ0_Am6ebnC0EP-psjO8Yu5gmlcOhu72hrxvi2s.js"></script>
+<script>window.CKEDITOR_BASEPATH = '/sites/all/libraries/ckeditor/'</script>
+<script src="//www.fema.gov/sites/default/files/js/js_gPqjYq7fqdMzw8-29XWQIVoDSWTmZCGy9OqaHppNxuQ.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.fema.gov/sites/default/files/googleanalytics/analytics.js?oxd8w3","ga");ga("create", "UA-29391347-1", {"cookieDomain":".fema.gov"});ga("set", "anonymizeIp", true);ga("send", "pageview");</script>
+<script src="//www.fema.gov/sites/default/files/js/js_x1Asg_paR91u1arDvF7gS_xR7fthnVj3L414MbNvdNU.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_7E18bMLOJVTzOcxdValVlyzHz_k7NhhgkX2FcSMA2HA.js"></script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"unicorn","theme_token":"9K9IaRk3fwYljPmaHdiHkU_eSiMpY9KNEtqrjotlkho","js":{"profiles\/fema_gov\/modules\/contrib\/extlink_extra\/extlink_extra.js":1,"profiles\/fema_gov\/themes\/bootstrap\/js\/bootstrap.js":1,"sites\/all\/modules\/jquery_update\/replace\/jquery\/1.9\/jquery.min.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/jquery_update\/replace\/ui\/external\/jquery.cookie.js":1,"sites\/all\/modules\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"sites\/all\/modules\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"profiles\/fema_gov\/modules\/contrib\/extlink\/extlink.js":1,"profiles\/fema_gov\/libraries\/colorbox\/jquery.colorbox-min.js":1,"sites\/all\/modules\/colorbox\/js\/colorbox.js":1,"sites\/all\/modules\/colorbox\/styles\/default\/colorbox_style.js":1,"sites\/all\/modules\/colorbox\/js\/colorbox_load.js":1,"sites\/all\/modules\/colorbox\/js\/colorbox_inline.js":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/js\/wcm_survey.js":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/js\/json3.min.js":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/js\/jquery.cookie.js":1,"0":1,"sites\/all\/modules\/google_analytics\/googleanalytics.js":1,"1":1,"profiles\/fema_gov\/themes\/unicorn\/js\/mediaelement\/build\/mediaelement-and-player.min.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_mediaelement_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_image_rotator.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/affix.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/alert.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/button.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/carousel.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/collapse.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/dropdown.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/modal.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/tooltip.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/popover.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/scrollspy.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/tab.js":1,"profiles\/fema_gov\/themes\/unicorn\/..\/bootstrap\/bootstrap\/js\/transition.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_content_collapse.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_nav_filter.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_site_wide_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_social_images.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_download_app.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/tablesorter.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_tables.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/stacktable.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_mobile_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/left_menu_collapse.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/unicorn_is_useful_fixes.js":1,"profiles\/fema_gov\/themes\/unicorn\/js\/jquery.dataTables.min.js":1},"css":{"modules\/system\/system.base.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"profiles\/fema_gov\/modules\/features\/fema_diamond\/fema_diamond.css":1,"sites\/all\/modules\/date\/date_api\/date.css":1,"sites\/all\/modules\/date\/date_popup\/themes\/datepicker.1.7.css":1,"sites\/all\/modules\/date\/date_repeat_field\/date_repeat_field.css":1,"profiles\/fema_gov\/modules\/custom\/diamond\/diamond.css":1,"profiles\/fema_gov\/modules\/custom\/fema_faq\/css\/fema_faq.css":1,"modules\/field\/theme\/field.css":1,"profiles\/fema_gov\/modules\/custom\/wcm_survey\/wcm_survey.css":1,"profiles\/fema_gov\/modules\/custom\/workbench_notification\/workbench_notification.css":1,"profiles\/fema_gov\/modules\/custom\/diamond\/diamond_medialibrary\/diamond_medialibrary.css":1,"profiles\/fema_gov\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/views\/css\/views.css":1,"sites\/all\/modules\/colorbox\/styles\/default\/colorbox_style.css":1,"sites\/all\/modules\/ctools\/css\/ctools.css":1,"profiles\/fema_gov\/modules\/contrib\/extlink_extra\/extlink_extra.508.css":1,"profiles\/fema_gov\/themes\/unicorn\/js\/mediaelement\/build\/mediaelementplayer.css":1,"profiles\/fema_gov\/themes\/unicorn\/css\/style.css":1,"profiles\/fema_gov\/themes\/unicorn\/css\/jquery.dataTables.min.css":1}},"colorbox":{"opacity":"0.85","current":"{current} of {total}","previous":"\u00ab Prev","next":"Next \u00bb","close":"Close","maxWidth":"98%","maxHeight":"98%","fixed":true,"mobiledetect":true,"mobiledevicewidth":"480px"},"wcmSurvey":{"userPercentage":"25","pageDepth":"4","url":"\/\/www.surveymonkey.com\/s\/FEMAgov","force":false,"surveyRetakeTimeout":"90","surveyPopup":"\u003Cdiv id=\u0022wcm-survey-popup\u0022 class=\u0022unicorn\u0022\u003E\n  \u003Cdiv class=\u0022logo\u0022\u003E\n    \u003Cimg alt=\u0022Federal Emergency Management Agency Seal\u0022 src=\u0022\/\/www.fema.gov\/sites\/default\/files\/images\/fema_surveypopup.png\u0022\/\u003E\n  \u003C\/div\u003E\n  \u003Cdiv class=\u0022message\u0022\u003E\n    \u003Cp\u003EYou have been selected to participate in a brief survey about your experience today with FEMA.gov.\u003C\/p\u003E  \u003C\/div\u003E\n  \u003Cdiv class=\u0022choices\u0022\u003E\n    \u003Cspan class=\u0022button yes\u0022\u003E\u003Ca title=\u0022Yes, I\u0027ll give feedback\u0022 href=\u0022\/\/www.surveymonkey.com\/s\/FEMAgov\u0022 class=\u0022accept\u0022 target=\u0022_blank\u0022 id=\u0022external_link\u0022\u003EYes, I\u0027ll give feedback\u003C\/a\u003E\u003C\/span\u003E\n    \u003Cspan class=\u0022button no\u0022\u003E\u003Ca title=\u0022No Thanks, I do not want to give feedback\u0022 href=\u0022#\u0022 class=\u0022decline\u0022\u003ENo, thanks\u003C\/a\u003E\u003C\/span\u003E\n  \u003C\/div\u003E\n\u003C\/div\u003E\n","debugMode":1,"position":"top","offset":"65px","height":"250px","width":"631px","maxHeight":"75%","maxWidth":"75%"},"diamondMedialibrary":{"path":"media-library"},"extlink":{"extTarget":0,"extClass":0,"extLabel":"(link is external)","extImgClass":0,"extSubdomains":1,"extExclude":"(.*\\.gov)|(.*\\.mil)|(\\.addthis.com)|(.*\\.fema.net)|(s3-us-gov-west-1\\.amazonaws\\.com)|(surveymonkey\\.com)","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":{"value":"You are now leaving an official website of the Federal Emergency Management Agency. Links to non-FEMA sites are provided for the visitor\u0027s convenience and do not represent an endorsement by FEMA of any commercial or private issues, products or services. Note that the privacy policy of the linked site may differ from that of FEMA.","format":"untouched_html"},"mailtoClass":0,"mailtoLabel":"(link sends e-mail)"},"extlink_extra":{"extlink_alert_type":"confirm","extlink_alert_timer":"0","extlink_alert_url":"\/now-leaving","extlink_cache_fix":0,"extlink_exclude_warning":"","extlink_508_fix":1,"extlink_508_text":" [external link]","extlink_url_override":0,"extlink_url_params":{"external_url":null,"back_url":null}},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m)?|xml|z|zip","trackColorbox":1,"trackDomainMode":"1"},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+  <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEMA" id="_fed_an_ua_tag"></script>
+<!--[if lt IE 9]>
+	  <link rel="stylesheet" href="/profiles/fema_gov/themes/unicorn/css/ie8.css">
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in one-sidebar sidebar-first page-node page-node- page-node-315781 node-type-site-page i18n-en unicorn" >
+<div id="skip-link">
+  <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+</div>
+
+
+
+<!-- this holds the mobile nag in desktop view -->
+<div id="dialog-download-app"></div>
+
+<div class="main-container container">
+  <div class="dg-bg"></div>
+  <div class="block-left">
+    <div class="global-nav-wrapper">
+      <div class="logo">
+
+                <a class="logo" href="/"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/fema-logo-main.png" alt="US Department of Homeland Security - Federal Emergency Management Agency" lang="en" /></a>
+      </div><!-- .logo -->
+
+      <div class="global-nav">
+
+        <!-- Global Navigation -->
+        <div type="" class="global-nav-modal" data-toggle="modal" data-target="#navigation" tabindex="0">
+          Navigation        </div>
+
+        <div class="modal fade" id="navigation" tabindex="-1" role="dialog" aria-labelledby="navigationLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                  <span aria-hidden="true"><div class="close-icon">&times;</div></span>
+                  <div class="close-text">Close</div>
+                </button>
+                <div class="modal-title" id="navigationLabel">Navigation</div>
+                <label for="unicornNavSearchBox">Enter Search Term(s):</label>
+                <input placeholder="Start typing here to filterâ¦" id="unicornNavSearchBox" type="text" size="31" />
+              </div><!-- .modal-header -->
+              <div class="modal-body">
+                <div id="navigationItems">
+                  <div id="noResults"> </div>
+                  <ul id="unicornNavFilter"><li class="first collapsed"><a href="/about-agency">About the Agency</a></li>
+<li class="leaf"><a href="/volunteer-donate-responsibly">Volunteer &amp; Donate Responsibly</a></li>
+<li class="collapsed"><a href="/apply-assistance">Apply for Assistance</a></li>
+<li class="collapsed"><a href="/welcome-assistance-firefighters-grant-program" title="Assistance To Firefighters Grant Program">Assistance To Firefighters Grant Program</a></li>
+<li class="leaf"><a href="/authorized-equipment-list" title="">Authorized Equipment List</a></li>
+<li class="collapsed"><a href="/blog">Blog</a></li>
+<li class="leaf"><a href="https://careers.fema.gov" title="">Careers</a></li>
+<li class="collapsed"><a href="/faith">Center for Faith-Based &amp; Neighborhood Partnerships</a></li>
+<li class="leaf"><a href="/children-and-disasters">Children and Disasters</a></li>
+<li class="leaf"><a href="/climate-change">Climate Change</a></li>
+<li class="collapsed"><a href="/community-resilience-indicators">Community Resilience Indicators and National-Level Measures: A Draft Interagency Concept</a></li>
+<li class="collapsed"><a href="/contact-us">Contact Us</a></li>
+<li class="collapsed"><a href="/dam-safety">Dam Safety</a></li>
+<li class="collapsed"><a href="/data-visualization">Data Visualization</a></li>
+<li class="collapsed"><a href="/disability" title="">Disability</a></li>
+<li class="collapsed"><a href="/disaster-assistance-reports">Disaster Assistance Reports</a></li>
+<li class="collapsed"><a href="/disasters" title="">Disaster Declarations</a></li>
+<li class="collapsed"><a href="/disaster-emergency-communications">Disaster Emergency Communications</a></li>
+<li class="leaf"><a href="/disaster-recovery-centers">Disaster Recovery Centers</a></li>
+<li class="leaf"><a href="/media-library/resources-documents" title="">Document and Resource Library</a></li>
+<li class="collapsed"><a href="/email">Email Updates</a></li>
+<li class="leaf"><a href="/emergency-management-agencies">Emergency Management Agencies</a></li>
+<li class="leaf"><a href="//training.fema.gov/emi" title="">Emergency Management Institute</a></li>
+<li class="leaf"><a href="/el-nino" title="">El NiÃ±o</a></li>
+<li class="collapsed"><a href="/office-environmental-planning-and-historic-preservation">Environmental Planning and Historic Preservation Program</a></li>
+<li class="collapsed"><a href="/ned">Exercise</a></li>
+<li class="leaf"><a href="/fact-sheets">Fact Sheets</a></li>
+<li class="collapsed"><a href="/finance-center">Finance Center</a></li>
+<li class="collapsed"><a href="/national-flood-insurance-program-flood-hazard-mapping">Flood Hazard Mapping</a></li>
+<li class="collapsed"><a href="/national-flood-insurance-program">Flood Insurance</a></li>
+<li class="leaf"><a href="//msc.fema.gov/portal/" title="">Flood Map Service Center</a></li>
+<li class="leaf"><a href="/faq/" title="">Frequently Asked Questions (FAQs)</a></li>
+<li class="collapsed"><a href="/grants" title="Grants">Grants</a></li>
+<li class="collapsed"><a href="/grants-management-modernization-program">Grants Management Modernization Program</a></li>
+<li class="collapsed"><a href="/hazard-mitigation-assistance">Hazard Mitigation Assistance</a></li>
+<li class="collapsed"><a href="/hazard-mitigation-planning">Hazard Mitigation Planning</a></li>
+<li class="collapsed"><a href="/hazus">Hazus</a></li>
+<li class="collapsed"><a href="/high-water-mark-initiative">High Water Mark Initiative</a></li>
+<li class="leaf"><a href="https://www.fema.gov" title="">Home</a></li>
+<li class="leaf"><a href="/how-make-payment-fema" title="">How to Make a Payment to FEMA</a></li>
+<li class="collapsed"><a href="/hurricane-harvey">Hurricane Harvey</a></li>
+<li class="collapsed"><a href="/hurricane-irma">Hurricane Irma</a></li>
+<li class="collapsed"><a href="/hurricane-maria" class="active">Hurricane Maria</a></li>
+<li class="collapsed"><a href="/hurricane-katrina-decade-progress-through-partnerships">Hurricane Katrina</a></li>
+<li class="leaf"><a href="/incident-management-assistance-teams" title="">Incident  Management Assistance Teams</a></li>
+<li class="leaf"><a href="https://training.fema.gov/is/" title="">Independent Study Program</a></li>
+<li class="leaf"><a href="/individual-and-community-preparedness-division">Individual and Community Preparedness Division</a></li>
+<li class="collapsed"><a href="/individual-assistance-program-tools">Individual Assistance Program Tools</a></li>
+<li class="collapsed"><a href="/individual-disaster-assistance">Individual Disaster Assistance</a></li>
+<li class="collapsed"><a href="/integrated-public-alert-warning-system">Integrated Public Alert &amp; Warning System</a></li>
+<li class="collapsed"><a href="/international-affairs">International Affairs</a></li>
+<li class="collapsed"><a href="/mobile-app">Mobile App</a></li>
+<li class="collapsed"><a href="/mississippi-recovery-office" title="">Mississippi Recovery</a></li>
+<li class="leaf"><a href="/media-library/multimedia/list" title="">Multimedia Library (Photos, Video, and Audio)</a></li>
+<li class="collapsed"><a href="/national-exercise-program">National Exercise Program</a></li>
+<li class="collapsed"><a href="/national-continuity-programs">National Continuity Programs</a></li>
+<li class="collapsed"><a href="/national-disaster-recovery-framework">National Disaster Recovery Framework</a></li>
+<li class="collapsed"><a href="/national-incident-management-system">National Incident Management System</a></li>
+<li class="collapsed"><a href="/national-preparedness">National Preparedness</a></li>
+<li class="leaf"><a href="/media-contacts">News Desk Contacts</a></li>
+<li class="collapsed"><a href="/news-releases" title="">News Releases</a></li>
+<li class="leaf"><a href="/official-accounts">Official Accounts</a></li>
+<li class="collapsed"><a href="/openfema">OpenFEMA</a></li>
+<li class="leaf"><a href="/preliminary-damage-assessment-reports" title="Preliminary Damage Assessments Reports">Preliminary Damage Assessment Reports</a></li>
+<li class="collapsed"><a href="/preparedness-non-disaster-grants">Preparedness (Non-Disaster) Grants</a></li>
+<li class="collapsed"><a href="/private-sector">Private Sector</a></li>
+<li class="collapsed"><a href="/protecting-homes">Protecting Homes</a></li>
+<li class="collapsed"><a href="/protecting-our-communities">Protecting Our Communities</a></li>
+<li class="collapsed"><a href="/protecting-your-businesses">Protecting Your Businesses</a></li>
+<li class="collapsed"><a href="/appeals" title="">Public Assistance Appeals Database</a></li>
+<li class="collapsed"><a href="/public-assistance-local-state-tribal-and-non-profit">Public Assistance: Local, State, Tribal and Non-Profit</a></li>
+<li class="collapsed"><a href="/recovery-resources">Recovery Resources</a></li>
+<li class="collapsed"><a href="/region-i-ct-me-ma-nh-ri-vt">Region I</a></li>
+<li class="collapsed"><a href="/region-ii-nj-ny-pr-vi-0">Region II</a></li>
+<li class="collapsed"><a href="/region-iii-dc-de-md-pa-va-wv">Region III</a></li>
+<li class="collapsed"><a href="/region-iv-al-fl-ga-ky-ms-nc-sc-tn">Region IV</a></li>
+<li class="collapsed"><a href="/region-v-il-mi-mn-oh-wi">Region V</a></li>
+<li class="collapsed"><a href="/region-vi-arkansas-louisiana-new-mexico-oklahoma-texas">Region VI</a></li>
+<li class="collapsed"><a href="/region-vii-ia-ks-mo-ne">Region VII</a></li>
+<li class="collapsed"><a href="/region-viii-co-mt-nd-sd-ut-wy">Region VIII</a></li>
+<li class="collapsed"><a href="/fema-region-ix-arizona-california-hawaii-nevada-pacific-islands">Region IX</a></li>
+<li class="collapsed"><a href="/region-x-ak-id-or-wa">Region X</a></li>
+<li class="collapsed"><a href="/required-notices">Required Notices</a></li>
+<li class="collapsed"><a href="/reservist-program" title="Reservist Program">Reservist Program</a></li>
+<li class="collapsed"><a href="/safer-stronger-protected-homes-communities">Safer, Stronger, Protected Homes &amp; Communities</a></li>
+<li class="collapsed"><a href="/social-media">Social Media</a></li>
+<li class="leaf"><a href="/states" title="">States</a></li>
+<li class="leaf"><a href="/testimony-and-speeches">Testimony &amp; Speeches</a></li>
+<li class="leaf"><a href="/text-messages">Text Messages</a></li>
+<li class="collapsed"><a href="/fema-tribal-affairs">Tribal</a></li>
+<li class="collapsed"><a href="/unified-federal-environmental-and-historic-preservation-review-presidentially-declared-disasters">Unified Federal Environmental and Historic Preservation Review</a></li>
+<li class="collapsed"><a href="/urban-search-rescue">Urban Search and Rescue</a></li>
+<li class="leaf"><a href="/us-coast-guard-retiree-fema-reservist-initiative">U.S. Coast Guard Retiree to FEMA Reservist Initiative</a></li>
+<li class="last collapsed"><a href="/voluntary-faith-based-community-based-organizations">Voluntary, Faith-Based, &amp; Community-Based Organizations</a></li>
+</ul>                </div><!-- .navigationItems -->
+              </div><!-- .modal-body -->
+            </div><!-- .modal-content -->
+          </div><!-- .modal-dialog -->
+        </div><!-- .modal -->
+
+        <!-- Global Search -->
+        <div type="" class="global-search" data-toggle="modal" data-target="#uniSearch" tabindex="0">
+          Search        </div>
+
+        <div class="modal fade search-modal" id="uniSearch" tabindex="-1" role="dialog" aria-labelledby="uniSearchLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                  <span aria-hidden="true"><div class="close-icon">&times;</div></span>
+                  <div class="close-text">Close</div>
+                </button>
+                <div class="modal-title" id="uniSearchLabel">Search</div>
+              </div><!-- .modal-header -->
+              <div class="modal-body">
+                <form accept-charset="UTF-8" action="//search.usa.gov/search" id="search_form" method="get">
+                  <div style="margin:0;padding:0;display:inline">
+                    <input name="utf8" type="hidden" value="&#x2713;" />
+                  </div>
+                  <input id="affiliate" name="affiliate" type="hidden" value="fema" />
+                  <label for="query">Enter Search Term(s):</label>
+                  <input placeholder="Search anything on fema.gov" autocomplete="off" class="usagov-search-autocomplete" id="query" name="query" type="text" size="31" />
+                  <input class="search-submit" name="commit" type="submit" value="GO" />
+                </form>
+              </div><!-- .modal-body -->
+            </div><!-- .modal-content -->
+          </div><!-- .modal-dialog -->
+        </div><!-- .modal -->
+
+        <!-- Global Languages -->
+        <div type="" class="language-modal" data-toggle="modal" data-target="#language" tabindex="0">
+          Languages        </div>
+
+        <div class="modal fade language" id="language" tabindex="-1" role="dialog" aria-labelledby="navigationLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                  <span aria-hidden="true"><div class="close-icon">&times;</div></span>
+                  <div class="close-text">Close</div>
+                </button>
+                <div class="modal-title" id="navigationLabel">Languages</div>
+              </div><!-- .modal-header -->
+              <div class="modal-body">
+                <ul><li><a href="/" lang="en">English</a></li><li><a href="/es" lang="es">EspaÃ±ol</a></li><li><a href="/fr" lang="fr">FranÃ§ais</a></li><li><a href="/el" lang="el">ÎÎ»Î»Î·Î½Î¹ÎºÎ¬</a></li><li><a href="/ar" lang="ar">Ø§ÙØ¹Ø±Ø¨ÙØ©</a></li><li><a href="/zh-hans" lang="zh-hans">ç®ä½ä¸­æ</a></li><li><a href="/de" lang="de">Deutsch</a></li><li><a href="/ht" lang="ht">Haitian Creole</a></li><li><a href="/he" lang="he">×¢××¨××ª</a></li><li><a href="/hi" lang="hi">à¤¹à¤¿à¤¨à¥à¤¦à¥</a></li><li><a href="/it" lang="it">Italiano</a></li><li><a href="/ja" lang="ja">æ¥æ¬èª</a></li><li><a href="/ko" lang="ko">íêµ­ì´</a></li><li><a href="/pl" lang="pl">Polski</a></li><li><a href="/pt-br" lang="pt-br">PortuguÃªs</a></li><li><a href="/ru" lang="ru">Ð ÑÑÑÐºÐ¸Ð¹</a></li><li><a href="/tl" lang="tl">Tagalog</a></li><li><a href="/th" lang="th">à¸ à¸²à¸©à¸²à¹à¸à¸¢</a></li><li><a href="/ur" lang="ur">Ø§Ø±Ø¯Ù</a></li><li><a href="/vi" lang="vi">Tiáº¿ng Viá»t</a></li><li><a href="/yi" lang="yi">Yiddish</a></li></ul>              </div><!-- .modal-body -->
+            </div><!-- .modal-content -->
+          </div><!-- .modal-dialog -->
+        </div><!-- .modal -->
+
+      </div><!-- .global-nav -->
+
+      <!-- Left Sidebar (Rendered) -->
+      <div class="contextual-nav-desktop"></div>
+        <div class="region region-sidebar-first">
+    <div class="menu-block-wrapper menu-block-8 menu-name-menu-left-menu parent-mlid-0 menu-level-1">
+  <ul><li class="first last expanded active-trail active menu-mlid-45013"><a href="/hurricane-maria" class="active-trail active">Hurricane Maria</a><ul><li class="first leaf menu-mlid-45042"><a href="/disaster/updates/hurricane-maria-rumor-control" title="">Rumor Control</a></li>
+<li class="leaf menu-mlid-45019"><a href="/disaster/updates/hurricane-maria-news-graphics-and-social-media" title="">News, Graphics, &amp; Social Media</a></li>
+<li class="leaf menu-mlid-45031"><a href="/resources-people-disabilities-access-functional-needs" title="">Accessible ASL Videos</a></li>
+<li class="leaf menu-mlid-45035"><a href="https://www.fema.gov/disaster/4339" title="">Puerto Rico | DR-4339</a></li>
+<li class="last leaf menu-mlid-45032"><a href="https://www.fema.gov/disaster/4340" title="">Virgin Islands | DR-4340</a></li>
+</ul></li>
+</ul></div>
+  </div>
+
+    </div><!-- .global-nav-wrapper-->
+  </div><!-- .block-left -->
+
+  <!-- Skip Nav for Main Content -->
+  <a id="main-content" name="main-content" href="#" class="element-invisible element-focusable">Main Content</a>
+  <div class="block-right">
+
+    <div class="content-wrapper">
+      <section>
+                                  <h1 class="page-header">Hurricane Maria</h1>
+                                                                                                      <div class="region region-content">
+    <section id="block-block-5" class="block block-block clearfix">
+
+      
+  <script></script>
+<style type="text/css">
+
+
+/* This hides the related links section for disaster/4341 */
+body.page-node-317009 div.content > h2, body.page-node-317012 div.content > h2  {
+display: none;
+}
+
+body.page-taxonomy img.gis_image {
+   border: none;
+    height: 153px !important;
+    margin-right: 0;
+    max-width: 100% !important;
+    width: 198px !important;
+}
+
+div.leadership  {
+margin-bottom: 22px;
+}
+
+div.leadership div.col-md-9 {
+padding-left:0;
+margin-left:35px;
+}
+
+div.leadership-main div.col-md-2 {
+text-align:center;
+overflow: hidden;
+}
+
+div.headshot-wrapper-big {
+width:140px; 
+height: 175px; 
+text-align:center;
+overflow: hidden; 
+margin-top: 7px;
+}
+
+div.content img.leader-headshot-big {
+margin-left: -25px; 
+height:175px !important; 
+width:175px !important; 
+max-width: inherit !important; 
+text-align:center;
+}
+
+div.headshot-wrapper {
+height: 113px; 
+width:100px; 
+overflow:hidden; 
+text-align:center;
+}
+
+div.content img.leader-headshot-small {
+margin-left:-8px; 
+width:115px !important;
+height:115px !important;
+max-width: inherit !important; 
+}
+
+</style>
+</section> <!-- /.block -->
+<section id="block-system-main" class="block block-system clearfix">
+
+      
+  <div id="node-315781" class="node node-site-page clearfix">
+
+    
+            
+    
+    <div class="content">
+        <div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even"><p><img alt="" height="133" src="/sites/default/files/images/maria_updates_web.png" style="margin:0px 15px; float:right" width="295" />This is the main page for up-to-date resources and information on the federal response to Hurricane Maria.</p><p>Follow the direction of state, local, and tribal officials. (<strong><a href="/es/huracan-maria">EspaÃ±ol</a></strong>)<br />Â </p><div class="row row"><div class="col-sm-4"><strong>Puerto Rico | DR-4339</strong><ul><li><a href="/es/disaster/4339">EspaÃ±ol | Spanish</a></li><li><a href="/disaster/4339">English</a></li></ul></div><div class="col-sm-4"><strong>U.S. Virgin Islands | DR-4340</strong><ul><li><a href="/es/disaster/4340">EspaÃ±ol | Spanish</a></li><li><a href="/ht/disaster/4340">kreyÃ²l ayisyen | Haitian Creole</a></li><li><a href="/disaster/4340">English</a></li></ul></div></div><h2>Cell Phones: No Cost Roaming Charges</h2><p>All Cellular Service customers, in both Puerto Rico and the U.S Virgin Islands will have service upon the first roaming partners availability.</p><p>Service providers will not be charging additional roaming charges in the areas <strong>at this time</strong>. Please check with your service provider for the date âroamingâ charges will be reinstated.</p><p>If you are having difficulties âroamingâ on your cellular device simply âresetâ the phone by turning it all the way off for a few seconds. Once you turn your device back on, you should be able to âroamâ freely.</p><h2>How to Find or Reunite with Loved Ones</h2><p>Following events like Hurricane Maria, we understand that communications networks are not always operational. As communications are restored, there are numerous options for survivors, friends, and family members to search for loved ones.Â </p><p>Survivors with internet access are encouraged to connect with friends and family members via social media platforms. Additional resources below are suggested for those both outside and inside the impacted areas.</p><p><strong>American Red Cross</strong><img alt=" Check in yourself or check on loved ones. To register so people know you're safe and well, use the thumbs up icon in the Emergency App or register at redcross.org/safeandwell. Search for a loved one by name and phone number or name and home address at redcross.org/safeandwell. Download the Red Cross Emergency App for free from your app store, or text GETEMERGENCY to 90999." src="/sites/default/files/images/redcrosssafewell.jpg" style="margin:10px 20px; width:582px; height:288px; float:right" /></p><p>The American Red Cross <a href="https://safeandwell.communityos.org/cms/index.php" target="_blank">Safe and Well website</a> allows individuals to register themselves as safe or search for loved ones. The site is always available, open to the public, and available in <a href="https://safeandwell.communityos.org/cms/index.php">English</a> and <a href="https://safeandwell-es.communityos.org/cms/">Spanish</a>. There are a number of ways to use this service:</p><ul><li>Registrations and searches can be done <strong>directly on the </strong><a href="https://safeandwell.communityos.org/cms/index.php"><strong>website</strong></a>.</li><li>Registrations can also be completed by <strong>texting SAFE to 78876</strong>. Messages exist in both Spanish and English.</li><li>To speak with someone at the American Red Cross concerning a missing friend or relative who has a serious, pre-existing health or mental health condition, please contact <strong>1-800 Red Cross (1-800-733-2767)</strong>.</li></ul><p>The American Red Cross <a href="http://www.redcross.org/get-help/how-to-prepare-for-emergencies/mobile-apps">Emergency App</a> features an âIâm Safeâ button that allows users to post a message to their social accounts, letting friends and family know they are out of harmâs way. The app can be downloaded for free in app stores by searching for âAmerican Red Crossâ or by texting âGETEMERGENCYâ to 90999.</p><p><strong>National Center for Missing &amp; Exploited Children </strong></p><p>Anyone who finds a child who may be separated from parents or caregivers, please contact the local police and enter basic information and/or a photo into the National Center for Missing &amp; Exploited Children's <a href="https://umr.missingkids.org/umr/reportUMR;jsessionid=91503C5C16CA4B963605DEBBF62F28CF?execution=e1s1" target="_blank">Unaccompanied Minors Registry</a>. If you find an unaccompanied child, please indicate whether the child has a disability or has access and functional needs in the appropriate field in the <a href="https://umr.missingkids.org/umr/reportUMR?execution=e1s1" target="_blank">Unaccompanied Minors Registry</a>. If you do not have access to the internet, please call 1-866-908-9570.</p><p><strong>Information for Tourists</strong></p><p>Any tourists requiring transport off the islands should contact the U.S. Virgin Islands Department of Tourism at (340) 772-0357 or visit <a href="http://www.usviupdate.com/">www.usviupdate.com/</a> for additional information.</p><p>The Puerto Rico Tourism Company has set up a hotline at 877-976-2400 for people staying at hotels.</p><p><strong>Local Resources</strong></p><p>The <a href="http://prfaa.pr.gov/">Puerto Rico Federal Affairs Administration</a> directed those seeking information or assistance to call 202-800-3133 or email <a href="mailto:maria1@prfaa.pr.gov">maria1@prfaa.pr.gov</a>.</p><p>Additional information for the U.S. Virgin Islands is available at the following locations:</p><ul><li><a href="http://VIalert.gov">VIalert.gov</a></li><li><a href="http://USVIupdate.com">USVIupdate.com</a></li><li><a href="http://www.informusvi.com/">InformUSVI.com</a></li></ul><h2>Federal Response Updates</h2><p></p><p><em>All figures as of October 5, 2017, 10 am EDT</em></p><p></p><div class="image-caption-outter-wrapper"><div class="image-caption-wrapper image-wrapper-right"><img src="/sites/default/files/images/3837203.jpg" alt="a soldier in uniform hugs a woman" title="" width="500px" height="334" /><div class="image-caption image-caption" style="max-width:500px">Coast Guard crews deliver relief supplies to residents in Bayamon, Puerto Rico. Credit: DVIDS  </div></div></div><strong>Federal Force Laydown</strong><ul><li>There are <strong>more than 14,000 federal staff</strong> including <strong>more than 800 FEMA personnel</strong>, on the ground in Puerto Rico and the U.S. Virgin Islands engaged in response and recovery operations from Hurricanes Maria and Irma.</li><li><strong>19 states</strong> supporting <strong>64</strong> <strong>requests </strong>for mutual aid</li></ul><p><strong>Survivor Impacts</strong></p><ul><li>All municipalities are eligible for Individual Assistance</li><li>Approximately <strong>65% of grocery stores</strong> are open</li><li>Mail pick-up or delivery to P.O. boxes at all 128 post offices including Vieques and Culebra</li></ul><p><strong>Transportation Impacts</strong></p><ul><li>More than<strong> 30 miles</strong> <strong>of roadway cleared</strong></li><li><strong>100% of federally maintained </strong><strong>ports</strong> are open or open with restrictions</li><li><strong>100% airports</strong> are open or open with restrictions</li></ul><p></p><div class="image-caption-outter-wrapper"><div class="image-caption-wrapper image-wrapper-right"><img src="/sites/default/files/images/3837350.jpg" alt="A long line of people form a chain to distribute cases of water" title="" width="500px" height="332" /><div class="image-caption image-caption" style="max-width:500px">Citizen-Soldiers from the New York National Guard work alongside the Puerto Rico National Guard and community members to bring water to residents in Lares, Puerto Rico. Credit: DVIDS  </div></div></div><strong>Water/Wastewater Impacts</strong><ul><li><strong>64% of waste water treatment plants</strong> are working on generator power</li></ul><p><strong>Hospitals and Medical Care Impacts</strong></p><ul><li>To provide additional surge capacity if needed, the Department of Defense hospital ship <strong>USNS Comfort</strong> arrived in Puerto Rico on October 3<ul><li>The ship offers the <strong>full range of medical care</strong> with surgical, obstetric and pediatric capability and is equivalent to a level-two trauma center in the United States. The ship is staffed by more than <strong>500 medical personnel </strong>and support staff and holds <strong>250 hospital beds</strong>.</li></ul></li><li><strong>92% </strong>(64/68) hospitals are open</li><li><strong>96% </strong>Â (46/48) Dialysis Centers open</li></ul><p><strong>Commodity Distribution</strong></p><ul><li>FEMA, working in coordination with federal partners, has provided <strong>millions of meals</strong> and <strong>millions of liters of water</strong> to Puerto Rico and U.S. Virgin Islands. Additional meals and water continue to arrive to the islands regularly via air and sea.</li><li>As of October 1, the Governor of Puerto Rico established <strong>Regional Staging Areas</strong> around the island, serving all <strong>78 municipalities</strong>. The National Guard is delivering supplies to the regional staging areas around the island.</li></ul><p><strong>To see more photos of the federal response to Hurricane Maria, visit the following collections from our federal partners:</strong></p><ul><li><a href="https://www.dvidshub.net/feature/HurricaneMaria">U.S. Department of Defense Photos and Videos</a></li><li><a href="https://www.dvidshub.net/search/?q=HURRICANE+MARIA&amp;filter%5Bbranch%5D=Coast+Guard&amp;view=list&amp;sort=publishdate">U.S. Coast Guard Videos and Photos</a></li><li><div><div><div><div><div><div><div><p><a href="https://www.flickr.com/photos/cbpphotos/with/36563957134/">U.S. Customs and Border Protection Photos</a></p></div></div></div></div></div></div></div></li></ul><p><strong>On Social Media</strong></p><blockquote><p dir="ltr">Landslide or Road Blocked after <a href="https://twitter.com/hashtag/HurricaneMaria?src=hash&amp;ref_src=twsrc%5Etfw">#HurricaneMaria</a> No Problem, Customs and Border Protection crew delivers "food basket" <a href="https://twitter.com/DHSgov?ref_src=twsrc%5Etfw">@DHSgov</a> <a href="https://twitter.com/fema?ref_src=twsrc%5Etfw">@fema</a> <a href="https://t.co/zKDGY7wShu">pic.twitter.com/zKDGY7wShu</a></p>â CBP Southeast (@CBPSoutheast) <a href="https://twitter.com/CBPSoutheast/status/915916539878100992?ref_src=twsrc%5Etfw">October 5, 2017</a></blockquote><blockquote><p dir="ltr">Hereâs <a href="https://twitter.com/chefjoseandres?ref_src=twsrc%5Etfw">@chefjoseandres</a> sharing his plan to feed <a href="https://twitter.com/hashtag/Maria?src=hash&amp;ref_src=twsrc%5Etfw">#Maria</a> survivors across Puerto Rico with support from federal partners. <a href="https://t.co/gReRfYgvI2">pic.twitter.com/gReRfYgvI2</a></p>â FEMA (@fema) <a href="https://twitter.com/fema/status/915675333185110025?ref_src=twsrc%5Etfw">October 4, 2017</a></blockquote><blockquote><p dir="ltr">Soldiers partner with <a href="https://twitter.com/fema?ref_src=twsrc%5Etfw">@FEMA</a> urban Search &amp; Rescue teams to deliver food &amp; water to <a href="https://twitter.com/hashtag/PuertoRico?src=hash&amp;ref_src=twsrc%5Etfw">#PuertoRico</a> residents isolated by <a href="https://twitter.com/hashtag/HurricaneMaria?src=hash&amp;ref_src=twsrc%5Etfw">#HurricaneMaria</a> damage. <a href="https://t.co/DCiLZweeZ9">pic.twitter.com/DCiLZweeZ9</a></p>â U.S. Army North (@USArmyNorth) <a href="https://twitter.com/USArmyNorth/status/915574981676851200?ref_src=twsrc%5Etfw">October 4, 2017</a></blockquote><h2>Point of Distribution Locations</h2><p>Points of distribution are open in Puerto Rico and the U.S. Virgin Islands for survivors to get meals, water, and other commodities.</p><p><strong>U.S. Virgin Islands</strong></p><ul><li>Curfew 6 pm to 8 am on St. Thomas / St. John</li><li><strong>POD</strong>s on St. Thomas / St. John will be closed until Monday (10/02)<br />Â </li><li>Permanent suspension of curfew from 11am to 6pm daily on St. Croix</li><li><strong>POD</strong>s will reopen on St. Croix for service Friday, September 29th and Saturday, September 30th.<ul><li><p><strong>Open from 12pm to 4pm</strong></p><ul><li><p>Alexander Henderson School</p></li><li><p>Juanita Gardine Elementary School</p></li><li><p>Cotton Valley Fire Station</p></li><li><p>Educational ComplexÂ </p></li><li><p>Eulalie Rivera School<br />Â </p></li></ul></li><li><p><strong>Open Saturday, September 30th</strong></p><ul><li><p>Theodora Dunbavin Alternative Education</p></li></ul></li></ul></li></ul><p><strong>Puerto Rico</strong> - This list is as of 9/28/2017.</p><ul><li>More locations will be added to this list as they open.</li></ul><p>Please search below for your municipality and/or community.</p><table class="datatable"><thead><tr align="center"><th scope="col" style="width:50%">Community</th><th scope="col" style="width:50%">Municipality</th></tr></thead><tbody><tr><td>Arecibo I, II</td><td>Arecibo</td></tr><tr><td>Barceloneta</td><td>Arecibo</td></tr><tr><td>Hatillo</td><td>Arecibo</td></tr><tr><td>Camuy</td><td>Arecibo</td></tr><tr><td>Quebradilla</td><td>Arecibo</td></tr><tr><td>Florida</td><td>Arecibo</td></tr><tr><td>Manati</td><td>Arecibo</td></tr><tr><td>Lares</td><td>Arecibo</td></tr><tr><td>Ciales</td><td>Arecibo</td></tr><tr><td>Aguadilla</td><td>Aguadilla</td></tr><tr><td>Aguada</td><td>Aguadilla</td></tr><tr><td>RincÃ³n</td><td>Aguadilla</td></tr><tr><td>AÃ±asco</td><td>Aguadilla</td></tr><tr><td>Moca</td><td>Aguadilla</td></tr><tr><td>San Sebastian</td><td>Aguadilla</td></tr><tr><td>Isabela</td><td>Aguadilla</td></tr><tr><td>Guaynabo</td><td>Bayamon</td></tr><tr><td>Toa Baja</td><td>Bayamon</td></tr><tr><td>CataÃ±o</td><td>Bayamon</td></tr><tr><td>Toa Alta</td><td>Bayamon</td></tr><tr><td>Vega Alta</td><td>Bayamon</td></tr><tr><td>Dorado</td><td>Bayamon</td></tr><tr><td>Vega Baja</td><td>Bayamon</td></tr><tr><td>Comerio</td><td>Bayamon</td></tr><tr><td>Orocovis</td><td>Bayamon</td></tr><tr><td>Naranjito</td><td>Bayamon</td></tr><tr><td>Morovia</td><td>Bayamon</td></tr><tr><td>Corozal</td><td>Bayamon</td></tr><tr><td>Barranquitas</td><td>Bayamon</td></tr><tr><td>Canovanas</td><td>CanÃ³vanas</td></tr><tr><td>Carolina</td><td>CanÃ³vanas</td></tr><tr><td>San Juan</td><td>CanÃ³vanas</td></tr><tr><td>Trujillo Alto</td><td>CanÃ³vanas</td></tr><tr><td>Loisa</td><td>CanÃ³vanas</td></tr><tr><td>Rio Grande</td><td>CanÃ³vanas</td></tr><tr><td>Ceiba</td><td>Ceiba</td></tr><tr><td>Fajardo</td><td>Ceiba</td></tr><tr><td>Luquillo</td><td>Ceiba</td></tr><tr><td>Culebra</td><td>Ceiba</td></tr><tr><td>Vieques</td><td>Ceiba</td></tr><tr><td>Naguabo</td><td>Ceiba</td></tr><tr><td>Yabucoa</td><td>Ceiba</td></tr><tr><td>Maunabo</td><td>Ceiba</td></tr><tr><td>Humacao</td><td>Ceiba</td></tr><tr><td>Caguas</td><td>Caguas</td></tr><tr><td>Cidra</td><td>Caguas</td></tr><tr><td>Cayey</td><td>Caguas</td></tr><tr><td>Aibonito</td><td>Caguas</td></tr><tr><td>Aguas Buenas</td><td>Caguas</td></tr><tr><td>Gurabo</td><td>Caguas</td></tr><tr><td>Juncos</td><td>Caguas</td></tr><tr><td>San Lorenzo</td><td>Caguas</td></tr><tr><td>Las Piedras</td><td>Caguas</td></tr><tr><td>Guayama</td><td>Guayama</td></tr><tr><td>Arroyo</td><td>Guayama</td></tr><tr><td>Patillas</td><td>Guayama</td></tr><tr><td>Salinas</td><td>Guayama</td></tr><tr><td>Coamo</td><td>Guayama</td></tr><tr><td>Santa Isabel</td><td>Guayama</td></tr><tr><td>MayagÃ¼ez</td><td>MayagÃ¼ez</td></tr><tr><td>Las Marias</td><td>MayagÃ¼ez</td></tr><tr><td>Maricao</td><td>MayagÃ¼ez</td></tr><tr><td>Hormigueros</td><td>MayagÃ¼ez</td></tr><tr><td>Cabo Rojo</td><td>MayagÃ¼ez</td></tr><tr><td>San German</td><td>MayagÃ¼ez</td></tr><tr><td>Sabana Grande</td><td>MayagÃ¼ez</td></tr><tr><td>Lajas</td><td>MayagÃ¼ez</td></tr><tr><td>Ponce</td><td>Ponce</td></tr><tr><td>Penuelas</td><td>Ponce</td></tr><tr><td>Guayanilla</td><td>Ponce</td></tr><tr><td>Yauco</td><td>Ponce</td></tr><tr><td>Guanica</td><td>Ponce</td></tr><tr><td>Juana Diaz</td><td>Ponce</td></tr><tr><td>Villalba</td><td>Ponce</td></tr><tr><td>Adjuntas</td><td>Ponce</td></tr><tr><td>Utuado</td><td>Utuado</td></tr></tbody></table><h2>How to Help</h2><div><ul></ul><p><img alt=" How to help after a disaster. The best way to help is with cash donations to trusted organizations. Cash is efficient, flexible to use, and requires no packaging or transport. Trusted organizations will ensure your money goes to help those in need." src="https://www.fema.gov/media-library-data/1476464381286-7e0b131f31391ddac73f3bdf11f69d2e/donations_medium.png" style="margin:10px 15px; width:400px; height:283px; float:right" /></p><p>For Hurricane Maria, there are three ways that the public can most effectively and efficiently help provide support for survivors in Puerto Rico and the U.S. Virgin Islands.</p><p><strong><em>The fastest way to help â cash is best</em></strong></p><p>The most effective means to support recovery of communities affected by Hurricane Maria is to donate money to trusted voluntary-, faith- and community-based charitable organizations. This gives these organizations the ability to purchase what survivors need right now. In addition, when these organizations purchase goods or services locally, they pump money back into the local and regional economy, helping businesses recover faster.</p><ul><li>To make a cash donation directly to the Commonwealth of Puerto Rico, visit <a href="http://www.unitedforpuertorico.com">www.unitedforpuertorico.com</a>.Â </li></ul><p><strong><em>Donating Goods</em></strong></p><p>It is important to remember unsolicited donated goods (e.g., clothing, miscellaneous household items, and mixed or perishable foodstuffs) require voluntary agencies to redirect valuable resources away from providing services to sort, package, transport, warehouse, and distribute items that may not meet the needs of disaster survivors.Â Â </p><ul><li>To responsibly donate goods, the <a href="https://www.nvoad.org/howtohelp/donate/">NVOAD website</a> has information on non-profit organizations accepting or registering individual and corporate in-kind donations.</li><li>If you would like to give in-kind donations, coordinate with NVOAD organizations to identify the best ways to pick up and drop off your donations.</li></ul><p><strong><em>Volunteering</em></strong></p><p>Anyone seeking an opportunity to get involved in response and recovery operations underway is encouraged to volunteer with local and nationally known organizations.</p><ul><li>To register as an affiliated volunteer with a voluntary or charitable organization, visit the <a href="https://www.nvoad.org/voad-members/">National VOAD</a> for a list of partners active in disaster.</li></ul><p>Thank you for your interest in helping the survivors of Hurricane Maria. When disaster strikes, America looks to FEMA to support survivors and first responders in communities all across the country. We are <a href="http://careers.fema.gov/hurricane-workforce">currently seeking talented and hard-working people</a> to help support the hurricane response and recovery efforts.</p><h2>Urban Search &amp; Rescue Operations</h2><p>Urban Search &amp; Rescue teams have reached all municipalities. Teams have saved or assisted 843 individuals and searched over 2,600 structures.</p><h2>Puerto Rico Road Status</h2><p><img alt=" Inaccessible due to mudslide at 140 km in the direction of Mayaguez towards Arecibo. Lanes towards Mayaguez being used in both directions. Inaccessible from 148.7 km to 142.8 km due to flooding in both directions. Inaccessible due to mudslide and detachment of road at 54.4 km. Detour by PR-603 and PR-6103. Signage, lightning, and fallen trees. Accessible in both directions. Inaccessible at 22.6 km due to structural concerns in both directions. Inaccessible at 4.1 km due to flooding in both directions. Inaccessible in three segments in San Juan direction. Lanes toward Fajardo being used in both directions. Inaccessible in three segments in San Juan direction. Lanes towards Fajardo being used in both directions. Closed in direction to Caguas. Lanes towards Fajardo used in both direction. Inaccessible at 93.9 km towards Ponce. Emergency lane towards Caguas being used in opposite direction. Inaccessible due to structural damage of bridge at 1 km. Inaccessible at 200 km in both directions due to flood. Lanes towards Mayaguez being used in both directions. Inaccessible due to mudslide at 12.6 km. Inaccessible from 148.7 km to 142.km due to flooding in both directions." src="/sites/default/files/images/maria_leadershipmapbook_20170928_0800v2_withlogo.png" style="height:711px" /></p><h2>Safety Tips</h2><ul><li>If you encounter flood waters, remember â <strong>turn around, donât drown</strong>. Don't drive through a flooded area.</li><li><strong>Avoid debris, downed power lines, and flood water,</strong> which may be electrically charged and hide dangerous debris or places where the ground is washed away. Avoid downed power or utility lines as they may be live with deadly voltage. Stay away and report them immediately to your power or utility company.</li><li>Emergency workers may be assisting people in flooded areas or cleaning up debris. You can help them by <strong>staying off the roads and out of the way as much as possible</strong>.</li><li>If your home has flood water inside or around it, donât walk or wade in it.The water may be contaminated by oil, gasoline, or raw sewage.</li><li>If you have a flooded basement in your home, never attempt to turn off power or operate circuit breakers while standing in water.</li><li>If your power is out, safely use a generator or battery-operated flashlights.</li><li><strong>Never use a generator inside a home, basement, shed or garage</strong> even if doors and windows are open.</li><li>Keep generators outside and far away from windows, doors and vents. Read both the label on your generator and the owner's manual and follow the instructions.</li><li><strong>Avoid plugging emergency generators into electric outlets</strong> or hooking them directly to your home's electrical system â they can feed electricity back into the power lines, putting you and line workers in danger.<p style="text-align:center"><img alt=" Listen to local officials for updates and instructions. Use texts or social media to check in with friends and family. Watch out for debris and downed power lines. Stay out of damaged buildings and homes until local authorities say it's safe. Photograph the damage to your property to assist in filing an insurance claim." src="https://www.fema.gov/media-library-data/1490804363803-8b43ce0fe9b98b8c000069ab9162a265/NeighborCheck10_medium.jpg" style="margin:10px 15px; width:724px; height:617px" /></p></li></ul></div><h2>Beware of Fraud &amp; Price Gouging</h2><p>After a disaster scam artists, identity thieves and other criminals may attempt to prey on vulnerable survivors. The most common post-disaster fraud practices include phony housing inspectors, fraudulent building contractors, bogus pleas for disaster donations and fake offers of state or federal aid.</p><p><strong>Survivors should keep in mind</strong>:</p><ul><li>FEMA does not authorize individual contractors to solicit on its behalf.Â  Beware of any individual contractors contacting you directly on behalf of FEMA to sign you up for debris removal or remediation services.</li><li>If you have any concerns about individuals representing themselves as FEMA or would like to report fraud, please contact the National Center for Disaster Fraud at (866) 720-5721 or via email at <a href="mailto:disaster@leo.gov"><strong>disaster@leo.gov</strong></a>.Â </li><li>Federal and state workers never ask for, or accept money, and always carry identification badges</li><li>There is <strong>NO FEE </strong>required to apply for or to get disaster assistance from FEMA, the U.S. Small Business Administration or the state</li><li>Scam attempts can be made over the phone, by mail or email, text or in person</li></ul><p><strong>Price Gouging </strong></p><p>Price gouging occurs when a supplier marks up the price of an item more than is justified by his actual costs. Survivors are particularly susceptible because their needs are immediate, and have few alternatives to choose from. If you find price gouging report below:</p><p><strong>Report Price Gouging</strong></p><p><strong>Puerto Rico</strong>:<br />United States Attorney's Office<br />Torre ChardÃ³n, Suite 1201<br />350 Carlos ChardÃ³n Street<br />San Juan, PR 00918</p><ul><li>Main Phone: (787) 766-5656</li><li>Toll Free Phone: 1â877âUSAâ5656 (1-877â872â5656)</li></ul><p>Â <br /><strong>U.S. Virgin Islands</strong>:<br />United States Attorney's Office<br />Federal Building &amp; U.S. Courthouse<br />Room 260<br />5500 Veterans Drive<br />St. Thomas, VI 00802-6424</p><ul><li>St. Thomas Main Phone: 340-774-5757</li><li>St. Croix Main Phone: 340-773-3920</li></ul><p><strong>Dealing with Contractors</strong>:</p><p>Survivors should take steps to protect themselves and avoid fraud when hiring contractors to clean property, remove debris or make repairs.</p><p><strong>Simple rules to avoid becoming a victim of fraud</strong>:</p><ul><li>Only use contractors licensed by your state</li><li>Get a written estimate and get more than one estimate</li><li>Demand and check references</li><li>Ask for proof of insurance<ul><li>i.e., liability and Workmen's Compensation</li></ul></li><li>Insist on a written contract and refuse to sign a contract with blank spaces</li><li>Get any guarantees in writing</li><li>Make final payments only after the work is completed</li><li>Pay by check.</li></ul><p>The best way to avoid fraud is to arm yourself against it by having a checklist to remind you of what you need to demand when hiring a contractor.</p><ul></ul><h2>Helping Children Cope</h2><div><p>To talk to a professional who can help you cope with emotional distress from the storm: Call the <a href="https://twitter.com/distressline">@disasterdistressline</a> at <strong>(800) 985-5990</strong> crisis support services are available <strong>24/7</strong>.</p><p>Children may cope more effectively with a disaster when they feel they understand what is happening and what they can do to help protect themselves, their family, and friends. Hereâs how you can help them cope and a <a href="/media-library/assets/documents/138687">Fact Sheet</a>:</p><ul><li>Talk about the concerns about the storm with your children. To not talk about it makes it even more threatening in your children's mind. Start by asking what your children have already heard and what understanding they have. As your children explain, listen for misinformation, misconceptions, and underlying fears or concerns, and then address these.</li><li>Explain - as simply and directly as possible - what is happening or likely to happen. The amount of information that will be helpful to children depends on their age and developmental level, as well as their coping style. For example, older children generally want and will benefit from more detailed information than younger children. Because every child is different, take cues from your own children as to how much information to provide.</li><li>Encourage your children to ask questions, and answer those questions directly. Like adults, children are better able to cope with a crisis if they feel they understand it. Question-and-answer exchanges help to ensure ongoing support as your children begin to understand the crisis and the response to it.</li><li>Limit television viewing of disasters and other crisis events, especially for younger children. Consider coverage on all media, including the internet and social media. When older children watch television, try to watch with them and use the opportunity to discuss what is being seen and how it makes you and your children feel.</li><li>Reassure children of the steps that are being taken to keep them safe. Disasters and other crises remind us that we are never completely safe from harm. Now more than ever it is important to reassure children that, in reality, they should feel safe in their schools, homes, and communities.</li><li>Consider sharing your feelings about a crisis with your children. This is an opportunity for you to role model how to cope and how to plan for the future. Before you reach out, however, be sure that you are able to express a positive or hopeful plan.</li><li>Help your children to identify concrete actions they can take to help those affected by recent events. Rather than focus on what could have been done to prevent a disaster or other crisis, concentrate on what can be done now to help those affected by the event.</li><li>Play games and do activities together to create meaningful dialogue and offer a distraction.</li><li>If you have concerns about your children's behavior, contact your children's pediatrician, other primary care provider, or a qualified mental health professional.</li></ul></div></div></div></div><div class="field field-name-field-updated-date field-type-entity-property-field field-label-inline clearfix"><div class="field-label">Last Updated:&nbsp;</div><div class="field-items"><div class="field-item even">10/05/2017 - 11:32</div></div></div>    </div>
+
+    
+    
+
+</div>
+
+
+</section> <!-- /.block -->
+  </div>
+        <div class="contextual-nav-mobile"></div>
+        <footer class="content-footer">
+          <a href="#footer-bottom" id="skipNavLink" class="element-invisible element-focusable">Skip footer content.</a>
+          <div class="clear"></div>
+            <div class="region region-footer">
+    <section id="block-unicorn-social-links-unicorn-social-links" class="block block-unicorn-social-links clearfix">
+
+      
+  <div class="socialImagesDiv">
+        <a id="showThisPageSpan" href="#"><span class="icon-show"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_share.png"  alt="Click to expand and share this page on social networks"></span><span id="showText">Share This Page.</span></a>
+        <div class="social-images">
+        <a href="https://www.facebook.com/sharer/sharer.php?u=UNIURL" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_facebook.png" alt="Facebook Icon"></a>
+        <a href="https://twitter.com/intent/tweet?text=Hurricane+Maria&url=UNIURL&via=fema" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_twitter.png" alt="Twitter Icon"></a>
+        <a href="https://www.linkedin.com/shareArticle?mini=true&url=UNIURL&title=Hurricane Maria&summary=&source=" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_linkedin.png" alt="LinkedIn Icon"></a>
+        <a href="https://plus.google.com/share?url=UNIURL" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_googleplus.png" alt="Google Plus Icon"></a>
+        <a href="http://www.tumblr.com/share/link?url=UNIURL&name=Hurricane Maria&description=" target="_blank"><img src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/social/icon_tumblr.png" alt="Tumblr Icon"></a>
+
+        </div>
+    </div>
+</section> <!-- /.block -->
+<section id="block-menu-menu-unicorn-footer-menu" class="block block-menu clearfix">
+
+      
+  <ul><li class="first leaf"><a href="/" title="">Home</a></li>
+<li class="leaf"><a href="/download-plug-ins" title="">Download Plug-ins</a></li>
+<li class="leaf"><a href="/about-agency" title="">About Us</a></li>
+<li class="leaf"><a href="/privacy-policy" title="">Privacy Policy</a></li>
+<li class="leaf"><a href="//www.oig.dhs.gov/" title="">Office of the Inspector General</a></li>
+<li class="leaf"><a href="/fema-strategic-plan" title="">Strategic Plan</a></li>
+<li class="leaf"><a href="//www.whitehouse.gov" title="">Whitehouse.gov</a></li>
+<li class="leaf"><a href="//www.dhs.gov" title="">DHS.gov</a></li>
+<li class="leaf"><a href="//www.ready.gov" title="">Ready.gov</a></li>
+<li class="leaf"><a href="//www.usa.gov" title="">USA.gov</a></li>
+<li class="last leaf"><a href="//www.disasterassistance.gov/" title="">DisasterAssistance.gov</a></li>
+</ul>
+</section> <!-- /.block -->
+<section id="block-boxes-unicorn-footer-dhs-text" class="block block-boxes block-boxes-simple clearfix">
+
+      
+  <div id='boxes-box-unicorn_footer_dhs_text' class='boxes-box'><div class="boxes-box-content"><p><a href="https://www.oig.dhs.gov/hotline"><img src="https://www.oig.dhs.gov/sites/default/files/img/oig-hotline.png" alt="OIG Hotline to report waste and abuse" /></a></p>
+<p lang="en"><img lang="en" src="//www.fema.gov/profiles/fema_gov/themes/unicorn/img/icon_usflag.gif" alt="US flag signifying that this is a United States Federal Government website"> Official website of the Department of Homeland Security</p></div></div>
+</section> <!-- /.block -->
+  </div>
+          <a id="footer-bottom" name="footer-bottom" href="#" class="element-invisible element-focusable">End of web page.</a>
+        </footer>
+      </section>
+      <div class="clearfix"></div>
+    </div><!-- .content-wrapper -->
+  </div><!-- .block-right -->
+</div><!-- main container -->
+
+<div class="container unicorn-home-page-secondary-content">
+  <div class="secondary-content">
+    <!-- use JS to inject content here from div.views-field-field-also-featured-content -->
+  </div><!-- .secondary-content -->
+
+  <div class="secondary-footer">
+    <!-- use JS to insert footer content here -->
+  </div><!-- .secondary-footer -->
+
+</div><!-- .unicorn-home-page-secondary-content -->
+<script src="//www.fema.gov/sites/default/files/js/js_AZ9y0PShar4GyPuQUcAgecHmIwX4TUOo0HFPa06mnF0.js"></script>
+<script src="//www.fema.gov/sites/default/files/js/js_x7i9_K8_u7Lf_Pr4XToSxjCDPT7-3IXdc15I1723_SU.js"></script>
+</body>
+</html>

--- a/web_monitoring/tests/test_html_diff.py
+++ b/web_monitoring/tests/test_html_diff.py
@@ -96,24 +96,31 @@ staging_version_ids = [
     # two `<ul>` elements on this page, but in the diff, the `<p>` gets moved
     # _into_ the `<ul>`, so it renders like a list item instead of like the
     # header-ish thing it actually is."
-     ('f2d5d701-707a-42e0-8881-653346d01e0a',
-      'fc74d750-c651-46b7-bf74-434ad8c62e04'),
-     # See issue #99
-     ('9d4de183-a186-456c-bffb-55d82989877d',
-      '775a8b04-9bac-4d0d-8db0-a8e133c4a964'),
-    ]
+    ('f2d5d701-707a-42e0-8881-653346d01e0a',
+     'fc74d750-c651-46b7-bf74-434ad8c62e04'),
+    # See issue #99
+    ('9d4de183-a186-456c-bffb-55d82989877d',
+     '775a8b04-9bac-4d0d-8db0-a8e133c4a964'),
+]
 
 # Fetch content as we need it, and cache. This can potentially matter if a
 # subset of the tests are run.
 version_content_cache = {}
-staging_cli = Client(
-    email=os.environ['WEB_MONITORING_DB_STAGING_EMAIL'],
-    password=os.environ['WEB_MONITORING_DB_STAGING_PASSWORD'],
-    url=os.environ['WEB_MONITORING_DB_STAGING_URL'])
-
-
-CACHE_DIR = Path.home() / Path('.cache', 'web-monitoring-processing', 'tests')
+CACHE_DIR = Path(__file__).resolve().parent / Path('fixtures', 'versions')
 os.makedirs(CACHE_DIR, exist_ok=True)
+
+
+def get_staging_cli():
+    try:
+        email = os.environ['WEB_MONITORING_DB_STAGING_EMAIL']
+        password = os.environ['WEB_MONITORING_DB_STAGING_PASSWORD']
+        url = os.environ['WEB_MONITORING_DB_STAGING_URL']
+    except KeyError:
+        raise Exception('''You must have the following env vars set to update fixture content:
+            WEB_MONITORING_DB_STAGING_EMAIL,
+            WEB_MONITORING_DB_STAGING_PASSWORD,
+            WEB_MONITORING_DB_STAGING_URL''')
+    return Client(email, password, url)
 
 
 def get_staging_content(version_id):
@@ -125,7 +132,7 @@ def get_staging_content(version_id):
             with open(CACHE_DIR / Path(version_id), 'r') as f:
                 content = f.read()
         except FileNotFoundError:
-            content = staging_cli.get_version_content(version_id)
+            content = get_staging_cli().get_version_content(version_id)
             with open(CACHE_DIR / Path(version_id), 'w') as f:
                 f.write(content)
         version_content_cache[version_id] = content

--- a/web_monitoring/tests/test_pf.py
+++ b/web_monitoring/tests/test_pf.py
@@ -1,3 +1,4 @@
+import pytest
 import web_monitoring.pagefreezer as pf
 
 
@@ -5,6 +6,7 @@ url1 = 'http://web.archive.org/web/20151204035406/http://www.energy.gov:80/techn
 url2 = 'http://web.archive.org/web/20151229231229/http://energy.gov:80/technologytransitions/us-department-energys-clean-energy-investment-center'
 
 
+@pytest.mark.skip(reason="PF diffs are no longer used and require PAGE_FREEZER_API_KEY environment var")
 def test_compare_and_df():
     # basic test just to exercise the important functions
     res = pf.compare(url1, url2)


### PR DESCRIPTION
This makes CI actually useful for PRs from forks.

1. Treat the versions that we need for tests as fixtures and store them *in the repo* instead of in an untracked cache on disk. This still preserves the ability to automagically grab new ones, but the credentials are only required if you’re doing that, which is extremely rare and should now never happen in CI.

2. Skip the PageFreezer diff tests. We don’t actually use that diff, so requiring everyone to have PF credentials and to run these tests seems unnecessary. (Still keeping the test around so folks with credentials *can* run it if needed.)