### PR TITLE
Remove redundant var copy in html_diff_render

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -273,8 +273,7 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
     soup_old = _cleanup_document_structure(soup_old)
     soup_new = _cleanup_document_structure(soup_new)
 
-    metadata, diff_bodies = diff_elements(soup_old.body, soup_new.body, include)
-    results = metadata.copy()
+    results, diff_bodies = diff_elements(soup_old.body, soup_new.body, include)
 
     for diff_type, diff_body in diff_bodies.items():
         soup = None


### PR DESCRIPTION
We copy `metadata` to `results` but we don't do anything with
`metadata`.

We could assign the method result to `results` and not have `metadata`
at all.