### PR TITLE
Add option to accept URLs with status != 200

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -89,6 +89,9 @@ DEBUG_MODE = os.environ.get('DIFFING_SERVER_DEBUG', 'False').strip().lower() == 
 VALIDATE_TARGET_CERTIFICATES = \
     os.environ.get('VALIDATE_TARGET_CERTIFICATES', 'False').strip().lower() == 'true'
 
+ACCEPT_ONLY_STATUS_200 = \
+    os.environ.get('ACCEPT_ONLY_STATUS_200', 'True').strip().lower() == 'true'
+
 access_control_allow_origin_header = \
     os.environ.get('ACCESS_CONTROL_ALLOW_ORIGIN_HEADER')
 
@@ -226,7 +229,8 @@ class DiffHandler(BaseHandler):
 
             try:
                 response = yield client.fetch(url, headers=headers,
-                                              validate_cert=VALIDATE_TARGET_CERTIFICATES)
+                                              validate_cert=VALIDATE_TARGET_CERTIFICATES,
+                                              raise_error=ACCEPT_ONLY_STATUS_200)
             except ValueError as error:
                 self.send_error(400, reason=str(error))
             except OSError as error:


### PR DESCRIPTION
Add env var `ACCEPT_ONLY_STATUS_200` which defaults to `True`.

We use the value of this var to set
`tornado.httpclient.AsyncHTTPClient.fetch` method param `raise_error`.

When `raise_error=False`, we can download any URL regardless of its
status code.

Tornado docs reference:
https://www.tornadoweb.org/en/stable/_modules/tornado/httpclient.html#HTTPClient

By default, the ``Future`` will raise an
`HTTPError` if the request returned a non-200 response code
(other errors may also be raised if the server could not be
contacted). Instead, if ``raise_error`` is set to False, the
response will always be returned regardless of the response code.