### PR TITLE
Make modules that implement CLIs runnable.

### DIFF
--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -108,3 +108,7 @@ Options:
                       from_date=_parse_date_argument(arguments['<from_date>']),
                       to_date=_parse_date_argument(arguments['<to_date>']),
                       skip_unchanged=skip_unchanged)
+
+
+if __name__ == '__main__':
+    main()

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -334,3 +334,7 @@ Options:
     arguments = docopt(doc, version='0.0.1')
     port = int(arguments['<port>'] or 8888)
     start_app(port)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
This makes it easier to ensure that a CLI is running against a specific Python
binary.

```
$ python -m web_monitoring.diffing_server --port 9999
Starting server on port 9999
^C
$ python -m web_monitoring.cli -h
Command Line Interface to the web_monitoring Python package

Usage:
wm import ia <url> [--from <from_date>] [--to <to_date>] [options]

<snipped>
```