### PR TITLE
Auto-publish docker images from `release` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           key: processing-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
           paths:
             - venv
-            
+
       - run:
           name: Tests
           command: |
@@ -66,7 +66,7 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: master
+              ignore: release
 
   build-and-publish:
     jobs:
@@ -74,11 +74,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
-      - hold:
-          type: approval
-          requires:
-            - build
+                - release
       - publish_docker:
           requires:
-            - hold
+            - build


### PR DESCRIPTION
We talked through this in this week's dev meeting. It's basically the same as the changes already made for DB in edgi-govdata-archiving/web-monitoring-db#410. We’re giving up on the CircleCI “approval” mechanism and instead just publishing from a special branch.