### PR TITLE
Add `url_rules` option to HTML diff

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -840,7 +840,10 @@ def flatten_el(el, include_hrefs, skip_tag=False):
     not returned (just its contents)."""
     if not skip_tag:
         if el.tag == 'img':
-            src_array = [el.get('src')]
+            src_array = []
+            el_src = el.get('src')
+            if el_src is not None:
+                src_array.append(el_src)
             srcset = el.get('srcset')
             if srcset is not None:
                 srcset_array = srcset.split(',')

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -371,8 +371,8 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         - `nosniff` uses the `Content-Type` header but does not sniff.
         - `ignore` doesn’t do any checking at all.
     strict_urls : string
-        The value of the URL parameter that indicates if the tag elements and href
-        elements should use special rules when checking equality,
+        The value of this parameter indicates whether the tag elements and href
+        elements should use special rules when checking their equality.
 
     Example
     -------
@@ -386,8 +386,6 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         a_headers,
         b_headers,
         content_type_options)
-
-    Strict_url_rule.mode = strict_urls
 
     soup_old = html5_parser.parse(a_text.strip() or EMPTY_HTML,
                                   treebuilder='soup', return_root=False)
@@ -678,16 +676,6 @@ class tag_token(DiffToken):
         obj.html_repr = html_repr
         obj.comparator = comparator
         return obj
-
-    def __eq__(self, other):
-        # This equality check aims to apply specific rules to the contents
-        # of the tag element solving false positive cases
-        if Strict_url_rule.mode:
-            return clean_resource(self, other)
-        return str.__eq__(self, other) or str.__eq__(self.lower(), other.lower())
-
-    def __hash__(self):
-        return hash(self.lower())
 
     def __repr__(self):
         return 'tag_token(%s, %s, html_repr=%s, post_tags=%r, pre_tags=%r, trailing_whitespace=%r)' % (

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -371,15 +371,8 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         - `nosniff` uses the `Content-Type` header but does not sniff.
         - `ignore` doesn’t do any checking at all.
     strict_urls : string
-        The value of this parameter indicates whether the tag elements and href
-        elements should use special rules when checking their equality.
-        Options can be:
-        - `WMB` which matches to the WaybackUrlComparator class and handles
-        comparisons as defined in its compare function.
-        - `UK_WBM` which matches to the WaybackUkUrlComparator class and
-        handles comparisons as defined in its compare function.
-        - `jsessionid` which matches to the ServletSessionUrlComparator class
-        and handles comparisons as defined in its compare function.
+        The value of the URL parameter that indicates if the tag elements and href
+        elements should use special rules when checking equality,
 
     Example
     -------
@@ -393,6 +386,8 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         a_headers,
         b_headers,
         content_type_options)
+
+    Strict_url_rule.mode = strict_urls
 
     soup_old = html5_parser.parse(a_text.strip() or EMPTY_HTML,
                                   treebuilder='soup', return_root=False)
@@ -683,6 +678,16 @@ class tag_token(DiffToken):
         obj.html_repr = html_repr
         obj.comparator = comparator
         return obj
+
+    def __eq__(self, other):
+        # This equality check aims to apply specific rules to the contents
+        # of the tag element solving false positive cases
+        if Strict_url_rule.mode:
+            return clean_resource(self, other)
+        return str.__eq__(self, other) or str.__eq__(self.lower(), other.lower())
+
+    def __hash__(self):
+        return hash(self.lower())
 
     def __repr__(self):
         return 'tag_token(%s, %s, html_repr=%s, post_tags=%r, pre_tags=%r, trailing_whitespace=%r)' % (

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -191,24 +191,24 @@ MAX_SPACERS = 2500
 
 class WaybackUrlComparator:
     matcher = re.compile(r'web/\d{14}(im_)?/(https?://)?(www.)?')
+    url_schema_matcher = re.compile(r'(https?\:\/\/)?(www\.)?')
+
+    def strip_url_schema(self, url):
+        schema_match = self.url_schema_matcher.search(url)
+        if schema_match:
+            return url[schema_match.end():]
 
     def compare(self, url_a, url_b):
         match_a = self.matcher.search(url_a)
         match_b = self.matcher.search(url_b)
         if match_a and match_b:
-            return url_a[match_a.end():] == url_b[match_b.end():]
+            url_a = self.strip_url_schema(url_a[match_a.end():])
+            url_b = self.strip_url_schema(url_b[match_b.end():])
+            return url_a == url_b
         else:
-            temp_url_a_strict = url_a.strict_urls
-            temp_url_b_strict = url_b.strict_urls
             url_a.strict_urls = None
             url_b.strict_urls = None
-
-            compare_result = (url_a == url_b)
-
-            url_a.strict_urls = temp_url_a_strict
-            url_b.strict_urls = temp_url_b_strict
-
-            return compare_result
+            return url_a == url_b
 
 
 class WaybackUkUrlComparator(WaybackUrlComparator):

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -327,7 +327,7 @@ class StrictUrlRule:
 
 def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
                      include='combined', content_type_options='normal',
-                     strict_urls=None):
+                     strict_urls='jsessionid'):
     """
     HTML Diff for rendering. This is focused on visually highlighting portions
     of a page’s text that have been changed. It does not do much to show how

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -529,6 +529,27 @@ def diff_elements(old, new, comparator, include='all'):
     return metadata, results
 
 
