### PR TITLE
Remove usage of CircleCI contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ workflows:
   build:
     jobs:
       - build:
-          context: web-monitoring-staging-access
           filters:
             branches:
               ignore: master
@@ -72,7 +71,6 @@ workflows:
   build-and-publish:
     jobs:
       - build:
-          context: web-monitoring-staging-access
           filters:
             branches:
               only:


### PR DESCRIPTION
They didn't work out to do what we actually wanted, so we should get rid of them (they aren’t serving any useful purpose at all). For more about this dumb experiment, see:

- 58eaa40540b3936d433cf3defeb74c2e8822e7c0
- #181
- https://discuss.circleci.com/t/using-contexts-on-a-non-org-fork-by-an-in-org-user/21318