### PR TITLE
Use CurlAsyncHTTPClient instead of the default AsyncHTTPClient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ git+https://github.com/anastasia/htmldiffer@develop
 git+https://github.com/danielballan/htmltreediff@customize
 lxml ~=4.2.5
 pandas ~=0.23.4
+pycurl ~=7.43
 raven ~=6.9.0
 requests ~=2.19.1
 toolz ~=0.9.0

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -54,6 +54,7 @@ XML_PROLOG_PATTERN = re.compile(
     b'<?xml\\s[^>]*encoding=[\'"]([^\'"]+)[\'"].*\?>',
     re.IGNORECASE)
 
+tornado.httpclient.AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
 client = tornado.httpclient.AsyncHTTPClient()
 
 


### PR DESCRIPTION
According to the docs: https://www.tornadoweb.org/en/stable/httpclient.html
`CurlAsyncHTTPClient` is better than the default `AsyncHTTPClient` in many ways:

* `curl_httpclient` is more likely to be compatible with sites that are
not-quite-compliant with the HTTP spec, or sites that use little-exercised
features of HTTP.
* `curl_httpclient` is faster.

The required code modification to use it is minimal.

`pycurl` is an additional requirement to use it. I also needed to install
system pkg `libcurl4-openssl-dev` to do that in my server (Ubuntu 14.04
LTS).