### PR TITLE
Fix parsing body tags containing the string `</body>`

### DIFF
--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -619,7 +619,7 @@ def parse_html(html):
     Parses an HTML fragment, returning an lxml element.  Note that the HTML
     will be wrapped in a <div> tag that was not in the original document.
     """
-    return fragment_fromstring(html, create_parent=True)
+    return html5_parser.parse(html, treebuilder='lxml')
 
 def split_trailing_whitespace(word):
     """

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -590,6 +590,9 @@ class UndiffableContentToken(DiffToken):
     pass
 
 
+# FIXME: this should be adapted to work off a BeautifulSoup element instead of
+# an etree/lxml element, since we already have that and could avoid re-parsing
+# the whole document a second time.
 def tokenize(html, include_hrefs=True):
     """
     Parse the given HTML and returns token objects (words with attached tags).

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -603,20 +603,19 @@ def parse_html(html, cleanup=True):
         html = cleanup_html(html)
     return fragment_fromstring(html, create_parent=True)
 
-_body_re = re.compile(r'<body.*?>', re.I|re.S)
-_end_body_re = re.compile(r'</body.*?>', re.I|re.S)
+_body_re = re.compile(r'^\s*<body.*?>', re.I|re.S)
+_end_body_re = re.compile(r'</body[^>]*?>\s*$', re.I|re.S)
 _ins_del_re = re.compile(r'</?(ins|del).*?>', re.I|re.S)
 
 def cleanup_html(html):
     """ This 'cleans' the HTML, meaning that any page structure is removed
     (only the contents of <body> are used, if there is any <body).
     Also <ins> and <del> tags are removed.  """
-    match = _body_re.search(html)
-    if match:
-        html = html[match.end():]
-    match = _end_body_re.search(html)
-    if match:
-        html = html[:match.start()]
+    body_start = _body_re.search(html)
+    if body_start:
+        body_end = _end_body_re.search(html)
+        if body_end:
+            html = html[body_start.end():body_end.start()]
     html = _ins_del_re.sub('', html)
     return html
 

--- a/web_monitoring/html_diff_render.py
+++ b/web_monitoring/html_diff_render.py
@@ -30,7 +30,6 @@ from .differs import compute_dmp_diff
 
 # Imports only used in forked tokenization code; may be ripe for removal:
 from lxml import etree
-from lxml.html import fragment_fromstring
 from html import escape as html_escape
 
 


### PR DESCRIPTION
In #259, it turned out some totally broken diffs were because of a poorly thought-through set of regexes used to clean up documents. We use those at a particularly dumb point in the process where we serialize the document and re-parse it a second time (!) because the tokenization routines we inherited from lxml were not designed to work with BeautifulSoup nodes.

While we should eventually fix the tokenization and double-parsing, this smaller patch does away with the regexes. Since we already have a parsed BeautifulSoup representation, we can do the cleanup more easily and reliably on *that* before serializing for the second parse.

Fixes #259.