### PR TITLE
Use dateutil for date parsing, drop pandas

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ dependencies:
 - python-dateutil
 - docopt
 - lxml
-- pandas
 - requests
 - toolz
 - tornado

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ git+https://github.com/anastasia/htmldiffer@develop
 git+https://github.com/danielballan/htmltreediff@customize
 html5-parser ~=0.4.8 --no-binary lxml
 lxml ~=4.4.1
-pandas ~=0.25.1
 sentry-sdk ~=0.13.1
 requests ~=2.22.0
 toolz ~=0.10.0

--- a/web_monitoring/cli.py
+++ b/web_monitoring/cli.py
@@ -39,11 +39,11 @@ and results between them.
 
 from collections import defaultdict
 from datetime import datetime, timedelta
+import dateutil.parser
 from docopt import docopt
 import json
 import logging
 from os.path import splitext
-import pandas
 from pathlib import Path
 import re
 import requests
@@ -564,7 +564,7 @@ def save_unplaybackable_mementos(path, mementos, expiration=7 * 24 * 60 * 60):
         date = mementos[url]
         needs_format = False
         if isinstance(date, str):
-            date = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
+            date = dateutil.parser.parse(date, ignoretz=True)
         else:
             needs_format = True
 
@@ -680,9 +680,7 @@ def _parse_date_argument(date_string):
         pass
 
     try:
-        parsed = pandas.to_datetime(date_string)
-        if not pandas.isnull(parsed):
-            return parsed
+        return dateutil.parser.parse(date_string)
     except ValueError:
         pass
 

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -16,6 +16,7 @@ Other potentially useful links:
 from base64 import b32encode
 from collections import namedtuple
 from datetime import datetime
+from dateutil.tz import tzutc
 import hashlib
 import logging
 import urllib.parse
@@ -412,10 +413,12 @@ class WaybackClient(utils.DepthCountedContext):
             Whether output should be gzipped.
         from_date : datetime, optional
             Only include captures after this date. Equivalent to the
-            `from` argument in the CDX API.
+            `from` argument in the CDX API. If it does not have a time zone, it
+            is assumed to be in UTC.
         to_date : str, optional
             Only include captures before this date. Equivalent to the `to`
-            argument in the CDX API.
+            argument in the CDX API.  If it does not have a time zone, it is
+            assumed to be in UTC.
         filter_field : str, optional
             A filter for any field in the results. Equivalent to the `filter`
             argument in the CDX API. (format: `[!]field:regex`)
@@ -486,6 +489,11 @@ class WaybackClient(utils.DepthCountedContext):
                 if isinstance(value, str):
                     final_query[key] = value
                 elif isinstance(value, datetime):
+                    # Make sure we have either a naive datetime (assumed to
+                    # represent UTC) or convert the datetime to UTC.
+                    value_utc = value
+                    if value.tzinfo:
+                        value = value.astimezone(tzutc())
                     final_query[key] = value.strftime(URL_DATE_FORMAT)
                 else:
                     final_query[key] = str(value).lower()

--- a/web_monitoring/internetarchive.py
+++ b/web_monitoring/internetarchive.py
@@ -493,8 +493,8 @@ class WaybackClient(utils.DepthCountedContext):
                     # represent UTC) or convert the datetime to UTC.
                     value_utc = value
                     if value.tzinfo:
-                        value = value.astimezone(tzutc())
-                    final_query[key] = value.strftime(URL_DATE_FORMAT)
+                        value_utc = value.astimezone(tzutc())
+                    final_query[key] = value_utc.strftime(URL_DATE_FORMAT)
                 else:
                     final_query[key] = str(value).lower()
 


### PR DESCRIPTION
I felt spurred on to just do this by #507 today.

The only actual remaining use of pandas in our codebase was for parsing dates, which is a little overkill! We also already depended on dateutil, so we should actually have used it in all the places we are parsing dates. This does so, and since there are no remaining uses of pandas, drops it from the dependencies.

A fix to how we handled dates in CDX searches came along for the ride, since I realized we were kind of failing to respect time zone info if it was present on a search date. 😓

(^^^ cc @danielballan since you are splitting this code out into a separate package.)

Fixes #360.