### PR TITLE
Clean up iterator and add multiple active elements test

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -341,10 +341,10 @@ def _cleanup_document_structure(soup):
 
 
 def _deactivate_deleted_active_elements(soup):
-    for index, element in enumerate(soup.find_all(ACTIVE_ELEMENTS)):
+    wrapper = soup.new_tag('template')
+    wrapper['class'] = 'wm-diff-deleted-inert'
+    for element in soup.find_all(ACTIVE_ELEMENTS):
         if element.find_parent('del'):
-            wrapper = soup.new_tag('template')
-            wrapper['class'] = 'wm-diff-deleted-inert'
             element.wrap(wrapper)
 
     return soup

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -341,10 +341,10 @@ def _cleanup_document_structure(soup):
 
 
 def _deactivate_deleted_active_elements(soup):
-    wrapper = soup.new_tag('template')
-    wrapper['class'] = 'wm-diff-deleted-inert'
     for element in soup.find_all(ACTIVE_ELEMENTS):
         if element.find_parent('del'):
+            wrapper = soup.new_tag('template')
+            wrapper['class'] = 'wm-diff-deleted-inert'
             element.wrap(wrapper)
 
     return soup

--- a/web_monitoring/tests/test_html_diff.py
+++ b/web_monitoring/tests/test_html_diff.py
@@ -4,11 +4,9 @@ import os
 from pathlib import Path
 from pkg_resources import resource_filename
 import pytest
-import html5_parser
 from web_monitoring.db import Client
 from web_monitoring.differs import html_tree_diff, html_differ
-from web_monitoring.html_diff_render import (html_diff_render,
-                                             _deactivate_deleted_active_elements)
+from web_monitoring.html_diff_render import html_diff_render
 
 def lookup_pair(fn):
     """Read example data named {fn}.before and {fn}.after"""
@@ -89,45 +87,6 @@ def test_contrived_examples_htmldiffer(fn):
     print(TEMPLATE.format(before, after, d))
     return d
 
-
-def test_deactivate_deleted_active_elements():
-    html = """
-<html>
-  <head></head>
-  <body>
-    <del>
-      <script src="script1.js"></script>
-    </del>
-    <p>test</p>
-    <del>
-      <script src="script2.js"></script>
-    </del>
-  </body>
-</html>"""
-    final_html = """<html>
- <head>
- </head>
- <body>
-  <del>
-   <template class="wm-diff-deleted-inert">
-    <script src="script1.js">
-    </script>
-   </template>
-  </del>
-  <p>
-   test
-  </p>
-  <del>
-   <template class="wm-diff-deleted-inert">
-    <script src="script2.js">
-    </script>
-   </template>
-  </del>
- </body>
-</html>"""
-    soup = html5_parser.parse(html, treebuilder='soup', return_root=False)
-    soup = _deactivate_deleted_active_elements(soup)
-    assert soup.prettify(formatter=None) == final_html
 
 ### TESTS ON MORE COMPLEX, REAL CASES
 

--- a/web_monitoring/tests/test_html_diff.py
+++ b/web_monitoring/tests/test_html_diff.py
@@ -8,6 +8,7 @@ from web_monitoring.db import Client
 from web_monitoring.differs import html_tree_diff, html_differ
 from web_monitoring.html_diff_render import html_diff_render
 
+
 def lookup_pair(fn):
     """Read example data named {fn}.before and {fn}.after"""
     fn1 = 'example_data/{}.before'.format(fn)

--- a/web_monitoring/tests/test_html_diff.py
+++ b/web_monitoring/tests/test_html_diff.py
@@ -4,10 +4,11 @@ import os
 from pathlib import Path
 from pkg_resources import resource_filename
 import pytest
+import html5_parser
 from web_monitoring.db import Client
 from web_monitoring.differs import html_tree_diff, html_differ
-from web_monitoring.html_diff_render import html_diff_render
-
+from web_monitoring.html_diff_render import (html_diff_render,
+                                             _deactivate_deleted_active_elements)
 
 def lookup_pair(fn):
     """Read example data named {fn}.before and {fn}.after"""
@@ -88,6 +89,45 @@ def test_contrived_examples_htmldiffer(fn):
     print(TEMPLATE.format(before, after, d))
     return d
 
+
+def test_deactivate_deleted_active_elements():
+    html = """
+<html>
+  <head></head>
+  <body>
+    <del>
+      <script src="script1.js"></script>
+    </del>
+    <p>test</p>
+    <del>
+      <script src="script2.js"></script>
+    </del>
+  </body>
+</html>"""
+    final_html = """<html>
+ <head>
+ </head>
+ <body>
+  <del>
+   <template class="wm-diff-deleted-inert">
+    <script src="script1.js">
+    </script>
+   </template>
+  </del>
+  <p>
+   test
+  </p>
+  <del>
+   <template class="wm-diff-deleted-inert">
+    <script src="script2.js">
+    </script>
+   </template>
+  </del>
+ </body>
+</html>"""
+    soup = html5_parser.parse(html, treebuilder='soup', return_root=False)
+    soup = _deactivate_deleted_active_elements(soup)
+    assert soup.prettify(formatter=None) == final_html
 
 ### TESTS ON MORE COMPLEX, REAL CASES
 

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -88,7 +88,7 @@ def test_deactivate_deleted_active_elements():
     b = '''<body><p>test2</p></body>'''
     result = html_diff_render(a, b)['combined']
     soup = html5_parser.parse(result, treebuilder='soup', return_root=False)
-    elements = soup.select('del.wm-diff > template.wm-diff-deleted-inert > script')
+    elements = soup.select('template.wm-diff-deleted-inert')
     assert len(elements) == 2
 
 

--- a/web_monitoring/tests/test_html_diff_validity.py
+++ b/web_monitoring/tests/test_html_diff_validity.py
@@ -8,6 +8,7 @@ doesn’t break or throw exceptions.
 
 from pathlib import Path
 from pkg_resources import resource_filename
+import html5_parser
 import pytest
 import re
 from web_monitoring.diff_errors import UndiffableContentError
@@ -64,6 +65,31 @@ def test_html_diff_render_doesnt_move_script_content_into_page_text():
     without_script = re.sub(r'(?s)<script[^>]*>.*?</script>', '', body)
     text_only = re.sub(r'<[^>]+>', '', without_script).strip()
     assert text_only == ''
+
+
+def test_deactivate_deleted_active_elements():
+    '''
+    Method `_deactivate_deleted_active_elements` is used by `html_diff_render`
+    internally to encapsulate `del > script` and `del > style` elements with a
+    `<template class="wm-diff-deleted-inert">` tag. The result for each deleted
+    tag should be like:
+
+    <del class="wm-diff">
+        <template class="wm-diff-deleted-inert">
+            <script src="s2.js">
+            </script>
+        </template>
+    </del>
+    '''
+    a = '''<body>
+           <script src="s1.js"></script>
+           <p>test</p>
+           <script src="s2.js"></script></body>'''
+    b = '''<body><p>test2</p></body>'''
+    result = html_diff_render(a, b)['combined']
+    soup = html5_parser.parse(result, treebuilder='soup', return_root=False)
+    elements = soup.select('del.wm-diff > template.wm-diff-deleted-inert > script')
+    assert len(elements) == 2
 
 
 @pytest.mark.skip(reason='lxml parser does not support CDATA in html')


### PR DESCRIPTION
Instead of creating the same `template` tag multiple times inside the
`for` loop, we create it only once and reuse it.

`enumerate` is redundant as we don't use the `index` it creates.