### PR TITLE
Compressed responses

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -335,7 +335,7 @@ def make_app():
         (r"/healthcheck", HealthCheckHandler),
         (r"/([A-Za-z0-9_]+)", BoundDiffHandler),
         (r"/", IndexHandler),
-    ], debug=DEBUG_MODE)
+    ], debug=DEBUG_MODE, compress_response=True)
 
 def start_app(port):
     app = make_app()


### PR DESCRIPTION
Service output wasn't compressed. Using `tornado.web.Application` option
`compress_response=True` enables that and reduces the result size
significantly, improving performance.

Gzip compression is supported from virtually every browser and HTTP
client library so I don't see a reason to make it optional.