### PR TITLE
Handle CDX API errors a little more gracefully

### DIFF
--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -265,6 +265,11 @@ class WaybackClient:
         response = utils.retryable_request('GET', CDX_SEARCH_URL,
                                            params=final_query,
                                            session=self.session)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as error:
+            raise WaybackException(str(error))
+
         lines = response.iter_lines()
         count = 0
 


### PR DESCRIPTION
While working on #429, I ran into trouble because the CDX API is generating lots of errors, which we’ve actually never seen before and handle incredibly poorly.

We previously just charged straight through situations where the response itself was an error and wound up raising an `UnexpectedResponseFormat` when parsing the first line. That means the user only ever sees the first line of the error, and is super confusing. Now we check for actual HTTP error codes right away and raise with a more complete message.

Before this change, we might have raised errors like:

```
web_monitoring.internetarchive.UnexpectedResponseFormat: <html>
```

Or:

```
UnexpectedResponseFormat: org.archive.util.io.RuntimeIOException: org.apache.commons.httpclient.ConnectTimeoutException: The host did not accept the connection within timeout of 2000 ms -- -r 25605744460-25606745292 http://archive.org/download/wbsrv-0208-0/all-20190516212237/part-0208.cdx.gz
```

But now we get:

```
web_monitoring.internetarchive.WaybackException: 503 Server Error: Service Temporarily Unavailable for url: http://web.archive.org/cdx/search/cdx?url=nasa.gov&showResumeKey=true&resolveRevisits=true
```

I’m not sure if wrapping the Requests HTTP exception in a `WaybackException` is right, but it felt like a useful way to reduce the variety of exception types a consumer of this method might need to handle and lets us stop using Requests if we want with fewer issues. On the flip side, the consumer gets a way more generic error object.