### PR TITLE
Upgrade CI from Python 3.6 to 3.7.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/web-monitoring-processing
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.6-slim
+FROM python:3.7-slim
 MAINTAINER enviroDGI@gmail.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Closes #341 

Question: Is there any reason to continue supporting and testing against 3.6? We must either add a 3.6 job in addition to the 3.7 job or we must update the README to specify a minimum version of 3.7 before this is merged.