### PR TITLE
Use html5-parser instead of lxml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6-slim
 MAINTAINER enviroDGI@gmail.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git gcc g++
+    git gcc g++ pkg-config libxml2-dev libxslt-dev
 
 # Set the working directory to /app
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ diff_match_patch_python ~=1.0.2
 docopt ~=0.6.2
 git+https://github.com/anastasia/htmldiffer@develop
 git+https://github.com/danielballan/htmltreediff@customize
+html5-parser ~=0.4.6
 lxml ~=4.3.3
 pandas ~=0.24.2
 sentry-sdk ~=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ diff_match_patch_python ~=1.0.2
 docopt ~=0.6.2
 git+https://github.com/anastasia/htmldiffer@develop
 git+https://github.com/danielballan/htmltreediff@customize
-html5-parser ~=0.4.7
+html5-parser ~=0.4.7 --no-binary lxml
 lxml ~=4.3.3
 pandas ~=0.24.2
 sentry-sdk ~=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ diff_match_patch_python ~=1.0.2
 docopt ~=0.6.2
 git+https://github.com/anastasia/htmldiffer@develop
 git+https://github.com/danielballan/htmltreediff@customize
-html5-parser ~=0.4.6
+html5-parser ~=0.4.7
 lxml ~=4.3.3
 pandas ~=0.24.2
 sentry-sdk ~=0.8.0

--- a/setup.py
+++ b/setup.py
@@ -20,20 +20,22 @@ def read(fname):
     return result
 
 
-RE_DELIM = re.compile(r';|--')
+# Delimits a setup.py-compatible requirement name/version from the extras that
+# only pip supports (environment info, CLI options, etc.).
+# https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+REQUIREMENT_DELIMITER = re.compile(r';|--')
 
 
 def cleanup(line):
-    match = RE_DELIM.search(line)
-    if match:
-        return line[:match.start()].strip()
-    return line
+    '''
+    Convert a pip requirements file line into an install_requires-style line.
+    '''
+    return REQUIREMENT_DELIMITER.split(line, 1)[0]
 
 
-# Requirements not on PyPI can't be installed through `install_requires`.
-# They have to be installed manually or with `pip install -r requirements.txt`.
-# Also, look for ; or -- on the line and, if present, remove that string and
-# everything after it.
+# Requirements not on PyPI or that use special pip features can't be installed
+# through `install_requires`. They have to be installed manually or with
+# `pip install -r requirements.txt`.
 requirements = [cleanup(r) for r in read('requirements.txt').splitlines()
                 if not r.startswith('git+https://')]
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup
 import glob
 import os
+import re
 from pathlib import Path
 import setuptools
 import sys
@@ -19,9 +20,21 @@ def read(fname):
     return result
 
 
+RE_DELIM = re.compile(r';|--')
+
+
+def cleanup(line):
+    match = RE_DELIM.search(line)
+    if match:
+        return line[:match.start()].strip()
+    return line
+
+
 # Requirements not on PyPI can't be installed through `install_requires`.
 # They have to be installed manually or with `pip install -r requirements.txt`.
