### PR TITLE
Use Sentry scope when setting breadcrumbs

### DIFF
--- a/web_monitoring/diffing_server.py
+++ b/web_monitoring/diffing_server.py
@@ -296,19 +296,21 @@ class DiffHandler(BaseHandler):
         # Pass non-raised (i.e. we manually called `send_error()`), non-user
         # errors to Sentry.io.
         if actual_error is None and response['code'] >= 500:
-            # TODO: this breadcrumb should happen at the start of the request
-            # handler, but we need to test and make sure crumbs are properly
-            # attached to *this* HTTP request and don't bleed over to others,
-            # since Sentry's special support for Tornado has been dropped.
-            headers = dict(self.request.headers)
-            if 'Authorization' in headers:
-                headers['Authorization'] = '[removed]'
-            sentry_sdk.add_breadcrumb(category='request', data={
-                'url': self.request.full_url(),
-                'method': self.request.method,
-                'headers': headers,
-            })
-            sentry_sdk.capture_message(f'{self._reason} (status: {response["code"]})')
+            with sentry_sdk.push_scope():
+                # TODO: this breadcrumb should happen at the start of the
+                # request handler, but we need to test and make sure crumbs are
+                # properly attached to *this* HTTP request and don't bleed over
+                # to others, since Sentry's special support for Tornado has
+                # been dropped.
+                headers = dict(self.request.headers)
+                if 'Authorization' in headers:
+                    headers['Authorization'] = '[removed]'
+                sentry_sdk.add_breadcrumb(category='request', data={
+                    'url': self.request.full_url(),
+                    'method': self.request.method,
+                    'headers': headers,
+                })
+                sentry_sdk.capture_message(f'{self._reason} (status: {response["code"]})')
 
         # Fill in full info if configured to do so
         if self.settings.get('serve_traceback') and 'exc_info' in kwargs:


### PR DESCRIPTION
We've had a longstanding issue where some of our Sentry errors wind up with a giant pile of accumulated breadcrumbs that seem to be from other requests:

<img width="676" alt="Screen Shot 2019-10-15 at 10 23 06 PM" src="https://user-images.githubusercontent.com/74178/66890501-3df5d080-ef9b-11e9-9f65-d1fc4080f113.png">

I think it might be because we are not creating a scope when manually adding these breadcrumbs for errors, and they aren't getting cleared when you call `capture_message` like they used to in the old SDK. So this simply wraps the breadcrumbs and the `capture_message` call in a new scope.