### PR TITLE
Catch TypeError by http client

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -229,7 +229,7 @@ class DiffHandler(BaseHandler):
                                               validate_cert=VALIDATE_TARGET_CERTIFICATES)
             except ValueError as error:
                 self.send_error(400, reason=str(error))
-            except OSError as error:
+            except (OSError, TypeError) as error:
                 self.send_error(502, reason=f'Could not fetch {url}: {error}')
             except tornado.simple_httpclient.HTTPTimeoutError:
                 self.send_error(504, reason=f'Timed out while fetching "{url}"')


### PR DESCRIPTION
I got a few of `TypeError` exceptions by the http client in production. I see that `TypeError` wasn't
handled so I add it to the exception handling code.

Since this problem is about not being able to fetch the target URL, I
think it makes sense to put it in the same place as `OSError`, (Could
not fetch url).

```
Exception in callback _HTTPConnection.finish.<locals>.<lambda>(<Future
finis...time_info={})>) at
/opt/web-monitoring/lib/python3.6/site-packages/tornado/simple_httpclient.py:657
handle: <Handle _HTTPConnection.finish.<locals>.<lambda>(<Future
finis...time_info={})>) at
/opt/web-monitoring/lib/python3.6/site-packages/tornado/simple_httpclient.py:657>
```

```
TypeError: 'NoneType' object is not callable
  File "asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "tornado/simple_httpclient.py", line 657, in <lambda>
    fut.add_done_callback(lambda f: final_callback(f.result()))
```