### PR TITLE
Track diff server errors with Sentry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ git+https://github.com/anastasia/htmldiffer@develop
 git+https://github.com/danielballan/htmltreediff@customize
 lxml ~=4.2.5
 pandas ~=0.23.4
-raven ~=6.9.0
+sentry-sdk ~=0.5.3
 requests ~=2.20.0
 toolz ~=0.9.0
 tornado ~=5.1

--- a/scripts/ia_healthcheck
+++ b/scripts/ia_healthcheck
@@ -7,7 +7,7 @@
 
 from datetime import datetime, timedelta
 import random
-import raven
+import sentry_sdk
 import sys
 from web_monitoring import db, internetarchive
 
@@ -15,9 +15,9 @@ from web_monitoring import db, internetarchive
 MAX_CAPTURE_AGE = timedelta(hours=72)
 LINKS_TO_CHECK = 10
 
-# Raven automatically instantiates using the `SENTRY_DSN` environment variable.
+# Sentry automatically instantiates with the `SENTRY_DSN` environment variable.
 # If not set, all its methods will operate conveniently as no-ops.
-sentry = raven.Client()
+sentry_sdk.init()
 
 
 def sample_monitored_urls(sample_size):
@@ -53,7 +53,8 @@ def wayback_has_captures(url, from_date=None):
     list of JSON
     """
     try:
-        versions = internetarchive.list_versions(url, from_date=from_date)
+        wayback = internetarchive.WaybackClient()
+        versions = wayback.list_versions(url, from_date=from_date)
         next(versions)
     except ValueError:
         return False
@@ -87,13 +88,13 @@ def output_results(statuses):
 
     if healthy_links + unhealthy_links == 0:
         print('Failed to sampled any pages!')
-        sentry.captureMessage('Failed to sampled any pages!')
+        sentry_sdk.capture_message('Failed to sampled any pages!')
     else:
         message = f'\nFound: {healthy_links} healthy links and {unhealthy_links} unhealthy links.'
         print(message)
         if unhealthy_links > 0:
             log_string = '\n'.join(logs)
-            sentry.captureMessage(f'{message}\n{log_string}')
+            sentry_sdk.capture_message(f'{message}\n{log_string}')
 
 
 if __name__ == "__main__":
@@ -107,6 +108,3 @@ if __name__ == "__main__":
         output_results(capture_statuses)
     except db.MissingCredentials as error:
         print(error, file=sys.stderr)
-    except Exception:
-        sentry.captureException()
-        raise


### PR DESCRIPTION
We should have done this long ago. Some caveats:

- This has forced me to go understand the various ways Tornado handles errors and how we’re using it only halfway correctly. I’m not trying to fix any of that here, though.

- Sentry automatically finds and captures things sent to Python’s logging framework at the `ERROR` level. Python happens to log out any response with a status code >= 400 that way, which results in spurious, duplicate logging, so I’ve ignored that particular logger.

- Through the same logging mechanism as above (but a different actual logger), Sentry automatically captures detailed exception info. However, if we manually call `self.send_error()`, that doesn’t happen (see point about understand Tornado error handling above).

    These kinds of errors are ones we’re generally expecting, though, so it’s debatable whether we should be capturing them with Sentry. I took the approach of capturing them if we didn’t explicitly mark them as `4xx` errors (i.e. we didn’t think they were the *user’s* fault).

Fixes #306.