+def _diffable_fragment(element):
+    """
+    Convert a beautiful soup element into an HTML fragment string with just the
+    element's *contents* that is ready for diffing.
+    """
+    # FIXME: we have to remove <ins> and <del> tags because *we* use them to
+    # indicate changes that we find. We probably shouldn't do that:
+    # https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/69#issuecomment-321424897
+    for edit_tag in element.find_all(_is_ins_or_del):
+        edit_tag.unwrap()
+    # Create a fragment string of just the element's contents
+    return ''.join(map(str, element.children))
+
+
+def _is_ins_or_del(tag):
+    return tag.name == 'ins' or tag.name == 'del'
+
+
+# FIXME: this should take two BeautifulSoup elements to diff (since we've
+# already parsed and generated those), not two HTML fragment strings that have
+# to get parsed again.
 def _htmldiff(old, new, comparator, include='all'):
     """
     A slightly customized version of htmldiff that uses different tokens.

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -262,9 +262,9 @@ class UrlRules:
     various Comparator classes and the keywords used to match them. This
     mapping is done inside the RULES dictionary.
     """
-    RULES = {'WBM': WaybackUrlComparator,
-             'jsessionid': ServletSessionUrlComparator,
-             'UK_WBM': WaybackUkUrlComparator}
+    RULES = {'jsessionid': ServletSessionUrlComparator,
+             'wayback': WaybackUrlComparator,
+             'wayback_uk': WaybackUkUrlComparator}
 
     @classmethod
     def compare_array(cls, url_list_a, url_list_b, comparator):
@@ -349,11 +349,11 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         Use specialized rules for comparing URLs in links, images, etc.
         Possible values are:
         - `jsessionid` ignores Java Servlet session IDs in URLs.
-        - `WBM` considers two Wayback Machine links as equivalent if they have
+        - `wayback` considers two Wayback Machine links as equivalent if they have
           the same original URL, regardless of each of their timestamps.
-        - `UK_WBM` like `WBM`, but for the UK Web Archive (webarchive.org.uk)
+        - `wayback_uk` like `wayback`, but for the UK Web Archive (webarchive.org.uk)
         You can also combine multiple comparison rules with a comma,
-        e.g. `jsessionid,WBM`. Use None or an empty string for exact
+        e.g. `jsessionid,wayback`. Use None or an empty string for exact
         comparisons. (Default: `jsessionid`)
 
     Example

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -225,15 +225,27 @@ class ServletSessionUrlComparator:
 
 
 class StrictUrlRule:
+    """
+    The StrictUrlRule class contains the mapping between the various Comparator
+    classes and the keywords used to match them. This mapping is done inside
+    the CLASS_RULES dictionary.
+    `WBM` stands for the Wayback Machine,
+    `UKWA` for the UK Web Archive.
+    These rules apply when comparing Wayback mementos or UK Web Archives where
+    links have been rewritten to point to another memento in Wayback instead
+    of the original URL.
+    The `jsessionid` rule serves to not take into account session IDs that are
+    kept in the URL instead of cookies.
+    """
     mode = None
