### PR TITLE
Add dependency caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 sudo: false
 env:
     global:


### PR DESCRIPTION
Since we have to build lxml and html5-parser every time, Travis is really slow. :\

Speed it up with dependency caching: https://docs.travis-ci.com/user/caching/