### PR TITLE
 Remove invisible content from link diff text

### DIFF
--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -85,6 +85,8 @@ def links_diff_html(a_text, b_text, a_headers=None, b_headers=None,
         }
         .links-list {
             border-collapse: collapse;
+            table-layout: fixed;
+            width: 100%;
         }
         .links-list th {
             background: #f6f6f6;
@@ -99,6 +101,13 @@ def links_diff_html(a_text, b_text, a_headers=None, b_headers=None,
             border-bottom: 1px solid #fff;
             opacity: 0.5;
             padding: 0.25em;
+        }
+        .links-list--change-type-col {
+            width: 1.5em;
+        }
+        .links-list--text-col,
+        .links-list--href-col {
+            width: 50%;
         }
         .links-list--href a {
             line-break: loose;
@@ -411,6 +420,9 @@ def _render_html_diff(raw_diff):
     tag = _tagger(result)
     result.body.append(
         tag('table', {'class': 'links-list'},
+            tag('col', {'class': 'links-list--change-type-col'}),
+            tag('col', {'class': 'links-list--text-col'}),
+            tag('col', {'class': 'links-list--href-col'}),
             tag('thead', {},
                 tag('tr', {},
                     tag('th'),


### PR DESCRIPTION
This leverages the HTML diff's [`undiffable_content_tags`](https://github.com/edgi-govdata-archiving/web-monitoring-processing/blob/master/web_monitoring/html_diff_render.py#L122-L135) to find and remove non-text elements (like `<script>` or `<style>`) from the DOM so they don't show up in the text of a link.

It also slightly improves the text algorithm when there's *no* text to show: we use the `title` attribute if there is one, otherwise straight-up *say* there's no text.

Fixes #198.

Diff that previously had JavaScript source code in it:

<img width="1267" alt="screen shot 2018-06-24 at 9 53 37 pm" src="https://user-images.githubusercontent.com/74178/41831114-07f81fe8-77fa-11e8-8f1b-9e65db69111f.png">

Diff with some links that previously had no text (the “[no text]” and “[tooltip: …]” ones):

<img width="1267" alt="screen shot 2018-06-24 at 9 53 49 pm" src="https://user-images.githubusercontent.com/74178/41831132-24171fd0-77fa-11e8-8d88-c7ad39d2559b.png">