-    URL_RULE =re.compile(r'(https?\:\/\/)?(www\.)?')
-    REGEX_RULES = {'WBM': WaybackUrlComparator,
+    URL_RULE = re.compile(r'(https?\:\/\/)?(www\.)?')
+    CLASS_RULES = {'WBM': WaybackUrlComparator,
                    'jsessionid': ServletSessionUrlComparator,
                    'UKWA': WaybackUkUrlComparator}
 
     def clean_resource_url(element, other, mode):
         try:
-            comparator = StrictUrlRule.REGEX_RULES[mode]()
+            comparator = StrictUrlRule.CLASS_RULES[mode]()
             return comparator.compare(element, other)
         except KeyError:
             raise KeyError(f'{StrictUrlRule.mode} is an invalid strict URL rule.')
@@ -296,7 +308,16 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         - `ignore` doesn’t do any checking at all.
     strict_urls : string
         The value of this parameter indicates whether the tag elements and href
-        elements should use special rules when checking their equality.
+        elements should use special rules when checking their equality. The
+        values of this parameter have to be defined in the CLASS_RULES
+        dictionary of the StrictUrlRule class and be matched with a Comparator
+        class. Options can be:
+        - `WMB` which matches to the WaybackUrlComparator class and handles
+        comparisons as defined in its compare function.
+        - `UKWA` which matches to the WaybackUkUrlComparator class and handles
+        comparisons as defined in its compare function.
+        - `jsessionid` which matches to the ServletSessionUrlComparator class
+        and handles comparisons as defined in its compare function.
 
     Example
     -------
@@ -690,6 +711,7 @@ def parse_html(html):
     will be wrapped in a <div> tag that was not in the original document.
     """
     return html5_parser.parse(html, treebuilder='lxml')
+
 
 def split_trailing_whitespace(word):
     """

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -383,7 +383,7 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
     soup_new = _cleanup_document_structure(soup_new)
 
     comparator = None
-    if strict_urls is not None:
+    if strict_urls:
         comparator = StrictUrlRule.get_comparator(strict_urls)
 
     results, diff_bodies = diff_elements(soup_old.body, soup_new.body, comparator, include)

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -191,9 +191,9 @@ MAX_SPACERS = 2500
 
 class Strict_url_rule:
     mode = False
-    REGEX_RULES = {'WBM': r"/web/\d{14}",
-                   'jsessionid': r";jsessionid[^;=]*=([^;]+)",
-                   'UKWA': r"https://www\.webarchive\.org\.uk/wayback/en/archive/\d{14}mp_/"}
+    REGEX_RULES = {'WBM': re.compile(r"/web/\d{14}"),
+                   'jsessionid': re.compile(r";jsessionid[^;=]*=([^;]+)"),
+                   'UKWA': re.compile(r"https://www\.webarchive\.org\.uk/wayback/en/archive/\d{14}mp_/")}
 
 
 def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
@@ -581,7 +581,7 @@ class tag_token(DiffToken):
         # This equality check aims to apply specific rules to the contents
         # of the tag element solving false positive cases
         if Strict_url_rule.mode:
-            return clean_resource(self, other)
+            return clean_resource_url(self, other)
         return str.__eq__(self, other) or str.__eq__(self.lower(), other.lower())
 
     def __hash__(self):
@@ -608,7 +608,7 @@ class href_token(DiffToken):
         # This equality check aims to apply specific rules to the contents of
         # the href element solving false positive cases
         if Strict_url_rule.mode:
-            return clean_resource(self, other)
+            return clean_resource_url(self, other)
         return str.__eq__(self, other) or str.__eq__(self.lower(), other.lower())
 
     def __hash__(self):
@@ -729,12 +729,12 @@ def fixup_chunks(chunks):
     return result
 
 
-def clean_resource(element, other):
+def clean_resource_url(element, other):
     try:
-        match_element = re.search(Strict_url_rule.REGEX_RULES[Strict_url_rule.mode], element)
+        match_element = Strict_url_rule.REGEX_RULES[Strict_url_rule.mode].search(element)
         if match_element:
             element = element[match_element.end():]
-        match_other = re.search(Strict_url_rule.REGEX_RULES[Strict_url_rule.mode], other)
+        match_other = Strict_url_rule.REGEX_RULES[Strict_url_rule.mode].search(other)
         if match_other:
             other = other[match_other.end():]
         return str.__eq__(element, other) or str.__eq__(element.lower(), other.lower())

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -191,7 +191,9 @@ MAX_SPACERS = 2500
 
 class Strict_url_rule:
     mode = False
-    REGEX_RULES = {'WBM': r"/web/\d{14}"}
+    REGEX_RULES = {'WBM': r"/web/\d{14}",
+                   'jsessionid': r";jsessionid[^;=]*=([^;]+)",
+                   'UKWA': r"https://www\.webarchive\.org\.uk/wayback/en/archive/\d{14}mp_/"}
 
 
 def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -282,6 +282,18 @@ class ServletSessionUrlComparator:
         return match_a == match_b
 
 
+class CompoundComparator:
+    def __init__(self, *comparators):
+        self.comparators = comparators
+
+    def compare(self, url_a, url_b):
+        for comparator in self.comparators:
+            if comparator.compare(url_a, url_b):
+                return True
+
+        return False
+
+
 class StrictUrlRule:
     """
     The StrictUrlRule class represents the the mapping between the
@@ -306,7 +318,9 @@ class StrictUrlRule:
     @classmethod
     def get_comparator(cls, mode):
         try:
-            return cls.CLASS_RULES[mode]()
+            comparators = [cls.CLASS_RULES[name.strip()]()
+                           for name in mode.split(',')]
+            return CompoundComparator(*comparators)
         except KeyError:
             raise KeyError(f'{mode} is an invalid strict URL rule.')
 

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -189,8 +189,14 @@ EMPTY_HTML = '''<html>
 MAX_SPACERS = 2500
 
 
+class Strict_url_rule:
+    mode = False
+    REGEX_RULES = {'WBM': r"/web/\d{14}"}
+
+
 def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
-                     include='combined', content_type_options='normal'):
+                     include='combined', content_type_options='normal',
+                     strict_urls=False):
     """
     HTML Diff for rendering. This is focused on visually highlighting portions
     of a page’s text that have been changed. It does not do much to show how
@@ -243,6 +249,9 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         - `nocheck` ignores the `Content-Type` header but still sniffs.
         - `nosniff` uses the `Content-Type` header but does not sniff.
         - `ignore` doesn’t do any checking at all.
+    strict_urls : string
+        The value of the URL parameter that indicates if the tag elements and href
+        elements should use special rules when checking equality,
 
     Example
     -------
@@ -256,6 +265,8 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
         a_headers,
         b_headers,
         content_type_options)
