### PR TITLE
Use a single, long-lived process pool for diffs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
 # These CSS color values are used to set the colors in html_diff_render, differs and links_diff
 # export DIFFER_COLOR_INSERTION="#4dac26"
 # export DIFFER_COLOR_DELETION="#d01c8b"
+
+# Set how many diffs can be run in parallel.
+# export DIFFER_PARALLELISM=10


### PR DESCRIPTION
The diffing server was constructing and using an independent process pool on every request. It seems unlikely that this is the main cause of our scalability issues (but maybe?), but it still seems like an obviously good thing to do. There's not much point in a pool if you aren't sharing it.

See also #303. I’m not marking this as a solution for it, since I don’t expect that it is. But we can put it in and see whether we start getting fewer errors.