-requirements = [r for r in read('requirements.txt').splitlines()
+# Also, look for ; or -- on the line and, if present, remove that string and
+# everything after it.
+requirements = [cleanup(r) for r in read('requirements.txt').splitlines()
                 if not r.startswith('git+https://')]
 
 

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -3,6 +3,7 @@ from diff_match_patch import diff, diff_bytes
 from web_monitoring.utils import get_color_palette
 from htmldiffer.diff import HTMLDiffer
 import htmltreediff
+import html5_parser
 import re
 import sys
 import web_monitoring.pagefreezer
@@ -29,7 +30,7 @@ def identical_bytes(a_body, b_body):
 
 def _get_text(html):
     "Extract textual content from HTML."
-    soup = BeautifulSoup(html, 'lxml')
+    soup = html5_parser.parse(html,  treebuilder='soup', return_root=False)
     [element.extract() for element in
      soup.find_all(string=lambda text: isinstance(text, Comment))]
     return soup.find_all(text=True)
@@ -131,7 +132,7 @@ def insert_style(html, css):
     -------
     render : string
     """
-    soup = BeautifulSoup(html, 'lxml')
+    soup = html5_parser.parse(html,  treebuilder='soup', return_root=False)
 
     # Ensure html includes a <head></head>.
     if not soup.head:

--- a/web_monitoring/differs.py
+++ b/web_monitoring/differs.py
@@ -1,4 +1,4 @@
-from bs4 import BeautifulSoup, Comment
+from bs4 import Comment
 from diff_match_patch import diff, diff_bytes
 from web_monitoring.utils import get_color_palette
 from htmldiffer.diff import HTMLDiffer
@@ -30,7 +30,7 @@ def identical_bytes(a_body, b_body):
 
 def _get_text(html):
     "Extract textual content from HTML."
-    soup = html5_parser.parse(html,  treebuilder='soup', return_root=False)
+    soup = html5_parser.parse(html, treebuilder='soup', return_root=False)
     [element.extract() for element in
      soup.find_all(string=lambda text: isinstance(text, Comment))]
     return soup.find_all(text=True)

--- a/web_monitoring/filtering.py
+++ b/web_monitoring/filtering.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
-from bs4 import BeautifulSoup
+import html5_parser
+
 
 day_list = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
 month_list = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
@@ -30,7 +31,9 @@ def df_filter(df):
                 break
 
         if (str(row['state']) == 'Change'):
-            social_soup = BeautifulSoup(str(row['new']), 'lxml')
+            social_soup = html5_parser.parse(str(row['new']),
+                                             treebuilder='soup',
+                                             return_root=False)
             social_list = list(social_soup.find_all(['a', 'script']))
             for x in social_list:
                 if (x.name == 'a'):

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -287,9 +287,6 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
                 'meta',
                 content=_diff_title(soup_old, soup_new))
             title_meta.attrs['name'] = 'wm-diff-title'
-            if not soup.head:
-                head = soup.new_tag('head')
-                soup.insert(0, head)
             soup.head.append(title_meta)
 
             old_head = soup.new_tag('template', id='wm-diff-old-head')

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -1,4 +1,4 @@
-from bs4 import BeautifulSoup
+import html5_parser
 from .content_type import raise_if_not_diffable_html
 from .differs import compute_dmp_diff
 from web_monitoring.utils import get_color_palette
@@ -388,7 +388,7 @@ def _create_empty_soup(title=''):
     title : string
         The new document's title.
     """
-    return BeautifulSoup(f"""<!doctype html>
+    return html5_parser.parse(f"""<!doctype html>
         <html>
             <head>
                 <meta charset="utf-8">
@@ -397,7 +397,7 @@ def _create_empty_soup(title=''):
             <body>
             </body>
         </html>
-        """, 'lxml')
+        """, treebuilder='soup', return_root=False)
 
 
 def not_deleted(diff_item):

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -6,6 +6,7 @@ from difflib import SequenceMatcher
 from .html_diff_render import (get_title, _html_for_dmp_operation,
                                undiffable_content_tags)
 import re
+import html5_parser
 
 
 def links_diff(a_text, b_text, a_headers=None, b_headers=None,
@@ -29,8 +30,8 @@ def links_diff(a_text, b_text, a_headers=None, b_headers=None,
         b_headers,
         content_type_options)
 
-    a_soup = BeautifulSoup(a_text, 'lxml')
-    b_soup = BeautifulSoup(b_text, 'lxml')
+    a_soup = html5_parser.parse(a_text, treebuilder='soup', return_root=False)
+    b_soup = html5_parser.parse(b_text, treebuilder='soup', return_root=False)
 
     a_links = sorted(
         set([Link.from_element(element) for element in _find_outgoing_links(a_soup)]),

--- a/web_monitoring/links_diff.py
+++ b/web_monitoring/links_diff.py
@@ -6,7 +6,6 @@ from difflib import SequenceMatcher
 from .html_diff_render import (get_title, _html_for_dmp_operation,
                                undiffable_content_tags)
 import re
-import html5_parser
 
 
 def links_diff(a_text, b_text, a_headers=None, b_headers=None,


### PR DESCRIPTION
Replace all `BeautifulSoup(html, 'lxml')` with
`html5_parser.parse(html, treebuilder='soup', return_root=False)`.

The aim is to improve robustness and speed.