### PR TITLE
Reorganize remote content fetching in diff server

### DIFF
--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -269,6 +269,23 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
                               f'b=file://{fixture_path("has_null_byte.txt")}')
         assert response.code == 200
 
+    def test_validates_good_hashes(self):
+        response = self.fetch('/html_source_dmp?format=json&'
+                              f'a=file://{fixture_path("empty.txt")}&'
+                              'a_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&'
+                              f'b=file://{fixture_path("empty.txt")}&'
+                              'b_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+        assert response.code == 200
+
+    def test_validates_bad_hashes(self):
+        response = self.fetch('/html_source_dmp?format=json&'
+                              f'a=file://{fixture_path("empty.txt")}&'
+                              'a_hash=f3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&'
+                              f'b=file://{fixture_path("empty.txt")}&'
+                              'b_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+        assert response.code == 500
+        assert 'hash' in json.loads(response.body)['error']
+
 
 def mock_diffing_method(c_body):
     return


### PR DESCRIPTION
This resolves the deprecations in Tornado's HTTP client by reorganizing the code responsible for fetching and validating the content to diff. We previously had a lot of logic spread around `get()` that was just fetching the remote content. I've placed all of it into a method for fetching a single URL. Hopefully this also makes it a little more readable, though it could probably still be a bit cleaner.

This also adds tests for hash validation, which we apparently did not have before. It also runs hash validation against local files now.

**This will conflict with #429.** Whichever merges second will need updating.

Fixes #282, and should unblock #369.