### PR TITLE
Move most editorconfig settings to all file types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,8 @@
-[*.py]
+[*]
 indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.py]
 max_line_length = 79


### PR DESCRIPTION
Prompted by repeated EOF problems on #187. I had assumed it would have been less of a pain because I thought we had `.editorconfig` set to include blank lines at the end of all text files. We didn’t, though!

This makes most of the `.editorconfig` settings apply to all file types, which seems right. Not sure why we were only applying rules to Python before (except max line length).