### PR TITLE
Use extension to guess MIME type for local files

### DIFF
--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -388,34 +388,21 @@ class MockAsyncHttpClient(AsyncHTTPClient):
 
 class MockResponderHeadersTest(unittest.TestCase):
     def test_pdf_extension(self):
-        headers = df.MockResponse._get_content_type_headers_from_url(
-            f'file://{fixture_path("simple.pdf")}'
-        )
-        assert headers['Content-Type'] == 'application/pdf'
+        response = df.MockResponse(f'file://{fixture_path("simple.pdf")}', '')
+        assert response.headers['Content-Type'] == 'application/pdf'
 
     def test_html_extension(self):
-        headers = df.MockResponse._get_content_type_headers_from_url(
-            f'file://{fixture_path("unknown_encoding.html")}'
-        )
-        assert headers['Content-Type'] == 'text/html'
+        response = df.MockResponse(f'file://{fixture_path("unknown_encoding.html")}', '')
+        assert response.headers['Content-Type'] == 'text/html'
 
     def test_txt_extension(self):
-        headers = df.MockResponse._get_content_type_headers_from_url(
-            f'file://{fixture_path("empty.txt")}'
-        )
-        assert headers['Content-Type'] == 'text/plain'
+        response = df.MockResponse(f'file://{fixture_path("empty.txt")}', '')
+        assert response.headers['Content-Type'] == 'text/plain'
 
     def test_no_extension_should_assume_html(self):
-        resp = df.MockResponse
-        headers = resp._get_content_type_headers_from_url(
-            f'file://{fixture_path("unknown_encoding")}'
-        )
-        assert headers['Content-Type'] == 'text/html'
+        response = df.MockResponse(f'file://{fixture_path("unknown_encoding")}', '')
+        assert response.headers['Content-Type'] == 'text/html'
 
     def test_unknown_extension_should_assume_html(self):
-        resp = df.MockResponse
-        headers = resp._get_content_type_headers_from_url(
-            f'file://{fixture_path("unknown_encoding.notarealextension")}'
-        )
-        assert headers['Content-Type'] == 'text/html'
-
+        response = df.MockResponse(f'file://{fixture_path("unknown_encoding.notarealextension")}', '')
+        assert response.headers['Content-Type'] == 'text/html'


### PR DESCRIPTION
Previously, we assumed `application/html; charset=UTF-8` for all local files. That's not really a valid MIME type, and we would like to support PDFs, and perhaps other stuff, in the future.

I used the built-in `mimetypes` package to guess values for the `Content-Type` and `Content-Encoding` headers based on the file extension.

This package only suggests `Content-Encodings` for a few archive formats (eg .gz, .bz2), so I'm not sure if it's ever likely to be relevant for our purposes, but, hey, it's free. I'm happy to delete this part if it doesn't seem likely to be useful in the future.

Issue: https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/231