### PR TITLE
Support list of origin URLs for CORS

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -77,16 +77,16 @@ access_control_allow_origin_header = \
 
 class BaseHandler(tornado.web.RequestHandler):
 
-    _ALLOWED_ORIGINS = None
-
     def set_default_headers(self):
         if access_control_allow_origin_header is not None:
-            if not self._ALLOWED_ORIGINS:
-                self._ALLOWED_ORIGINS = set([origin.strip() for origin in
-                                             access_control_allow_origin_header.split(',')])
+            if 'allowed_origins' not in self.settings:
+                self.settings['allowed_origins'] = \
+                    set([origin.strip() for origin
+                         in access_control_allow_origin_header.split(',')])
             req_origin = self.request.headers.get('Origin')
             if req_origin:
-                if req_origin in self._ALLOWED_ORIGINS or '*' in self._ALLOWED_ORIGINS:
+                allowed = self.settings.get('allowed_origins')
+                if allowed and (req_origin in allowed or '*' in allowed):
                     self.set_header('Access-Control-Allow-Origin', req_origin)
             self.set_header('Access-Control-Allow-Credentials', 'true')
             self.set_header('Access-Control-Allow-Headers', 'x-requested-with')

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -74,16 +74,23 @@ DEBUG_MODE = os.environ.get('DIFFING_SERVER_DEBUG', 'False').strip().lower() == 
 
 access_control_allow_origin_header = \
     os.environ.get('ACCESS_CONTROL_ALLOW_ORIGIN_HEADER')
-
+ALLOWED_ORIGINS = set()
+if access_control_allow_origin_header:
+    ALLOWED_ORIGINS = set([orig.strip() for orig in
+                           access_control_allow_origin_header.split(',')])
 
 class BaseHandler(tornado.web.RequestHandler):
 
     def set_default_headers(self):
         if access_control_allow_origin_header is not None:
-            self.set_header("Access-Control-Allow-Origin",
-                            access_control_allow_origin_header)
-            self.set_header("Access-Control-Allow-Credentials", "true")
-            self.set_header("Access-Control-Allow-Headers", "x-requested-with")
+            req_origin = self.request.headers.get('Origin')
+            if req_origin and req_origin in ALLOWED_ORIGINS:
+                self.set_header('Access-Control-Allow-Origin', req_origin)
+            else:
+                self.set_header('Access-Control-Allow-Origin',
+                                access_control_allow_origin_header)
+            self.set_header('Access-Control-Allow-Credentials', 'true')
+            self.set_header('Access-Control-Allow-Headers', 'x-requested-with')
             self.set_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
 
     def options(self):

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -166,6 +166,26 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         assert response.headers.get('Access-Control-Allow-Headers') == 'x-requested-with'
         assert response.headers.get('Access-Control-Allow-Methods') == 'GET, OPTIONS'
 
+    # The processing of the access_control_allow_origin_header to produce
+    # ALLOWED_ORIGINS happens inside the diffing_server module and not on web
+    # app init. As a result, we need to mock patch both of them here to make
+    # the unit test work.
+    @patch('web_monitoring.diffing_server.access_control_allow_origin_header',
+           'http://one.com,http://two.com,http://three.com')
+    @patch('web_monitoring.diffing_server.ALLOWED_ORIGINS',
+           set(['http://one.com', 'http://two.com','http://three.com']))
+    def test_cors_origin_header(self):
+        """The allowed origins is a list of URLs. If the request has HTTP
+        header `Origin` as one of them, the response `Access-Control-Allow-Origin`
+        should have the same value.
+        This is necessary for CORS requests with credentials to work properly.
+        """
+        response = self.fetch('/html_token?format=json&include=all'
+                              '&a=https://example.org&b=https://example.org',
+                               headers={'Accept': 'application/json',
+                                        'Origin':'http://two.com'})
+        assert response.headers.get('Access-Control-Allow-Origin') == 'http://two.com'
+
 
 def mock_diffing_method(c_body):
     return

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -154,7 +154,8 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
 
     @patch('web_monitoring.diffing_server.access_control_allow_origin_header', '*')
     def test_check_cors_headers(self):
-        """Since we have set Access-Control-Allow-Origin: * on app init,
+        """
+        Since we have set Access-Control-Allow-Origin: * on app init,
         the response should have a list of HTTP headers required by CORS.
         Access-Control-Allow-Origin value equals request Origin header because
         we use setting `access_control_allow_origin_header='*'`.
@@ -171,7 +172,8 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
     @patch('web_monitoring.diffing_server.access_control_allow_origin_header',
            'http://one.com,http://two.com,http://three.com')
     def test_cors_origin_header(self):
-        """The allowed origins is a list of URLs. If the request has HTTP
+        """
+        The allowed origins is a list of URLs. If the request has HTTP
         header `Origin` as one of them, the response `Access-Control-Allow-Origin`
         should have the same value. If not, there shouldn't be any such header
         at all.


### PR DESCRIPTION
ENV var `ACCESS_CONTROL_ALLOW_ORIGIN_HEADER` can be a list of comma
separated URLs like:
```
ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="https://web-beta.archive.org,https://web.archive.org"
```
If an AJAX CORS request has HTTP header `Origin:
https://web.archive.org` the response will include:
`Access-Control-Allow-Origin: https://web.archive.org`.

This is required when passing credentials with a CORS request. Using
just `*` raises a browser error.

In case users keep using `ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"`,
nothing changes, the server response still has:
`Access-Control-Allow-Origin: *` and CORS works provided you don't pass
credentials with that.

Added also a relevent unit test.