### PR TITLE
Improve encoding detection

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -326,7 +326,7 @@ class DiffHandler(BaseHandler):
 
 def _extract_encoding(headers, content):
     encoding = None
-    content_type = headers.get('Content-Type', '')
+    content_type = headers.get('Content-Type', '').lower()
     if 'charset=' in content_type:
         encoding = content_type.split('charset=')[-1]
     if not encoding:
@@ -337,6 +337,8 @@ def _extract_encoding(headers, content):
         prolog_match = XML_PROLOG_PATTERN.search(content, endpos=2048)
         if prolog_match:
             encoding = prolog_match.group(1).decode('ascii', errors='ignore')
+    if encoding:
+        encoding = encoding.strip()
     # Handle common mistakes and errors in encoding names
     if encoding == 'iso-8559-1':
         encoding = 'iso-8859-1'

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -367,7 +367,7 @@ def _extract_encoding(headers, content):
 
 
 def _decode_body(response, name, raise_if_binary=True):
-    encoding = _extract_encoding(response.headers, response.body) or 'UTF-8'
+    encoding = _extract_encoding(response.headers, response.body)
     text = response.body.decode(encoding, errors='replace')
     text_length = len(text)
     if text_length == 0:

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -1,3 +1,4 @@
+import codecs
 import concurrent.futures
 from docopt import docopt
 import hashlib
@@ -343,17 +344,17 @@ def _extract_encoding(headers, content):
     # mistake: https://encoding.spec.whatwg.org/#names-and-labels
     if encoding == 'iso-8859-1' and 'html' in content_type:
         encoding = 'windows-1252'
+    # Check if the selected encoding is known. If not, fallback to default.
+    try:
+        codecs.lookup(encoding)
+    except (LookupError, ValueError, TypeError):
+        encoding = 'ascii'
     return encoding
 
 
 def _decode_body(response, name, raise_if_binary=True):
     encoding = _extract_encoding(response.headers, response.body) or 'UTF-8'
-    try:
-        text = response.body.decode(encoding, errors='replace')
-    except LookupError:
-        # If the encoding we found isn't known, fall back to ascii
-        text = response.body.decode('ascii', errors='replace')
-
+    text = response.body.decode(encoding, errors='replace')
     text_length = len(text)
     if text_length == 0:
         return text

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -5,6 +5,7 @@ import hashlib
 import inspect
 import functools
 import os
+import re
 import cchardet
 import sentry_sdk
 import tornado.gen
@@ -53,6 +54,19 @@ DIFF_ROUTES = {
     "html_tree_diff": web_monitoring.differs.html_tree_diff,
     "html_differ": web_monitoring.differs.html_differ,
 }
+
+# Matches a <meta> tag in HTML used to specify the character encoding:
+# <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+# <meta charset="utf-8" />
+META_TAG_PATTERN = re.compile(
+    b'<meta[^>]+charset\\s*=\\s*[\'"]?([^>]*?)[ /;\'">]',
+    re.IGNORECASE)
+
+# Matches an XML prolog that specifies character encoding:
+# <?xml version="1.0" encoding="ISO-8859-1"?>
+XML_PROLOG_PATTERN = re.compile(
+    b'<?xml\\s[^>]*encoding=[\'"]([^\'"]+)[\'"].*\?>',
+    re.IGNORECASE)
 
 client = tornado.httpclient.AsyncHTTPClient()
 
@@ -316,8 +330,16 @@ def _extract_encoding(headers, content):
     content_type = headers.get('Content-Type', '').lower()
     if 'charset=' in content_type:
         encoding = content_type.split('charset=')[-1]
-        if encoding:
-            encoding = encoding.strip()
+    if not encoding:
+        meta_tag_match = META_TAG_PATTERN.search(content, endpos=2048)
+        if meta_tag_match:
+            encoding = meta_tag_match.group(1).decode('ascii', errors='ignore')
+    if not encoding:
+        prolog_match = XML_PROLOG_PATTERN.search(content, endpos=2048)
+        if prolog_match:
+            encoding = prolog_match.group(1).decode('ascii', errors='ignore')
+    if encoding:
+        encoding = encoding.strip()
     if not encoding and content:
         # try to identify encoding using cchardet. Use up to 18kb of the
         # content for detection. Its not necessary to use the full content
@@ -340,7 +362,7 @@ def _extract_encoding(headers, content):
     try:
         codecs.lookup(encoding)
     except (LookupError, ValueError, TypeError):
-        encoding = 'ascii'
+        encoding = 'utf-8'
     return encoding
 
 

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -250,7 +250,7 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         headers = {'Content-Type': 'text/xhtml;CHARSET=iso-8859-5 '}
         assert df._extract_encoding(headers, b'') == 'iso-8859-5'
         headers = {'Content-Type': '\x94Invalid\x0b'}
-        assert df._extract_encoding(headers, b'') == 'ascii'
+        assert df._extract_encoding(headers, b'') == 'utf-8'
 
     def test_extract_encoding_from_body(self):
         # Polish content without any content-type headers or meta tag.

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -244,6 +244,14 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         response = mock_tornado_request('unknown_encoding.html')
         df._decode_body(response, 'a')
 
+    def test_extract_encoding_bad_headers(self):
+        headers = {'Content-Type': '  text/html; charset=iso-8859-7'}
+        assert df._extract_encoding(headers, b'') == 'iso-8859-7'
+        headers = {'Content-Type': 'text/xhtml;CHARSET=iso-8859-5 '}
+        assert df._extract_encoding(headers, b'') == 'iso-8859-5'
+        headers = {'Content-Type': '\x94Invalid\x0b'}
+        assert df._extract_encoding(headers, b'') == 'ascii'
+
     def test_diff_content_with_null_bytes(self):
         response = self.fetch('/html_source_dmp?format=json&'
                               f'a=file://{fixture_path("has_null_byte.txt")}&'

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -252,6 +252,15 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         headers = {'Content-Type': '\x94Invalid\x0b'}
         assert df._extract_encoding(headers, b'') == 'ascii'
 
+    def test_extract_encoding_from_body(self):
+        # Polish content without any content-type headers or meta tag.
+        headers = {}
+        body = """<html><head><title>TITLE</title></head>
+        <i>czyli co zrobić aby zobaczyć w tekstach polskie litery.</i>
+        Obowiązku czytania nie ma, ale wiele może wyjaśnić.
+        <body></body>""".encode('iso-8859-2')
+        assert df._extract_encoding(headers, body) == 'iso-8859-2'
+
     def test_diff_content_with_null_bytes(self):
         response = self.fetch('/html_source_dmp?format=json&'
                               f'a=file://{fixture_path("has_null_byte.txt")}&'


### PR DESCRIPTION
Improve `web_monitoring.diffing_server._extract_encoding` in many ways and add more unit tests.

1. Drop regex to detect html & xml encoding from specific tags in their contents and use `cchardet` instead. This has MANY benefits: a) can detect encoding for any type of HTML/XML/other markup without needing to check for specific meta tag. b) previous meta tag extraction couldn't handle border cases with various syntax errors, etc. c) Code is simplified. b) `cchardet` is faster than applying regex to response contents.

2. Handle bad content-type header cases. Previous code couldn't work with them.

3. Use `codecs.lookup` to check if the detected encoding is known to python. If not, fallback to default. Its beter if all encoding related logic is inside `_extract_encoding` and not have some of it in `_decode_body` as it was earlier.


