### PR TITLE
Make diff colors configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,6 @@ export DIFFING_SERVER_DEBUG="False"
 # This is used in the web_monitoring.diffing_server module.
 export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
 
-# These are used to set the colors in html_diff_render and differs
-export DIFFER_INSERTION=""
-export DIFFER_DELETION=""
+# These CSS color values are used to set the colors in html_diff_render, differs and links_diff
+# export DIFFER_COLOR_INSERTION="#4dac26"
+# export DIFFER_COLOR_DELETION="#d01c8b"

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ export DIFFING_SERVER_DEBUG="False"
 
 # This is used in the web_monitoring.diffing_server module.
 export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
+
+# These are used to set the colors in html_diff_render and differs
+export DIFFER_INSERTION=""
+export DIFFER_DELETION=""

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -145,8 +145,12 @@ def insert_style(html, css):
 
 
 def html_tree_diff(a_text, b_text):
-    differ_insertion = os.environ.get('DIFFER_INSERTION', '#d4fcbc').strip()
-    differ_deletion = os.environ.get('DIFFER_DELETION', '#fbb6c2').strip()
+    differ_insertion = os.environ.get('DIFFER_INSERTION')
+    if differ_insertion is None or differ_insertion == '':
+        differ_insertion = '#d4fcbc'
+    differ_deletion = os.environ.get('DIFFER_DELETION')
+    if differ_deletion is None or differ_deletion == '':
+        differ_deletion = '#fbb6c2'
     css = """
 diffins {text-decoration : none; background-color: %s;}
 diffdel {text-decoration : none; background-color: %s;}
@@ -162,8 +166,12 @@ diffdel * {text-decoration : none; background-color: %s;}
 
 
 def html_differ(a_text, b_text):
-    differ_insertion = os.environ.get('DIFFER_INSERTION', '#d4fcbc').strip()
-    differ_deletion = os.environ.get('DIFFER_DELETION', '#fbb6c2').strip()
+    differ_insertion = os.environ.get('DIFFER_INSERTION')
+    if differ_insertion is None or differ_insertion == '':
+        differ_insertion = '#d4fcbc'
+    differ_deletion = os.environ.get('DIFFER_DELETION')
+    if differ_deletion is None or differ_deletion == '':
+        differ_deletion = '#fbb6c2'
     css = """
 .htmldiffer_insert {text-decoration : none; background-color: %s;}
 .htmldiffer_delete {text-decoration : none; background-color: %s;}

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -1,11 +1,12 @@
 from bs4 import BeautifulSoup, Comment
 from diff_match_patch import diff, diff_bytes
+from web_monitoring.utils import get_color_palette
 from htmldiffer.diff import HTMLDiffer
 import htmltreediff
-import os
 import re
 import sys
 import web_monitoring.pagefreezer
+
 
 # BeautifulSoup can sometimes exceed the default Python recursion limit (1000).
 sys.setrecursionlimit(10000)
@@ -145,19 +146,17 @@ def insert_style(html, css):
 
 
 def html_tree_diff(a_text, b_text):
-    differ_insertion = os.environ.get('DIFFER_INSERTION')
-    if differ_insertion is None or differ_insertion == '':
-        differ_insertion = '#d4fcbc'
-    differ_deletion = os.environ.get('DIFFER_DELETION')
-    if differ_deletion is None or differ_deletion == '':
-        differ_deletion = '#fbb6c2'
-    css = """
-diffins {text-decoration : none; background-color: %s;}
-diffdel {text-decoration : none; background-color: %s;}
-diffins * {text-decoration : none; background-color: %s;}
-diffdel * {text-decoration : none; background-color: %s;}
-    """ % (differ_insertion, differ_deletion, differ_insertion,
-           differ_deletion)
+    color_palette = get_color_palette()
+    css = f'''
+diffins {{text-decoration : none; background-color:
+    {color_palette['differ_insertion']};}}
+diffdel {{text-decoration : none; background-color:
+    {color_palette['differ_deletion']};}}
+diffins * {{text-decoration : none; background-color:
+    {color_palette['differ_insertion']};}}
+diffdel * {{text-decoration : none; background-color:
+    {color_palette['differ_deletion']};}}
+    '''
     d = htmltreediff.diff(a_text, b_text,
                           ins_tag='diffins', del_tag='diffdel',
                           pretty=True)
@@ -166,19 +165,18 @@ diffdel * {text-decoration : none; background-color: %s;}
 
 
 def html_differ(a_text, b_text):
