### PR TITLE
Use fallback cache keys in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: processing-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+          keys:
+            - processing-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "dev-requirements.txt" }}
+            - processing-{{ arch }}-
 
       # Bundle install dependencies
       - run:


### PR DESCRIPTION
In CircleCI, we load cached dependencies based on a checksum of the `requirements.txt` and `dev-requirements.txt` files. That's good, but if those files have changed, we don't use any cache at all! Some of our dependencies take a while to build, so the cache is still helpful, since it's not likely *all* the dependencies are changing.

This uses a list of cache keys we can fall back to, so we are still likely to get some useful dependency caching in tests.