### PR TITLE
Add header Access-Control-Allow-Credentials: true

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -82,6 +82,7 @@ class BaseHandler(tornado.web.RequestHandler):
         if access_control_allow_origin_header is not None:
             self.set_header("Access-Control-Allow-Origin",
                             access_control_allow_origin_header)
+            self.set_header("Access-Control-Allow-Credentials", "true")
             self.set_header("Access-Control-Allow-Headers", "x-requested-with")
             self.set_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
 


### PR DESCRIPTION
With the latest new feature to pass HTTP headers to target pages,
we use `pass_headers=cookie` and AJAX fetch option `{credentials: 'include'}`
in our application to invoke `web-monitoring-processing`.

Unfortunately, the browser raises an error and requires also
`Access-Control-Allow-Credentials: true` in the response to work
properly. I'm adding this with the current PR.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials