### PR TITLE
HOTFIX: version uploads with `status` field fail

### DIFF
--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -86,7 +86,7 @@ def _build_version(*, page_id, uuid, capture_time, uri, hash, source_type,
 def _build_importable_version(*, page_url, uuid=None, capture_time, uri,
                               version_hash, source_type, title,
                               page_maintainers=None, page_tags=None,
-                              source_metadata=None):
+                              source_metadata=None, status=None):
     """
     Build a Version dict from parameters, performing some validation.
 
@@ -105,6 +105,7 @@ def _build_importable_version(*, page_url, uuid=None, capture_time, uri,
                'source_type': str(source_type),
                'title': str(title),
                'source_metadata': source_metadata,
+               'status': str(status),
                'page_maintainers': page_maintainers,
                'page_tags': page_tags}
     return version


### PR DESCRIPTION
In #174, I made a last minute fix to add `status` as a top level field in our version imports (it was already supported by the API, but we had failed to update our code to send it). I must have missed committing a file though, because it's failing!

I added the code to put `status` in the dictionary we send to `db_client.add_versions()`, but missed where the DB client validates those dicts. It was not ready to accept `status` as a valid field.

This adds the field so it passes validation, but I wonder if, longer term, we should just pass along whatever fields we get and rely on checking the import results later to understand whether something was malformed. The current setup gets you your error messages earlier, but makes it harder to keep pace with upstream API changes (i.e. it’s not forwards-compatible).