### PR TITLE
HOTFIX: fix truncated healtcheck script messages

### DIFF
--- a/scripts/ia_healthcheck
+++ b/scripts/ia_healthcheck
@@ -12,6 +12,15 @@ import sys
 from web_monitoring import db, internetarchive
 
 
+# The current Sentry client truncates string values at 512 characters. It
+# appears that monkey-patching this module global is only way to change it and
+# that doing so is the intended method:
+#   https://github.com/getsentry/sentry-python/blob/5f9f7c469af16a731948a482ea162c2348800999/sentry_sdk/utils.py#L662-L664
+# That doesn't seem great, so I've asked about this on their forums:
+#   https://forum.sentry.io/t/some-stack-traces-are-truncated/7309/4
+sentry_sdk.utils.MAX_STRING_LENGTH = 2048
+
+
 MAX_CAPTURE_AGE = timedelta(hours=72)
 LINKS_TO_CHECK = 10
 
@@ -85,6 +94,11 @@ def output_results(statuses):
         message = f'{status_text}: {url}'
         print(message)
         logs.append(message)
+
+    # At this point, everything is OK; we don't need breadcrumbs and other
+    # extra noise to come with the message we are about to send.
+    with sentry_sdk.configure_scope() as scope:
+        scope.clear()
 
     if healthy_links + unhealthy_links == 0:
         print('Failed to sampled any pages!')


### PR DESCRIPTION
Out healthcheck script was unintentionally stuck on a very old version of the Sentry SDK because it had to run on the same codebase as our Wayback imports, which were part of a very long-lived branch. When everything got merged, we wound up getting upgraded to a *much* newer version of the Sentry client package, and it turns out it now truncates strings at 512 characters. Of course, the healthcheck script outputs pretty long messages, so that's not OK.

The max length is hardcoded as a constant in `sentry.utils.MAX_STRING_LENGTH`, and there doesn't appear to be any setting or feature to override it. Instead, there is a comment in the code that says:

    # This is intentionally not just the default such that one can patch `MAX_STRING_LENGTH` and affect `strip_string`.

...so that's what I've gone ahead and done here. It doesn't feel great, so I also commented on a relevant post on Sentry's forums about it: https://forum.sentry.io/t/some-stack-traces-are-truncated/7309/4