### PR TITLE
Support etag headers

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -135,7 +135,7 @@ class DiffHandler(BaseHandler):
 
         # Uses the "weak validation" directive since we don't guarantee that future
         # responses for the same diff will be byte-for-byte identical.
-        etag = str('W/"' + web_monitoring.utils.hash_content(validation_bytes) + '"').encode('utf-8')
+        etag = f'W/"{web_monitoring.utils.hash_content(validation_bytes)}"'
         return etag
 
     def head(self, differ):

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -138,15 +138,6 @@ class DiffHandler(BaseHandler):
         etag = f'W/"{web_monitoring.utils.hash_content(validation_bytes)}"'
         return etag
 
-    def head(self, differ):
-
-        self.set_etag_header()
-        if self.check_etag_header():
-            self.set_status(304)
-            self.finish()
-            return
-
-
     @tornado.gen.coroutine
     def get(self, differ):
 

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -92,6 +92,15 @@ access_control_allow_origin_header = \
 class BaseHandler(tornado.web.RequestHandler):
 
     def set_default_headers(self):
+        # Set Etag header if possible.
+        try:
+            etag = hashlib.sha256(
+                web_monitoring.__version__.encode('utf-8') + self.request.path.encode('utf-8') + str(query_params).encode('utf-8')
+            ).hexdigest().encode('utf-8')
+            self.set_header('Etag', etag)
+        except NameError:
+            pass
+
         if access_control_allow_origin_header is not None:
             if 'allowed_origins' not in self.settings:
                 self.settings['allowed_origins'] = \

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -231,7 +231,6 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         response = mock_tornado_request('simple.pdf')
         with self.assertRaises(UndecodableContentError):
             df._decode_body(response, 'a')
-        self.assertFalse(response.headers.get('Etag'))
 
     def test_fetch_undecodable_content(self):
         response = self.fetch('/html_source_dmp?format=json&'


### PR DESCRIPTION
I believe this closes #264. This is my first time dealing with Tornado, and I was quite pleased to see that it can do most of the heavy lifting here.

I wasn't exactly sure of the client behavior we wanted to support, so I implemented it for GET and HEAD requests.