### PR TITLE
Catch spurious parse_timestamp exceptions in db.get_change

### DIFF
--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -613,12 +613,9 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         data = result['data']
         # For changes which were created just-in-time to fulfill this API request,
         # created/updated_at will be None, and that's OK.
-        try:
+        if data['created_at'] and data['updated_at']:
             data['created_at'] = parse_timestamp(data['created_at'])
             data['updated_at'] = parse_timestamp(data['updated_at'])
-        except TypeError as exc:
-            warnings.warn("Ignoring empty created/updated_at "
-                          "for unsaved Change: {}".format(exc))
         return result
 
     def list_annotations(self, *, page_id, to_version_id, from_version_id='',

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -611,8 +611,14 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         result = res.json()
         # In place, replace datetime strings with datetime objects.
         data = result['data']
-        data['created_at'] = parse_timestamp(data['created_at'])
-        data['updated_at'] = parse_timestamp(data['updated_at'])
+        # For changes which were created just-in-time to fulfill this API request,
+        # created/updated_at will be None, and that's OK.
+        try:
+            data['created_at'] = parse_timestamp(data['created_at'])
+            data['updated_at'] = parse_timestamp(data['updated_at'])
+        except TypeError as exc:
+            warnings.warn("Ignoring empty created/updated_at "
+                          "for unsaved Change: {}".format(exc))
         return result
 
     def list_annotations(self, *, page_id, to_version_id, from_version_id='',


### PR DESCRIPTION
Catch exceptions in db.py thrown when a Change without created_at/updated_at values is returned by the API. These empty values are legit because Changes which were requested but had not previously existed are created to fill a response but not saved, and those fields are filled at save time.