### PR TITLE
Fix examples in docs so they render nicely

### DIFF
--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -72,6 +72,7 @@ def original_url_for_memento(memento_url):
     Examples
     --------
     Extract original URL.
+
     >>> original_url_for_memento('http://web.archive.org/web/20170813195036/https://arpa-e.energy.gov/?q=engage/events-workshops')
     'https://arpa-e.energy.gov/?q=engage/events-workshops'
     """
@@ -347,6 +348,7 @@ class WaybackClient:
         Examples
         --------
         Grab the datetime and URL of the first nasa.gov snapshot.
+
         >>> with WaybackClient() as client:
         >>>     versions = client.list_versions('nasa.gov')
         >>>     version = next(versions)
@@ -356,6 +358,7 @@ class WaybackClient:
         "http://web.archive.org/web/19961231235847id\_/http://www.nasa.gov:80/"
 
         Loop through all the snapshots.
+
         >>> for version in client.list_versions('nasa.gov'):
         ...     # do something
         """

--- a/web_monitoring/pagefreezer.py
+++ b/web_monitoring/pagefreezer.py
@@ -56,6 +56,7 @@ def result_into_df(result):
     --------
 
     Query PageFreezer and pack the result into a DataFrame.
+
     >>> response = compare(url_1, url_2)
     >>> df = result_into_df(response['result'])
     """


### PR DESCRIPTION
Our docs are rendering examples like:

![screen shot 2018-09-14 at 12 19 42 pm](https://user-images.githubusercontent.com/74178/45570773-d1008c00-b818-11e8-9844-2b3e4a25e1a3.png)

But adding some blank lines give us:

![screen shot 2018-09-14 at 12 19 34 pm](https://user-images.githubusercontent.com/74178/45570786-da89f400-b818-11e8-8237-575e439c6258.png)
