### PR TITLE
Simplify flatten_el and fixup_chunks process

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -644,7 +644,8 @@ def fixup_chunks(chunks):
     cur_word = None
     result = []
     for chunk in chunks:
-        if chunk[0] == TokenType.img:
+        current_token = chunk[0]
+        if current_token == TokenType.img:
             src = chunk[1]
             tag, trailing_whitespace = split_trailing_whitespace(chunk[2])
             cur_word = tag_token('img', src, html_repr=tag,
@@ -653,27 +654,27 @@ def fixup_chunks(chunks):
             tag_accum = []
             result.append(cur_word)
 
-        elif chunk[0] == TokenType.href:
+        elif current_token == TokenType.href:
             href = chunk[1]
             cur_word = href_token(href, pre_tags=tag_accum, trailing_whitespace=" ")
             tag_accum = []
             result.append(cur_word)
 
-        elif chunk[0] == TokenType.undiffable:
+        elif current_token == TokenType.undiffable:
             cur_word = UndiffableContentToken(chunk[1], pre_tags=tag_accum)
             tag_accum = []
             result.append(cur_word)
 
-        elif chunk[0] == TokenType.word:
+        elif current_token == TokenType.word:
             chunk, trailing_whitespace = split_trailing_whitespace(chunk[1])
             cur_word = DiffToken(chunk, pre_tags=tag_accum, trailing_whitespace=trailing_whitespace)
             tag_accum = []
             result.append(cur_word)
 
-        elif chunk[0] == TokenType.start_tag:
+        elif current_token == TokenType.start_tag:
             tag_accum.append(chunk[1])
 
-        elif chunk[0] == TokenType.end_tag:
+        elif current_token == TokenType.end_tag:
             if tag_accum:
                 tag_accum.append(chunk[1])
             else:

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -639,8 +639,8 @@ def fixup_chunks(chunks):
             src = chunk[1]
             tag, trailing_whitespace = split_trailing_whitespace(chunk[2])
             cur_word = tag_token('img', src, html_repr=tag,
-                                    pre_tags=tag_accum,
-                                    trailing_whitespace=trailing_whitespace)
+                                 pre_tags=tag_accum,
+                                 trailing_whitespace=trailing_whitespace)
             tag_accum = []
             result.append(cur_word)
 

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -670,7 +670,7 @@ def fixup_chunks(chunks):
             else:
                 assert cur_word, (
                     "Weird state, cur_word=%r, result=%r, chunks=%r of %r"
-                    % (cur_word, result, chunk[1], chunks))
+                    % (cur_word, result, chunk, chunks))
                 cur_word.post_tags.append(chunk[1])
         else:
             assert(0)


### PR DESCRIPTION
`flatten_el` generates chunks which could be a tuple or a string.
Then `fixup_chunks` reads the chunks and creates tokens.

The fact that `flatten_el` returns both tuples and strings is a bit
confusing and complicates the program structure. We can simplify
and make it faster as well.

Instead of returning tuples only for `img`, `href` and `UNDIFFABLE`, we
now return tuple for all `flatten_el` return values. This adds
`START_TAG`, `END_TAG` and `WORD`.

`fixup_chunks` structure now becomes less complex. You don't need to do
`if isinstance(chunk, tuple)` for each chunk and you don't need
`is_word`, `is_start_tag`, `is_end_tag` methods any more.

Chunk processing is much more straightforward and less method calls are done
which is good for performance. (All these `.startswith` calls are now
gone).