### PR TITLE
Update Wayback docs to better use new features

### DIFF
--- a/docs/source/wayback.rst
+++ b/docs/source/wayback.rst
@@ -71,12 +71,14 @@ There is a copy edited for human viewers on the web, available at the record's
 was originally scraped, availabe at the record's ``raw_url``. For analysis
 purposes, we generally want the ``raw_url``.
 
-Let's download the raw content using ``requests``.
+Let's download the raw content using ``WaybackClient``. (You could download the
+content directly with an HTTP library like ``requests``, but ``WaybackClient``
+adds extra tools for dealing with Wayback Machine servers.)
 
 .. ipython:: python
 
-   import requests
-   content = requests.get(record.raw_url).content.decode()
+   response = client.get_memento(record.raw_url)
+   content = response.content.decode()
 
 We can use the built-in method ``count`` on strings to count the number of
 times that ``'mars'`` appears in the content.

--- a/docs/source/wayback.rst
+++ b/docs/source/wayback.rst
@@ -135,4 +135,11 @@ Memento API. We implement a Python client that can speak both.
 
     .. automethod:: search
     .. automethod:: list_versions
+    .. automethod:: get_memento
     .. automethod:: timestamped_uri_to_version
+
+Hello
+
+.. autoclass:: WaybackSession
+
+    .. automethod:: reset

--- a/docs/source/wayback.rst
+++ b/docs/source/wayback.rst
@@ -138,8 +138,6 @@ Memento API. We implement a Python client that can speak both.
     .. automethod:: get_memento
     .. automethod:: timestamped_uri_to_version
 
-Hello
-
 .. autoclass:: WaybackSession
 
     .. automethod:: reset

--- a/docs/source/wayback.rst
+++ b/docs/source/wayback.rst
@@ -4,14 +4,14 @@
 Python API to Internet Archive Wayback Machine
 **********************************************
 
-Search for historical snapshots of a URL. Download metadata about the snapshots
-and/or the snapshot content itself.
+Search for historical mementos (archived copies) of a URL. Download metadata
+about the mementos and/or the memento content itself.
 
 Tutorial
 ========
 
-What is the earliest snapshot of nasa.gov?
-------------------------------------------
+What is the earliest memento of nasa.gov?
+-----------------------------------------
 
 Instantiate a :class:`WaybackClient`.
 
@@ -51,7 +51,7 @@ Wayback Machine. Looking at the record in detail,
 
    record
 
-we can find our answer: Wayback's first snapshot of nasa.gov was in 1996. We
+we can find our answer: Wayback's first memento of nasa.gov was in 1996. We
 can use dot access on ``record`` to access the date specifically.
 
 .. ipython:: python
@@ -61,9 +61,9 @@ can use dot access on ``record`` to access the date specifically.
 How many times does the word 'mars' appear on nasa.gov?
 -------------------------------------------------------
 
-Above, we access the metadata for the oldest snapshot on nasa.gov, stored in
+Above, we access the metadata for the oldest memento on nasa.gov, stored in
 the variable ``record``. Starting from where we left off, we'll access the
-*content* of the snapshot and do a very simple analysis.
+*content* of the memento and do a very simple analysis.
 
 The Wayback Machine provides two ways to look at the data it has captured.
 There is a copy edited for human viewers on the web, available at the record's

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -232,9 +232,11 @@ class WaybackSession(utils.DisableAfterCloseSession, requests.Session):
         Number of seconds from which to calculate how long to back off and wait
         when retrying requests. The first retry is always immediate, but
         subsequent retries increase by powers of 2:
+
             seconds = backoff * 2 ^ (retry number - 1)
+
         So if this was `4`, retries would happen after the following delays:
-            0 seconds, 4 seconds, 8 seconds, 16 seconds, ...
+        0 seconds, 4 seconds, 8 seconds, 16 seconds, ...
     timeout : int or float or tuple of (int or float, int or float), optional
         A timeout to use for all requests. If not set, there will be no
         no explicit timeout. See the Requests docs for more:


### PR DESCRIPTION
We made a bunch of improvements to our Wayback tools in #174, but we didn’t update the docs as well as we should have in that PR. This attempts to remedy that:

- Use `WaybackClient.get_memento()` in Wayback tutorial.
- Use the term “memento” instead of “snapshot” throughout the tutorial.
- Add a diagram and docstring to the top of the `cli` module.
- Ensure we generate API docs for `WaybackClient.get_memento()` and `WaybackSession`