### PR TITLE
Ensure links diff columns are resonable widths

### DIFF
--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -85,6 +85,8 @@ def links_diff_html(a_text, b_text, a_headers=None, b_headers=None,
         }
         .links-list {
             border-collapse: collapse;
+            table-layout: fixed;
+            width: 100%;
         }
         .links-list th {
             background: #f6f6f6;
@@ -99,6 +101,13 @@ def links_diff_html(a_text, b_text, a_headers=None, b_headers=None,
             border-bottom: 1px solid #fff;
             opacity: 0.5;
             padding: 0.25em;
+        }
+        .links-list--change-type-col {
+            width: 1.5em;
+        }
+        .links-list--text-col,
+        .links-list--href-col {
+            width: 50%;
         }
         .links-list--href a {
             line-break: loose;
@@ -411,6 +420,9 @@ def _render_html_diff(raw_diff):
     tag = _tagger(result)
     result.body.append(
         tag('table', {'class': 'links-list'},
+            tag('col', {'class': 'links-list--change-type-col'}),
+            tag('col', {'class': 'links-list--text-col'}),
+            tag('col', {'class': 'links-list--href-col'}),
             tag('thead', {},
                 tag('tr', {},
                     tag('th'),


### PR DESCRIPTION
The table of links always fills the full width and the columns are split:
- 1.5 em for the change type (+/-/o)
- 50/50 of remaining space for text and URL

Fixes #199.

In the normal case:

<img width="1270" alt="screen shot 2018-06-24 at 9 30 38 pm" src="https://user-images.githubusercontent.com/74178/41830426-e55565da-77f5-11e8-86a3-63c014703a85.png">

In the ugly case of #198 (still to be fixed):

<img width="1268" alt="screen shot 2018-06-24 at 9 30 21 pm" src="https://user-images.githubusercontent.com/74178/41830429-f071235a-77f5-11e8-9c45-aae2e08b4ad8.png">