+
+    Strict_url_rule.mode = strict_urls
 
     soup_old = html5_parser.parse(a_text.strip() or EMPTY_HTML,
                                   treebuilder='soup', return_root=False)
@@ -564,6 +575,16 @@ class tag_token(DiffToken):
         obj.html_repr = html_repr
         return obj
 
+    def __eq__(self, other):
+        # This equality check aims to apply specific rules to the contents
+        # of the tag element solving false positive cases
+        if Strict_url_rule.mode:
+            return clean_resource(self, other)
+        return str.__eq__(self, other) or str.__eq__(self.lower(), other.lower())
+
+    def __hash__(self):
+        return hash(self.lower())
+
     def __repr__(self):
         return 'tag_token(%s, %s, html_repr=%s, post_tags=%r, pre_tags=%r, trailing_whitespace=%r)' % (
             self.tag,
@@ -580,6 +601,16 @@ class href_token(DiffToken):
     show the href when it changes.  """
 
     hide_when_equal = True
+
+    def __eq__(self, other):
+        # This equality check aims to apply specific rules to the contents of
+        # the href element solving false positive cases
+        if Strict_url_rule.mode:
+            return clean_resource(self, other)
+        return str.__eq__(self, other) or str.__eq__(self.lower(), other.lower())
+
+    def __hash__(self):
+        return hash(self.lower())
 
     def html(self):
         return ' Link: %s' % self
@@ -694,6 +725,21 @@ def fixup_chunks(chunks):
         result[-1].post_tags.extend(tag_accum)
 
     return result
+
+
+def clean_resource(element, other):
+    try:
+        match_element = re.search(Strict_url_rule.REGEX_RULES[Strict_url_rule.mode], element)
+        if match_element:
+            element = element[match_element.end():]
+        match_other = re.search(Strict_url_rule.REGEX_RULES[Strict_url_rule.mode], other)
+        if match_other:
+            other = other[match_other.end():]
+        return str.__eq__(element, other) or str.__eq__(element.lower(), other.lower())
+    except KeyError:
+        raise KeyError("{} is an invalid strict URL rule."
+                       "".format(Strict_url_rule.mode))
+
 
 def flatten_el(el, include_hrefs, skip_tag=False):
     """ Takes an lxml element el, and generates all the text chunks for

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -196,6 +196,25 @@ def test_html_diff_works_wbm_snapshots():
     assert results['change_count'] == 0
 
 
+def test_html_diff_works_without_custom_url_comparisons():
+    results = html_diff_render(
+        '''
+        <div>
+            This article is about the planet. For the deity, see
+            <a href=/web/20171105043925/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>.
+        </div>
+        ''',
+        '''
+        <div>
+            This article is about the planet. For the deity, see
+            <a href=/web/20171203125801/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>.
+        </div>
+        ''',
+        include='all')
+
+    assert results['change_count'] == 2
+
+
 def test_html_diff_works_with_wbm_srcset():
     results = html_diff_render(
         '''
@@ -257,5 +276,26 @@ def test_html_diff_works_with_uk_wbm_snapshots():
         '<a href="https://www.webarchive.org.uk/wayback/en/archive/20190525141538/https://www.example.gov/></a>',
         '<a href="https://www.webarchive.org.uk/wayback/en/archive/20181231224558/https://www.example.gov/></a>',
         include='all', strict_urls='UK_WBM')
+
+    assert results['change_count'] == 0
+
+
+def test_html_diff_compound_comparisons_works():
+    results = html_diff_render(
+        '''
+        <div>
+            <a href=/web/20171105043925/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>
+            <a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=A2DECB66D2648BFED11FC721FC3043A1"></a>
+            <a href="https://www.webarchive.org.uk/wayback/en/archive/20190525141538/https://www.example.gov/></a>
+        </div>
+        ''',
+        '''
+        <div>
+            <a href=/web/20171203125801/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>
+            <a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=45312D9542FDB015289A1BBD76958F43"></a>
+            <a href="https://www.webarchive.org.uk/wayback/en/archive/20181231224558/https://www.example.gov/></a>
+        </div>
+        ''',
+        include='all', strict_urls='jsessionid,WBM,UK_WBM')
 
     assert results['change_count'] == 0

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -177,7 +177,7 @@ def test_html_diff_works_on_documents_with_no_body():
     assert isinstance(results['combined'], str)
 
 
-def test_html_diff_works_wbm_snapshots():
+def test_html_diff_works_wayback_snapshots():
     results = html_diff_render(
         '''
         <div>
@@ -191,7 +191,7 @@ def test_html_diff_works_wbm_snapshots():
             <a href=/web/20171203125801/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>.
         </div>
         ''',
-        include='all', url_rules='WBM')
+        include='all', url_rules='wayback')
 
     assert results['change_count'] == 0
 
@@ -215,7 +215,7 @@ def test_html_diff_works_without_custom_url_comparisons():
     assert results['change_count'] == 2
 
 
-def test_html_diff_works_with_wbm_srcset():
+def test_html_diff_works_with_wayback_srcset():
     results = html_diff_render(
         '''
         <img
@@ -235,7 +235,7 @@ def test_html_diff_works_with_wbm_srcset():
             width="275"
             height="275">
         ''',
-        include='all', url_rules='WBM')
+        include='all', url_rules='wayback')
 
     assert results['change_count'] == 0
 
@@ -271,11 +271,11 @@ def test_html_diff_works_with_jsessionid():
     assert results['change_count'] == 0
 
 
-def test_html_diff_works_with_uk_wbm_snapshots():
+def test_html_diff_works_with_wayback_uk_snapshots():
     results = html_diff_render(
         '<a href="https://www.webarchive.org.uk/wayback/en/archive/20190525141538/https://www.example.gov/></a>',
         '<a href="https://www.webarchive.org.uk/wayback/en/archive/20181231224558/https://www.example.gov/></a>',
-        include='all', url_rules='UK_WBM')
+        include='all', url_rules='wayback_uk')
 
     assert results['change_count'] == 0
 
@@ -296,6 +296,6 @@ def test_html_diff_compound_comparisons_works():
             <a href="https://www.webarchive.org.uk/wayback/en/archive/20181231224558/https://www.example.gov/></a>
         </div>
         ''',
-        include='all', url_rules='jsessionid,WBM,UK_WBM')
+        include='all', url_rules='jsessionid,wayback,wayback_uk')
 
     assert results['change_count'] == 0

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -191,7 +191,7 @@ def test_html_diff_works_wbm_snapshots():
             <a href=/web/20171203125801/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>.
         </div>
         ''',
-        include='all', strict_urls='WBM')
+        include='all', url_rules='WBM')
 
     assert results['change_count'] == 0
 
@@ -235,7 +235,7 @@ def test_html_diff_works_with_wbm_srcset():
             width="275"
             height="275">
         ''',
