### PR TITLE
Make default diff colors more colorblind-friendly

### DIFF
--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -118,7 +118,7 @@ def get_color_palette():
         A dictionary containing the differ_insertion and differ_deletion css
         color codes
     """
-    differ_insertion = os.environ.get('DIFFER_COLOR_INSERTION', '#4dac26')
-    differ_deletion = os.environ.get('DIFFER_COLOR_DELETION', '#d01c8b')
+    differ_insertion = os.environ.get('DIFFER_COLOR_INSERTION', '#a1d76a')
+    differ_deletion = os.environ.get('DIFFER_COLOR_DELETION', '#e8a4c8')
     return {'differ_insertion': differ_insertion,
             'differ_deletion': differ_deletion}


### PR DESCRIPTION
Update the default diff colors to tones that are less saturated (so you can see the text on them) and more colorblind-friendly. We’ve been using these colors in production for months with everybody liking them, so it’s time to finally bake them in as the defaults.

Fixes #158.