### PR TITLE
HOTFIX: #410 broke our docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-slim
 MAINTAINER enviroDGI@gmail.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git gcc g++ pkg-config libxml2-dev libxslt-dev
+    git gcc g++ pkg-config libxml2-dev libxslt-dev libz-dev
 
 # Set the working directory to /app
 WORKDIR /app


### PR DESCRIPTION
I had tested a previous version of the dockerfile in #410, but not the final one, which fails to build properly. It was missing libz. :(