### PR TITLE
Disable SSL cert validation for target sites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,11 +18,21 @@ export WEB_MONITORING_DB_STAGING_URL="https://api-staging.monitoring.envirodatag
 export WEB_MONITORING_DB_STAGING_EMAIL=""
 export WEB_MONITORING_DB_STAGING_PASSWORD=""
 
-# This is used in diffing_server
+
+# Diff-Related variables --------------------------
+
+# Set the diffing server to debug mode. Returns tracebacks in error responses
+# and auto-reloads the server when source files change.
 export DIFFING_SERVER_DEBUG="False"
 
-# This is used in the web_monitoring.diffing_server module.
+# Allow CORS requests. If set, the value will be used as the
+# `ACCESS_CONTROL_ALLOW_ORIGIN` header in HTTP responses.
 export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
+
+# The diff server does not normally validate SSL certificates when requesting
+# pages to diff. If this is set to "true", diff requests will fail if upstream
+# https:// requests have invalid certificates.
+# export VALIDATE_TARGET_CERTIFICATES="false"
 
 # These CSS color values are used to set the colors in html_diff_render, differs and links_diff
 # export DIFFER_COLOR_INSERTION="#4dac26"

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -156,7 +156,8 @@ class DiffHandler(BaseHandler):
                 if header_value:
                     headers[header_key] = header_value
 
-        fetched = yield [client.fetch(url, headers=headers, raise_error=False)
+        fetched = yield [client.fetch(url, headers=headers, raise_error=False,
+                                      validate_cert=False)
                          for url in to_fetch.values()]
         responses.update({param: response for param, response in
                           zip(to_fetch, fetched)})

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -72,6 +72,9 @@ class MockResponse:
 
 DEBUG_MODE = os.environ.get('DIFFING_SERVER_DEBUG', 'False').strip().lower() == 'true'
 
+VALIDATE_TARGET_CERTIFICATES = \
+    os.environ.get('VALIDATE_TARGET_CERTIFICATES', 'False').strip().lower() == 'true'
+
 access_control_allow_origin_header = \
     os.environ.get('ACCESS_CONTROL_ALLOW_ORIGIN_HEADER')
 
@@ -157,7 +160,7 @@ class DiffHandler(BaseHandler):
                     headers[header_key] = header_value
 
         fetched = yield [client.fetch(url, headers=headers, raise_error=False,
-                                      validate_cert=False)
+                                      validate_cert=VALIDATE_TARGET_CERTIFICATES)
                          for url in to_fetch.values()]
         responses.update({param: response for param, response in
                           zip(to_fetch, fetched)})


### PR DESCRIPTION
Target sites with bad SSL configuration like the examples here:
https://badssl.com/ cannot be checked. Our HTTP client raises an error.

Using the option `validate_cert=False` allows us to access them without
an issue.

HTTP requests become a bit faster too as we don't run the SSL validation
code.