-    differ_insertion = os.environ.get('DIFFER_INSERTION')
-    if differ_insertion is None or differ_insertion == '':
-        differ_insertion = '#d4fcbc'
-    differ_deletion = os.environ.get('DIFFER_DELETION')
-    if differ_deletion is None or differ_deletion == '':
-        differ_deletion = '#fbb6c2'
-    css = """
-.htmldiffer_insert {text-decoration : none; background-color: %s;}
-.htmldiffer_delete {text-decoration : none; background-color: %s;}
-.htmldiffer_insert * {text-decoration : none; background-color: %s;}
-.htmldiffer_delete * {text-decoration : none; background-color: %s;}
-    """ % (differ_insertion, differ_deletion, differ_insertion,
-           differ_deletion)
+    color_palette = get_color_palette()
+    css = f'''
+.htmldiffer_insert {{text-decoration : none; background-color:
+    {color_palette['differ_insertion']};}}
+.htmldiffer_delete {{text-decoration : none; background-color:
+    {color_palette['differ_deletion']};}}
+.htmldiffer_insert * {{text-decoration : none; background-color:
+    {color_palette['differ_insertion']};}}
+.htmldiffer_delete * {{text-decoration : none; background-color:
+    {color_palette['differ_deletion']};}}
+    '''
+
     d = HTMLDiffer(a_text, b_text).combined_diff
     # TODO Count number of changes.
     return {'diff': insert_style(d, css)}

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -297,8 +297,12 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
             "style",
             type="text/css",
             id='wm-diff-style')
-        differ_insertion = os.environ.get('DIFFER_INSERTION', '#d4fcbc').strip()
-        differ_deletion = os.environ.get('DIFFER_DELETION', '#fbb6c2').strip()
+        differ_insertion = os.environ.get('DIFFER_INSERTION')
+        if differ_insertion is None or differ_insertion == '':
+            differ_insertion = '#d4fcbc'
+        differ_deletion = os.environ.get('DIFFER_DELETION')
+        if differ_deletion is None or differ_deletion == '':
+            differ_deletion = '#fbb6c2'
         change_styles.string = """
             ins, ins > * {text-decoration: none; background-color: %s;}
             del, del > * {text-decoration: none; background-color: %s;}"""\

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -21,6 +21,7 @@ import copy
 import difflib
 import html
 import logging
+import os
 import re
 from .content_type import raise_if_not_diffable_html
 from .differs import compute_dmp_diff
@@ -296,9 +297,12 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
             "style",
             type="text/css",
             id='wm-diff-style')
