### PR TITLE
Use lru_cache to speed up tag_info()

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -1455,11 +1455,15 @@ def merge_change_groups(change_chunks, doc, tag_type=None):
 TagInfo = namedtuple('TagInfo', ('name', 'open', 'source'))
 
 @lru_cache(maxsize=1024)
-def tag_info(token):
-    if not token.startswith('<'):
+def tag_info(tag_text):
+    """
+    Read text like `<span>` and return a `TagInfo` named tuple or None if not
+    a tag.
+    """
+    if not tag_text.startswith('<'):
         return None
-    name = token.split()[0].strip('<>/')
-    return TagInfo(name, not token.startswith('</'), token)
+    name = tag_text.split()[0].strip('<>/')
+    return TagInfo(name, not tag_text.startswith('</'), tag_text)
 
 # TODO: rewrite this in a way that doesn't mutate the input?
 def reconcile_change_groups(insert_groups, delete_groups, document):


### PR DESCRIPTION
`web_monitoring.html_diff_render.tag_info()` method reads a tag (e.g.
`<span>`) and returns a `TagInfo` named tuple.

Since the range of tags is somehow limited, this method receives the
same tags and repeats its processing over and over again even when
working on a single page. It makes sense to cache its results in memory
using `functools.lru_cache` to speedup processing.

Experiments using `.cache_info()` also showed that the cache is
effective (many hits) and operation is faster.

Note that we moved `tag_info` outside `reconcile_change_groups` method
to be able to reuse the memory cache universally.