### PR TITLE
Add `active` argument to `db.Client.list_pages()` and use it in the IA healthcheck

### DIFF
--- a/scripts/ia_healthcheck
+++ b/scripts/ia_healthcheck
@@ -30,14 +30,14 @@ def sample_monitored_urls(sample_size):
     list of string
     """
     client = db.Client.from_env()
-    page = client.list_pages(chunk=1, chunk_size=1)
+    page = client.list_pages(chunk=1, chunk_size=1, active=True)
     url_count = page['meta']['total_results']
     return (get_page_url(client, index)
             for index in random.sample(range(url_count), sample_size))
 
 
 def get_page_url(client, index):
-    return client.list_pages(chunk=index, chunk_size=1)['data'][0]['url']
+    return client.list_pages(chunk=index, chunk_size=1, active=True)['data'][0]['url']
 
 
 def wayback_has_captures(url, from_date=None):

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -168,7 +168,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
                    tags=None, maintainers=None, url=None, title=None,
                    include_versions=None, include_earliest=None,
                    include_latest=None, source_type=None, hash=None,
-                   start_date=None, end_date=None):
+                   start_date=None, end_date=None, active=None):
         """
         List all Pages, optionally filtered by search criteria.
 
@@ -191,6 +191,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
             SHA256 hash of Version content
         start_date : datetime, optional
         end_date : datetime, optional
+        active : boolean, optional
 
         Returns
         -------
@@ -207,7 +208,8 @@ Alternatively, you can instaniate Client(user, password) directly.""")
                   'include_latest': include_latest,
                   'source_type': source_type,
                   'hash': hash,
-                  'capture_time': _time_range_string(start_date, end_date)}
+                  'capture_time': _time_range_string(start_date, end_date),
+                  'active': active}
         url = f'{self._api_url}/pages'
         res = requests.get(url, auth=self._auth, params=params)
         _process_errors(res)


### PR DESCRIPTION
This is pretty straightforward and adds support for the new `active` DB API argument to our Python wrapper, then uses that in the IA healthcheck script, since we should only really be checking active pages.

Fixes #327, #328.