+        differ_insertion = os.environ.get('DIFFER_INSERTION', '#d4fcbc').strip()
+        differ_deletion = os.environ.get('DIFFER_DELETION', '#fbb6c2').strip()
         change_styles.string = """
-            ins, ins > * {text-decoration: none; background-color: #d4fcbc;}
-            del, del > * {text-decoration: none; background-color: #fbb6c2;}"""
+            ins, ins > * {text-decoration: none; background-color: %s;}
+            del, del > * {text-decoration: none; background-color: %s;}"""\
+                               % (differ_insertion, differ_deletion)
         soup.head.append(change_styles)
 
         soup.body.replace_with(diff_body)

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -19,9 +19,9 @@ from bs4 import BeautifulSoup, Comment
 from collections import Counter, namedtuple
 import copy
 import difflib
+from web_monitoring.utils import get_color_palette
 import html
 import logging
-import os
 import re
 from .content_type import raise_if_not_diffable_html
 from .differs import compute_dmp_diff
@@ -297,16 +297,13 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
             "style",
             type="text/css",
             id='wm-diff-style')
-        differ_insertion = os.environ.get('DIFFER_INSERTION')
-        if differ_insertion is None or differ_insertion == '':
-            differ_insertion = '#d4fcbc'
-        differ_deletion = os.environ.get('DIFFER_DELETION')
-        if differ_deletion is None or differ_deletion == '':
-            differ_deletion = '#fbb6c2'
-        change_styles.string = """
-            ins, ins > * {text-decoration: none; background-color: %s;}
-            del, del > * {text-decoration: none; background-color: %s;}"""\
-                               % (differ_insertion, differ_deletion)
+
+        color_palette = get_color_palette()
+        change_styles.string = f'''
+            ins, ins > * {{text-decoration: none; background-color:
+                {color_palette['differ_insertion']};}}
+            del, del > * {{text-decoration: none; background-color:
+                {color_palette['differ_deletion']};}}'''
         soup.head.append(change_styles)
 
         soup.body.replace_with(diff_body)

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 from .content_type import raise_if_not_diffable_html
 from .differs import compute_dmp_diff
+from web_monitoring.utils import get_color_palette
 from difflib import SequenceMatcher
 from .html_diff_render import (get_title, _html_for_dmp_operation,
                                undiffable_content_tags)
@@ -75,54 +76,60 @@ def links_diff_html(a_text, b_text, a_headers=None, b_headers=None,
     soup = _render_html_diff(diff['diff'])
 
     # Add styling and metadata
+    color_palette = get_color_palette()
     change_styles = soup.new_tag(
         'style',
         type='text/css',
         id='wm-diff-style')
-    change_styles.string = """
-        body {
+    change_styles.string = f"""
+        body {{
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             margin: 0;
-        }
-        .links-list {
+        }}
+        .links-list {{
             border-collapse: collapse;
             table-layout: fixed;
             width: 100%;
-        }
-        .links-list th {
+        }}
+        .links-list th {{
             background: #f6f6f6;
             border-bottom: 1px solid #ccc;
             padding: 0.25em;
             text-align: left;
-        }
-        .links-list > tbody > tr:first-child > td {
+        }}
+        .links-list > tbody > tr:first-child > td {{
             padding-top: 0.5em;
-        }
-        .links-list--item > td {
+        }}
+        .links-list--item > td {{
             border-bottom: 1px solid #fff;
             opacity: 0.5;
             padding: 0.25em;
-        }
-        .links-list--change-type-col {
+        }}
+        .links-list--change-type-col {{
             width: 1.5em;
-        }
+        }}
         .links-list--text-col,
-        .links-list--href-col {
+        .links-list--href-col {{
             width: 50%;
-        }
-        .links-list--href a {
+        }}
+        .links-list--href a {{
             line-break: loose;
             word-break: break-all;
-        }
+        }}
         [wm-has-deletions] > td,
-        [wm-has-insertions] > td {
+        [wm-has-insertions] > td {{
             background-color: #eee;
             opacity: 1;
-        }
-        [wm-inserted] > td { background-color: #acf2bd; }
-        [wm-deleted] > td  { background-color: #fdb8c0; }
-        ins { text-decoration: none; background-color: #acf2bd; }
-        del { text-decoration: none; background-color: #fdb8c0; }"""
+        }}
+        [wm-inserted] > td {{
+            background-color: {color_palette['differ_insertion']};}}
+        [wm-deleted] > td  {{
+            background-color: {color_palette['differ_deletion']};}}
+        ins {{ text-decoration: none;
+            background-color: {color_palette['differ_insertion']};}}
+        del {{ text-decoration: none;
+            background-color: {color_palette['differ_deletion']};}}"""
+
     soup.head.append(change_styles)
     soup.title.string = get_title(diff['b_parsed'])
 

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import hashlib
 import io
 import lxml.html
+import os
 import requests
 import time
 
@@ -97,3 +98,20 @@ def rate_limited(calls_per_second=2, group='default'):
             time.sleep(minimum_wait - (current_time - last_call))
         yield
         _last_call_by_group[group] = time.time()
+
+
+def get_color_palette():
+    """
+    Read and return the CSS color env variables that indicate the colors in
+    html_diff_render, differs and links_diff.
+
+    Returns
+    ------
+    palette: Dictionary
+        A dictionary containing the differ_insertion and differ_deletion css
+        color codes
+    """
+    differ_insertion = os.environ.get('DIFFER_INSERTION', '#4dac26')
+    differ_deletion = os.environ.get('DIFFER_DELETION', '#d01c8b')
+    return {'differ_insertion': differ_insertion,
+            'differ_deletion': differ_deletion}

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -111,7 +111,7 @@ def get_color_palette():
         A dictionary containing the differ_insertion and differ_deletion css
         color codes
     """
-    differ_insertion = os.environ.get('DIFFER_INSERTION', '#4dac26')
-    differ_deletion = os.environ.get('DIFFER_DELETION', '#d01c8b')
+    differ_insertion = os.environ.get('DIFFER_COLOR_INSERTION', '#4dac26')
+    differ_deletion = os.environ.get('DIFFER_COLOR_DELETION', '#d01c8b')
     return {'differ_insertion': differ_insertion,
             'differ_deletion': differ_deletion}


### PR DESCRIPTION
Hello again! As we continue to use web-monitoring-processing in Internet Archive's wayback-diff project we have found that it might be useful to have an easy way to configure the diff colors. Changing the colors would help us make diffs stand out, for example, for color blind people.

The code allows the user to omit the DIFFER_INSERTION and DIFFER_DELETION options from the .env file and fallback to the default values, if they don't want to use this feature.

I hope this proves to be useful for you too.