### PR TITLE
Make a separate `build_docker` job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           at: /tmp/workspace
       - run:
           name: Load Image
-          command: docker load /tmp/workspace/docker-image
+          command: docker load --input /tmp/workspace/docker-image
       - run:
           name: Re-tag Image
           command: docker image tag envirodgi/processing:$CIRCLE_SHA1 envirodgi/processing:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,34 @@ jobs:
             . venv/bin/activate
             cd docs && make html
 
+  build_docker:
+    machine: true
+    steps:
+      - checkout
+      - run: |
+          docker build -t envirodgi/processing:$CIRCLE_SHA1 .
+      - run:
+          name: Save Image
+          command: |
+            mkdir /tmp/workspace
+            docker save --output /tmp/workspace/docker-image envirodgi/processing:$CIRCLE_SHA1
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - docker-image
+
+  use_built_docker:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load Image
+          command: docker load /tmp/workspace/docker-image
+      - run:
+          name: Re-tag Image
+          command: docker image tag envirodgi/processing:$CIRCLE_SHA1 envirodgi/processing:latest
+
   publish_docker:
     machine: true
     steps:
@@ -67,6 +95,13 @@ workflows:
           filters:
             branches:
               ignore: release
+      - build_docker:
+          filters:
+            branches:
+              ignore: release
+      - use_built_docker:
+          requires:
+            - build_docker
 
   build-and-publish:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,54 +62,35 @@ jobs:
           paths:
             - docker-image
 
-  use_built_docker:
+  publish_docker:
     machine: true
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Load Image
+          name: Load Built Docker Image
           command: docker load --input /tmp/workspace/docker-image
       - run:
           name: Re-tag Image
           command: docker image tag envirodgi/processing:$CIRCLE_SHA1 envirodgi/processing:latest
-
-  publish_docker:
-    machine: true
-    steps:
-      - checkout
-      - run: |
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run: |
-          docker build -t envirodgi/processing:$CIRCLE_SHA1 .
-          docker build -t envirodgi/processing:latest .
-      - run: |
-          docker push envirodgi/processing:$CIRCLE_SHA1
-          docker push envirodgi/processing:latest
+      - run:
+          name: Publish to Docker Hub
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push envirodgi/processing:$CIRCLE_SHA1
+            docker push envirodgi/processing:latest
 
 workflows:
   version: 2
   build:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore: release
-      - build_docker:
-          filters:
-            branches:
-              ignore: release
-      - use_built_docker:
+      - build
+      - build_docker
+      - publish_docker:
           requires:
+            - build
             - build_docker
-
-  build-and-publish:
-    jobs:
-      - build:
           filters:
             branches:
               only:
                 - release
-      - publish_docker:
-          requires:
-            - build


### PR DESCRIPTION
This adds a new CI job called `build_docker` that just builds the Docker image in order to make sure it works.

In #410, I did a bad job testing the Docker build (I tested an earlier version, but forgot to test the final version that we merged, which failed). That led to a hotfix (#419), which is no good. This should help mitigate that.

The first commit here also contains a bogus job called `use_built_docker`, which I’m using to test workspaces so that it’s possible the release workflow wouldn’t need to repeat building. ~Not ready for merging, obviously!~ *(Update: this is all fixed up now.)*