### PR TITLE
Accept responses with HTTP status >= 300 from web archives

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -226,7 +226,14 @@ class DiffHandler(BaseHandler):
 
             try:
                 response = yield client.fetch(url, headers=headers,
-                                              validate_cert=VALIDATE_TARGET_CERTIFICATES)
+                                              validate_cert=VALIDATE_TARGET_CERTIFICATES,
+                                              raise_error=False)
+                # Accept response with HTTP status >= 300 only if its coming
+                # from a web archive. HTTP header `Memento-Datetime` is an
+                # indication about that.
+                if response.code >= 300 and \
+                        response.headers.get('Memento-Datetime') is None:
+                    response.rethrow()
             except ValueError as error:
                 self.send_error(400, reason=str(error))
             except OSError as error:

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -188,6 +188,18 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         self.assertFalse(response.headers.get('Etag'))
         self.json_check(response)
 
+    def test_web_archive_404(self):
+        """
+        If a page has HTTP status != 2xx but comes from a web archive,
+        we proceed with diffing.
+        """
+        response = self.fetch('/html_token?format=json&include=all'
+                              '&a=http://web.archive.org/web/20180925033850/http://httpstat.us/404'
+                              '&b=https://example.org')
+        # The error is upstream, but the message should indicate it was a 404.
+        self.assertEqual(response.code, 200)
+        assert 'change_count' in json.loads(response.body)
+
     @patch('web_monitoring.diffing_server.access_control_allow_origin_header', '*')
     def test_check_cors_headers(self):
         """

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -188,17 +188,22 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         self.assertFalse(response.headers.get('Etag'))
         self.json_check(response)
 
-    def test_web_archive_404(self):
+    def test_accepts_errors_from_web_archives(self):
         """
         If a page has HTTP status != 2xx but comes from a web archive,
         we proceed with diffing.
         """
-        response = self.fetch('/html_token?format=json&include=all'
-                              '&a=http://web.archive.org/web/20180925033850/http://httpstat.us/404'
-                              '&b=https://example.org')
-        # The error is upstream, but the message should indicate it was a 404.
-        self.assertEqual(response.code, 200)
-        assert 'change_count' in json.loads(response.body)
+        mock = MockAsyncHttpClient()
+        with patch.object(df, 'client', wraps=mock):
+            mock.respond_to(r'/error$', code=404, headers={'Memento-Datetime': 'Tue Sep 25 2018 03:38:50'})
+            mock.respond_to(r'/success$')
+
+            response = self.fetch('/html_token?format=json&include=all'
+                                  '&a=https://archive.org/20180925033850/http://httpstat.us/error'
+                                  '&b=https://example.org/success')
+
+            self.assertEqual(response.code, 200)
+            assert 'change_count' in json.loads(response.body)
 
     @patch('web_monitoring.diffing_server.access_control_allow_origin_header', '*')
     def test_check_cors_headers(self):


### PR DESCRIPTION
We need to accept and process responses from web archives without
requiring a status = 2xx response.
We check for HTTP header `Memento-Datetime` which is used in web
archives to detect that.