-        include='all', strict_urls='WBM')
+        include='all', url_rules='WBM')
 
     assert results['change_count'] == 0
 
@@ -266,7 +266,7 @@ def test_html_diff_works_with_jsessionid():
     results = html_diff_render(
         '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=A2DECB66D2648BFED11FC721FC3043A1"></a>',
         '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=45312D9542FDB015289A1BBD76958F43"></a>',
-        include='all', strict_urls='jsessionid')
+        include='all', url_rules='jsessionid')
 
     assert results['change_count'] == 0
 
@@ -275,7 +275,7 @@ def test_html_diff_works_with_uk_wbm_snapshots():
     results = html_diff_render(
         '<a href="https://www.webarchive.org.uk/wayback/en/archive/20190525141538/https://www.example.gov/></a>',
         '<a href="https://www.webarchive.org.uk/wayback/en/archive/20181231224558/https://www.example.gov/></a>',
-        include='all', strict_urls='UK_WBM')
+        include='all', url_rules='UK_WBM')
 
     assert results['change_count'] == 0
 
@@ -296,6 +296,6 @@ def test_html_diff_compound_comparisons_works():
             <a href="https://www.webarchive.org.uk/wayback/en/archive/20181231224558/https://www.example.gov/></a>
         </div>
         ''',
-        include='all', strict_urls='jsessionid,WBM,UK_WBM')
+        include='all', url_rules='jsessionid,WBM,UK_WBM')
 
     assert results['change_count'] == 0

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -175,3 +175,85 @@ def test_html_diff_works_on_documents_with_no_body():
 
     assert 'combined' in results
     assert isinstance(results['combined'], str)
+
+
+def test_html_diff_works_wbm_snapshots():
+    results = html_diff_render(
+        '<div role="note" class="hatnote navigation-not-searchable">'
+        'This article is about the planet. For the deity, see <a href="/web/'
+        '20171105043925/https://en.wikipedia.org/wiki/Mars_(mythology)" title='
+        '"Mars (mythology)">Mars (mythology)</a>. For other uses, see <a href='
+        '"/web/20171105043925/https://en.wikipedia.org/wiki/Mars_'
+        '(disambiguation)" class="mw-disambig" title="Mars (disambiguation)">'
+        'Mars (disambiguation)</a>.</div>',
+        '<div role="note" class="hatnote navigation-not-searchable">'
+        'This article is about the planet. For the deity, see <a href="/web/'
+        '20171203125801/https://en.wikipedia.org/wiki/Mars_(mythology)" title='
+        '"Mars (mythology)">Mars (mythology)</a>. For other uses, see <a href='
+        '"/web/20171203125801/https://en.wikipedia.org/wiki/Mars_'
+        '(disambiguation)" class="mw-disambig" title="Mars (disambiguation)">'
+        'Mars (disambiguation)</a>.</div>',
+        include='all', strict_urls='WBM')
+
+    assert results['change_count'] == 0
+
+
+def test_html_diff_works_with_wbm_srcset():
+    results = html_diff_render(
+        '<img alt="OSIRIS Mars true color.jpg" srcset="//web-beta.archive.org/'
+        'web/20171105043925im_/https://upload.wikimedia.org/wikipedia/commons/'
+        'thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color'
+        '.jpg 1.5x, //web-beta.archive.org/web/20171105043925im_/https://'
+        'upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_'
+        'color.jpg/550px-OSIRIS_Mars_true_color.jpg 2x" data-file-width="2205"'
+        ' data-file-height="2205" width="275" height="275">',
+        '<img alt="OSIRIS Mars true color.jpg" srcset="//web-beta.archive.org/'
+        'web/20171203125801im_/https://upload.wikimedia.org/wikipedia/commons/'
+        'thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color'
+        '.jpg 1.5x, //web-beta.archive.org/web/20171203125801im_/https://'
+        'upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_'
+        'color.jpg/550px-OSIRIS_Mars_true_color.jpg 2x" data-file-width="2205"'
+        ' data-file-height="2205" width="275" height="275">',
+        include='all', strict_urls='WBM')
+
+    assert results['change_count'] == 0
+
+
+def test_html_diff_works_with_srcset():
+    results = html_diff_render(
+        '<img alt="OSIRIS Mars true color.jpg" src="https://upload.wikimedia.'
+        'org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-'
+        'OSIRIS_Mars_true_color.jpg">',
+        '<img alt="OSIRIS Mars true color.jpg" src="https://upload.wikimedia.'
+        'org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/275px-'
+        'OSIRIS_Mars_true_color.jpg" srcset="https://upload.wikimedia.org/'
+        'wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_'
+        'Mars_true_color.jpg 1.5x, https://upload.wikimedia.org/wikipedia/'
+        'commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/550px-OSIRIS_Mars_true_'
+        'color.jpg 2x" data-file-width="2205" data-file-height="2205" width='
+        '"275" height="275">',
+        include='all')
+
+    assert results['change_count'] == 0
+
+
+def test_html_diff_works_with_jsessionid():
+    results = html_diff_render(
+        '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=A2DECB66D2648B'
+        'FED11FC721FC3043A1"></a>',
+        '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=45312D9542FDB0'
+        '15289A1BBD76958F43"></a>',
+        include='all', strict_urls='jsessionid')
+
+    assert results['change_count'] == 0
+
+
+def test_html_diff_works_with_uk_wbm_snapshots():
+    results = html_diff_render(
+        '<a href="https://www.webarchive.org.uk/wayback/en/archive/'
+        '20190525141538/https://www.example.gov/></a>',
+        '<a href="https://www.webarchive.org.uk/wayback/en/archive/'
+        '20181231224558/https://www.example.gov/></a>',
+        include='all', strict_urls='UK_WBM')
+
+    assert results['change_count'] == 0

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -179,20 +179,18 @@ def test_html_diff_works_on_documents_with_no_body():
 
 def test_html_diff_works_wbm_snapshots():
     results = html_diff_render(
-        '<div role="note" class="hatnote navigation-not-searchable">'
-        'This article is about the planet. For the deity, see <a href="/web/'
-        '20171105043925/https://en.wikipedia.org/wiki/Mars_(mythology)" title='
-        '"Mars (mythology)">Mars (mythology)</a>. For other uses, see <a href='
-        '"/web/20171105043925/https://en.wikipedia.org/wiki/Mars_'
-        '(disambiguation)" class="mw-disambig" title="Mars (disambiguation)">'
-        'Mars (disambiguation)</a>.</div>',
-        '<div role="note" class="hatnote navigation-not-searchable">'
-        'This article is about the planet. For the deity, see <a href="/web/'
-        '20171203125801/https://en.wikipedia.org/wiki/Mars_(mythology)" title='
-        '"Mars (mythology)">Mars (mythology)</a>. For other uses, see <a href='
-        '"/web/20171203125801/https://en.wikipedia.org/wiki/Mars_'
-        '(disambiguation)" class="mw-disambig" title="Mars (disambiguation)">'
-        'Mars (disambiguation)</a>.</div>',
+        '''
+        <div>
+            This article is about the planet. For the deity, see
+            <a href=/web/20171105043925/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>.
+        </div>
+        ''',
+        '''
+        <div>
+            This article is about the planet. For the deity, see
+            <a href=/web/20171203125801/https://en.wikipedia.org/wiki/Mars_(mythology)>Mars (mythology)</a>.
+        </div>
+        ''',
         include='all', strict_urls='WBM')
 
     assert results['change_count'] == 0
@@ -200,20 +198,24 @@ def test_html_diff_works_wbm_snapshots():
 
 def test_html_diff_works_with_wbm_srcset():
     results = html_diff_render(
-        '<img alt="OSIRIS Mars true color.jpg" srcset="//web-beta.archive.org/'
-        'web/20171105043925im_/https://upload.wikimedia.org/wikipedia/commons/'
-        'thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color'
-        '.jpg 1.5x, //web-beta.archive.org/web/20171105043925im_/https://'
-        'upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_'
-        'color.jpg/550px-OSIRIS_Mars_true_color.jpg 2x" data-file-width="2205"'
-        ' data-file-height="2205" width="275" height="275">',
-        '<img alt="OSIRIS Mars true color.jpg" srcset="//web-beta.archive.org/'
-        'web/20171203125801im_/https://upload.wikimedia.org/wikipedia/commons/'
-        'thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color'
-        '.jpg 1.5x, //web-beta.archive.org/web/20171203125801im_/https://'
-        'upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_'
-        'color.jpg/550px-OSIRIS_Mars_true_color.jpg 2x" data-file-width="2205"'
-        ' data-file-height="2205" width="275" height="275">',
+        '''
+        <img
+            alt="OSIRIS Mars true color.jpg"
+            srcset="//web-beta.archive.org/web/20171105043925im_/https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color.jpg 1.5x, //web-beta.archive.org/web/20171105043925im_/https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/550px-OSIRIS_Mars_true_color.jpg 2x"
+            data-file-width="2205"
+            data-file-height="2205"
+            width="275"
+            height="275">
+        ''',
+        '''
+        <img
+            alt="OSIRIS Mars true color.jpg"
+            srcset="//web-beta.archive.org/web/20171203125801im_/https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color.jpg 1.5x, //web-beta.archive.org/web/20171203125801im_/https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/550px-OSIRIS_Mars_true_color.jpg 2x"
+            data-file-width="2205"
+            data-file-height="2205"
+            width="275"
+            height="275">
+        ''',
         include='all', strict_urls='WBM')
 
     assert results['change_count'] == 0
@@ -221,17 +223,21 @@ def test_html_diff_works_with_wbm_srcset():
 
 def test_html_diff_works_with_srcset():
     results = html_diff_render(
-        '<img alt="OSIRIS Mars true color.jpg" src="https://upload.wikimedia.'
-        'org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-'
-        'OSIRIS_Mars_true_color.jpg">',
-        '<img alt="OSIRIS Mars true color.jpg" src="https://upload.wikimedia.'
-        'org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/275px-'
-        'OSIRIS_Mars_true_color.jpg" srcset="https://upload.wikimedia.org/'
-        'wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_'
-        'Mars_true_color.jpg 1.5x, https://upload.wikimedia.org/wikipedia/'
-        'commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/550px-OSIRIS_Mars_true_'
-        'color.jpg 2x" data-file-width="2205" data-file-height="2205" width='
-        '"275" height="275">',
+        '''
+        <img
+            alt="OSIRIS Mars true color.jpg"
+            src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color.jpg">
+        ''',
+        '''
+        <img
+            alt="OSIRIS Mars true color.jpg"
+            src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/275px-OSIRIS_Mars_true_color.jpg"
+            srcset="https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/413px-OSIRIS_Mars_true_color.jpg 1.5x, https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/OSIRIS_Mars_true_color.jpg/550px-OSIRIS_Mars_true_color.jpg 2x"
+            data-file-width="2205"
+            data-file-height="2205"
+            width="275"
+            height="275">
+        ''',
         include='all')
 
     assert results['change_count'] == 0
@@ -239,10 +245,8 @@ def test_html_diff_works_with_srcset():
 
 def test_html_diff_works_with_jsessionid():
     results = html_diff_render(
-        '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=A2DECB66D2648B'
-        'FED11FC721FC3043A1"></a>',
-        '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=45312D9542FDB0'
-        '15289A1BBD76958F43"></a>',
+        '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=A2DECB66D2648BFED11FC721FC3043A1"></a>',
+        '<a href="https://www.ncdc.noaa.gov/homr/api;jsessionid=45312D9542FDB015289A1BBD76958F43"></a>',
         include='all', strict_urls='jsessionid')
 
     assert results['change_count'] == 0
@@ -250,10 +254,8 @@ def test_html_diff_works_with_jsessionid():
 
 def test_html_diff_works_with_uk_wbm_snapshots():
     results = html_diff_render(
-        '<a href="https://www.webarchive.org.uk/wayback/en/archive/'
-        '20190525141538/https://www.example.gov/></a>',
-        '<a href="https://www.webarchive.org.uk/wayback/en/archive/'
-        '20181231224558/https://www.example.gov/></a>',
+        '<a href="https://www.webarchive.org.uk/wayback/en/archive/20190525141538/https://www.example.gov/></a>',
+        '<a href="https://www.webarchive.org.uk/wayback/en/archive/20181231224558/https://www.example.gov/></a>',
         include='all', strict_urls='UK_WBM')
 
     assert results['change_count'] == 0


### PR DESCRIPTION
This PR aims to fix the false positive issue that appears when comparing webpages whose resources might have extra information. This information might be a timestamp in the path of a linked resource (occurring when diffing web archives of pages) or a jsessionid, etc.

In this PR I am implementing the __eq__ functions on the href_token and tag_token classes.
If the URL parameter "strict_urls" is set, and there is a matching value in the REGEX_RULES dictionary of the Strict_url_rule class, the __eq__ function of those objects will take into account the appropriate rule when deciding if the objects are equal or not.

This solves issue #391 

Looking forward to any comments/suggestions on my approach :)