### PR TITLE
Use more descriptive errors for upstream failures

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -318,6 +318,10 @@ class DiffHandler(BaseHandler):
                     self.send_error(
                         504,
                         reason=f'Timed out while fetching "{url}"')
+                elif isinstance(response.error, ValueError):
+                    self.send_error(
+                        400,
+                        reason=str(response.error))
                 else:
                     self.send_error(
                         502,

--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -311,17 +311,17 @@ class DiffHandler(BaseHandler):
             try:
                 response.rethrow()
             except (ValueError, OSError, tornado.httpclient.HTTPError):
-                # Response code == 599 means that
-                # no HTTP response was received.
-                # In this case the error code should
-                # become 400 indicating that the error was
-                # raised because of a bad request parameter.
-                if response.code == 599:
+                url = response.request.url
+                # Timeouts aren't distinguishable from other network failures
+                # by status code, so check the actual error type.
+                if isinstance(response.error, tornado.simple_httpclient.HTTPTimeoutError):
                     self.send_error(
-                        400, reason=str(response.error))
+                        504,
+                        reason=f'Timed out while fetching "{url}"')
                 else:
                     self.send_error(
-                        response.code, reason=str(response.error))
+                        502,
+                        reason=f'Received a {response.code} status while fetching "{url}": {response.error}')
                 raise tornado.httpclient.HTTPError(0)
 
 

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -128,14 +128,14 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=example.org&b=https://example.org')
         self.json_check(response)
-        self.assertEqual(response.code, 400)
+        self.assertEqual(response.code, 502)
         self.assertFalse(response.headers.get('Etag'))
 
     def test_invalid_url_b_format(self):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=https://example.org&b=example.org')
         self.json_check(response)
-        self.assertEqual(response.code, 400)
+        self.assertEqual(response.code, 502)
         self.assertFalse(response.headers.get('Etag'))
 
     def test_invalid_diffing_method(self):
@@ -163,14 +163,14 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=https://eeexample.org&b=https://example.org')
         self.json_check(response)
-        self.assertEqual(response.code, 400)
+        self.assertEqual(response.code, 502)
         self.assertFalse(response.headers.get('Etag'))
 
     def test_not_reachable_url_b(self):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=https://example.org&b=https://eeexample.org')
         self.json_check(response)
-        self.assertEqual(response.code, 400)
+        self.assertEqual(response.code, 502)
         self.assertFalse(response.headers.get('Etag'))
 
     def test_missing_params_caller_func(self):
@@ -182,7 +182,9 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         response = self.fetch('/html_token?format=json&include=all'
                               '&a=http://httpstat.us/404'
                               '&b=https://example.org')
-        self.assertEqual(response.code, 404)
+        # The error is upstream, but the message should indicate it was a 404.
+        self.assertEqual(response.code, 502)
+        assert '404' in json.loads(response.body)['error']
         self.assertFalse(response.headers.get('Etag'))
         self.json_check(response)
 

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -128,14 +128,14 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=example.org&b=https://example.org')
         self.json_check(response)
-        self.assertEqual(response.code, 502)
+        self.assertEqual(response.code, 400)
         self.assertFalse(response.headers.get('Etag'))
 
     def test_invalid_url_b_format(self):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=https://example.org&b=example.org')
         self.json_check(response)
-        self.assertEqual(response.code, 502)
+        self.assertEqual(response.code, 400)
         self.assertFalse(response.headers.get('Etag'))
 
     def test_invalid_diffing_method(self):


### PR DESCRIPTION
When a request to another server to get diff content fails, we used to simply return the upstream server's error, which makes it tough to determine which request was problematic (was it the `a` or `b` param?) and can be hard to distinguish from an error inside the diffing server itself.

Instead, we now use 502/504 status codes in these cases (these codes are both for *gateways,* implying that the error happened upstream) and add the URL that failed to the error message. The upstream status code (if any) and message are also included in the full error text. This should help make it much more clear which request is failing and where exactly the failure is coming from.

Hopefully this will make situations like #425 more clear. @vbanos any thoughts on this?

We could also provide more structured data in the response JSON for the upstream URL, status code, and message, but that would require changes to `write_error()` and I wasn’t sure it was actually worthwhile.