### PR TITLE
Return to being totally lenient on text decoding

### DIFF
--- a/web_monitoring/diff_errors.py
+++ b/web_monitoring/diff_errors.py
@@ -3,9 +3,3 @@ class UndiffableContentError(ValueError):
     Raised when the content provided to a differ is incompatible with the
     diff algorithm. For example, if a PDF was provided to an HTML differ.
     """
-
-
-class UndecodableContentError(ValueError):
-    """
-    Raised when the content downloaded for diffing could not be decoded.
-    """

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -11,9 +11,7 @@ import tornado.web
 import traceback
 import web_monitoring
 import web_monitoring.differs
-from web_monitoring.diff_errors import (
-    UndiffableContentError, UndecodableContentError
-)
+from web_monitoring.diff_errors import UndiffableContentError
 import web_monitoring.html_diff_render
 import web_monitoring.links_diff
 
@@ -182,8 +180,7 @@ class DiffHandler(BaseHandler):
 
         # Handle errors that are allowed to be public
         actual_error = 'exc_info' in kwargs and kwargs['exc_info'][1] or None
-        if isinstance(actual_error, (UndiffableContentError,
-                                     UndecodableContentError)):
+        if isinstance(actual_error, UndiffableContentError):
             response['code'] = 422
             response['error'] = str(actual_error)
 

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 from tornado.testing import AsyncHTTPTestCase
 import web_monitoring.diffing_server as df
-from web_monitoring.diff_errors import UndecodableContentError
 
 
 class DiffingServerTestCase(AsyncHTTPTestCase):

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -98,20 +98,6 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         with self.assertRaises(KeyError):
             df.caller(mock_diffing_method, response, response)
 
-    def test_undecodable_content(self):
-        response = self.fetch('https://www.cl.cam.ac.uk/~mgk25/'
-                              'ucs/examples/UTF-8-test.txt')
-        with self.assertRaises(UndecodableContentError):
-            df._decode_body(response, 'a', False)
-
-    def test_fetch_undecodable_content(self):
-        response = self.fetch('/html_token?format=json&include=all&'
-                              'a=https://example.org&'
-                              'b=https://www.cl.cam.ac.uk'
-                              '/~mgk25/ucs/examples/UTF-8-test.txt')
-        self.json_check(response)
-        self.assertEqual(response.code, 422)
-
     def test_a_is_404(self):
         response = self.fetch('/html_token?format=json&include=all'
                               '&a=http://httpstat.us/404'


### PR DESCRIPTION
This removes the `?ignore_decoding_errors` query param and changes the behavior to never raise exceptions when there are text decoding problems in the diffing server (instead, we just replace the error with the unicode "REPLACEMENT CHARACTER" character, like a browser generally would).

This winds up partially reverting #155 and removing one of our protections against incorrectly trying to diff large binary blobs, but the other content sniffing logic added in #155 is still there and should hopefully be a good enough solution to that problem. The reality is that there's lots of content on the web with actual encoding errors, and we still need to be able to diff it. To do that, the UI would have turned on `ignore_decoding_errors` all the time anyway, so it was probably a pointless switch to have.

Fixes #203.

@danielballan I left the `UndecodableContentError` type in there, but it’s totally vestigial now. Since we’ve waffled back and forth on this, I thought it might be useful to keep, but if you think it’s just confusing cruft, I’ll pull it out.