### PR TITLE
Unify db client get/post request creation

### DIFF
--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -168,7 +168,7 @@ variables:
 Alternatively, you can instaniate Client(user, password) directly.""")
         return cls(email=email, password=password, url=url)
 
-    def request(self, method, url, data=None, **kwargs):
+    def request(self, method, url, data=None, raw_response=False, **kwargs):
         if data is not None:
             headers = kwargs.setdefault('headers', {})
             if isinstance(data, collections.Sequence):
@@ -179,7 +179,10 @@ Alternatively, you can instaniate Client(user, password) directly.""")
                 kwargs['data'] = json.dumps(data)
         response = self._session.request(method=method, url=url, **kwargs)
         _process_errors(response)
-        return response.json()
+        if raw_response:
+            return response
+        else:
+            return response.json()
 
     ### PAGES ###
 
@@ -715,7 +718,14 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         """
         db_result = self.get_version(version_id)
         content_uri = db_result['data']['uri']
-        return self.request(GET, content_uri)
+        raw_response = self.request(GET,
+                                    content_uri,
+                                    raw_response=True,
+                                    headers={'accept': None})
+        if raw_response.headers.get('Content-Type', '').startswith('text/'):
+            return raw_response.text
+        else:
+            return raw_response.content
 
     def get_version_by_versionista_id(self, versionista_id):
         """

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -163,6 +163,12 @@ variables:
 Alternatively, you can instaniate Client(user, password) directly.""")
         return cls(email=email, password=password, url=url)
 
+    def get_request(self, url, params=None):
+        return requests.get(url,
+                            params=params,
+                            auth=self._auth,
+                            headers={'accept': 'application/json'})
+
     ### PAGES ###
 
     def list_pages(self, *, chunk=None, chunk_size=None, sort=None,
@@ -222,7 +228,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
                   'active': active,
                   'include_total': include_total or None}
         url = f'{self._api_url}/pages'
-        res = requests.get(url, auth=self._auth, params=params)
+        res = self.get_request(url, params=params)
         _process_errors(res)
         result = res.json()
         data = result['data']
@@ -264,7 +270,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         response : dict
         """
         url = f'{self._api_url}/pages/{page_id}'
-        res = requests.get(url, auth=self._auth)
+        res = self.get_request(url)
         _process_errors(res)
         result = res.json()
         # In place, replace datetime strings with datetime objects.
@@ -349,7 +355,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
             url = f'{self._api_url}/versions'
         else:
             url = f'{self._api_url}/pages/{page_id}/versions'
-        res = requests.get(url, auth=self._auth, params=params)
+        res = self.get_request(url, params=params)
         _process_errors(res)
         result = res.json()
         # In place, replace datetime strings with datetime objects.
@@ -383,7 +389,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         url = f'{self._api_url}/versions/{version_id}'
         params = {'include_change_from_previous': include_change_from_previous,
                   'include_change_from_earliest': include_change_from_earliest}
-        res = requests.get(url, auth=self._auth, params=params)
+        res = self.get_request(url, params=params)
         _process_errors(res)
         result = res.json()
         data = result['data']
@@ -553,7 +559,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         response : dict
         """
         url = f'{self._api_url}/imports/{import_id}'
-        res = requests.get(url, auth=self._auth)
+        res = self.get_request(url)
         _process_errors(res)
         return res.json()
 
@@ -577,9 +583,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         response : dict
         """
         url = f'{self._api_url}/pages/{page_id}/changes/'
-        res = requests.get(url, auth=self._auth, params={
-            'include_total': include_total or None
-        })
+        res = self.get_request(url, params={'include_total': include_total or None})
         _process_errors(res)
         result = res.json()
         # In place, replace datetime strings with datetime objects.
@@ -606,7 +610,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         """
         url = (f'{self._api_url}/pages/{page_id}/changes/'
                f'{from_version_id}..{to_version_id}')
-        res = requests.get(url, auth=self._auth)
+        res = self.get_request(url)
         _process_errors(res)
         result = res.json()
         # In place, replace datetime strings with datetime objects.
@@ -642,9 +646,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         """
         url = (f'{self._api_url}/pages/{page_id}/changes/'
                f'{from_version_id}..{to_version_id}/annotations')
-        res = requests.get(url, auth=self._auth, params={
-            'include_total': include_total or None
-        })
+        res = self.get_request(url, params={'include_total': include_total or None})
         _process_errors(res)
         result = res.json()
         # In place, replace datetime strings with datetime objects.
@@ -700,7 +702,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         url = (f'{self._api_url}/pages/{page_id}/changes/'
                f'{from_version_id}..{to_version_id}/annotations/'
                f'{annotation_id}')
-        res = requests.get(url, auth=self._auth)
+        res = self.get_request(url)
         _process_errors(res)
         result = res.json()
         # In place, replace datetime strings with datetime objects.
@@ -725,7 +727,7 @@ Alternatively, you can instaniate Client(user, password) directly.""")
         """
         db_result = self.get_version(version_id)
         content_uri = db_result['data']['uri']
-        res = requests.get(content_uri)
+        res = self.get_request(content_uri)
         _process_errors(res)
         if res.headers.get('Content-Type', '').startswith('text/'):
             return res.text


### PR DESCRIPTION
In preparation for tasks such as adding timeouts or accept headers to all requests, centralize API request creation