### PR TITLE
Pass diff request header to remote URLs

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -144,6 +144,7 @@ class DiffHandler(BaseHandler):
         header_keys = query_params.get('pass_headers')
         if header_keys:
             for header_key in header_keys.split(','):
+                header_key = header_key.strip()
                 header_value = self.request.headers.get(header_key)
                 if header_value:
                     headers[header_key] = header_value

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -136,12 +136,12 @@ class DiffHandler(BaseHandler):
                     body = f.read()
                     responses[param] = MockResponse(url, body, headers)
         # Now fetch any nonlocal URLs.
-        # Pass request headers defined by URL param pass_header=HEADER_NAME
+        # Pass request headers defined by URL param pass_headers=HEADER_NAME
         # to nonlocal URLs. Useful for passing data like cookie headers.
         # HEADER_NAME can be one or multiple headers separated by ','
         to_fetch = {k: v for k, v in urls.items() if k not in responses}
         headers = {}
-        header_keys = query_params.get('pass_header')
+        header_keys = query_params.get('pass_headers')
         if header_keys:
             for header_key in header_keys.split(','):
                 header_value = self.request.headers.get(header_key)

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -136,8 +136,17 @@ class DiffHandler(BaseHandler):
                     body = f.read()
                     responses[param] = MockResponse(url, body, headers)
         # Now fetch any nonlocal URLs.
+        # Pass request header defined by URL param pass_header=HEADER_NAME
+        # to nonlocal URLs. Useful for passing data like cookie headers.
         to_fetch = {k: v for k, v in urls.items() if k not in responses}
-        fetched = yield [client.fetch(url, raise_error=False)
+        headers = {}
+        header_key = query_params.get('pass_header')
+        if header_key:
+            header_value = self.request.headers.get(header_key)
+            if header_value:
+                headers[header_key] = header_value
+
+        fetched = yield [client.fetch(url, headers=headers, raise_error=False)
                          for url in to_fetch.values()]
         responses.update({param: response for param, response in
                           zip(to_fetch, fetched)})

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -136,15 +136,17 @@ class DiffHandler(BaseHandler):
                     body = f.read()
                     responses[param] = MockResponse(url, body, headers)
         # Now fetch any nonlocal URLs.
-        # Pass request header defined by URL param pass_header=HEADER_NAME
+        # Pass request headers defined by URL param pass_header=HEADER_NAME
         # to nonlocal URLs. Useful for passing data like cookie headers.
+        # HEADER_NAME can be one or multiple headers separated by ','
         to_fetch = {k: v for k, v in urls.items() if k not in responses}
         headers = {}
-        header_key = query_params.get('pass_header')
-        if header_key:
-            header_value = self.request.headers.get(header_key)
-            if header_value:
-                headers[header_key] = header_value
+        header_keys = query_params.get('pass_header')
+        if header_keys:
+            for header_key in header_keys.split(','):
+                header_value = self.request.headers.get(header_key)
+                if header_value:
+                    headers[header_key] = header_value
 
         fetched = yield [client.fetch(url, headers=headers, raise_error=False)
                          for url in to_fetch.values()]


### PR DESCRIPTION
Add param `pass_header=HEADER_KEY` to diffing server.
When set, it gets HTTP header with specified key and passes it as
an HTTP header to remote URLs `a` and `b`.

Useful for passing things like cookies to remote URLs if necessary
(e.g. password protected sites with cookie authentication).

Please note that to use this feature with cookies in a web application,
you need an addition parameter `credentials: "include"` in your request.
https://fetch.spec.whatwg.org/#cors-protocol-and-credentials