### PR TITLE
Use cchardet to accelerate bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4 ==4.6.3
+cchardet ==2.1.4
 python-dateutil ~=2.7.3
 diff_match_patch_python ~=1.0.2
 docopt ~=0.6.2

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -1,3 +1,4 @@
+import cchardet as chardet
 from bs4 import BeautifulSoup, Comment
 from diff_match_patch import diff, diff_bytes
 from web_monitoring.utils import get_color_palette

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -1,3 +1,4 @@
+import cchardet as chardet
 import concurrent.futures
 from docopt import docopt
 import hashlib

--- a/web_monitoring/filtering.py
+++ b/web_monitoring/filtering.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlparse
+import cchardet as chardet
 from bs4 import BeautifulSoup
 
 day_list = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -14,7 +14,7 @@ For now, you can mentally divide this module into two sections:
    depends on some parts of the LXML module, but that could change. (The entry
    point for this is _htmldiff)
 """
-
+import cchardet as chardet
 from bs4 import BeautifulSoup, Comment
 from collections import Counter, namedtuple
 import copy

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -1,3 +1,4 @@
+import cchardet as chardet
 from bs4 import BeautifulSoup
 from .content_type import raise_if_not_diffable_html
 from .differs import compute_dmp_diff

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from contextlib import contextmanager
+import cchardet as chardet
 import hashlib
 import io
 import lxml.html


### PR DESCRIPTION
BeautifulSoup may use `chardet` if available to do better encoding
detection.
https://github.com/newvem/beautifulsoup/blob/master/bs4/dammit.py#L18
We don't have it currently in `requirements.txt`.

`cchardet` is a drop in replacement of `chardet` which supports way more
encodings and is far better and faster than `chardet`. Their names are
somehow similar but their technology is totally different. Please check
out their homepages to learn more:

https://pypi.org/project/chardet/

https://pypi.org/project/cchardet/

We just need to do `import cchardet as chardet` before importing `bs4`
to use it, no other code change is necessary.

Performance improves significantly using it.