### PR TITLE
HOTFIX: Don't use domain prefix queries for CDX

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -112,7 +112,13 @@ NEVER_QUERY_DOMAINS = (
 )
 # Query an entire domain for snapshots if we are interested in more than this
 # many URLs in the domain (NEVER_QUERY_DOMAINS above overrides this).
-MAX_QUERY_URLS_PER_DOMAIN = 30
+# NOTE: this is intentionally set high enough that we are unlikely to ever
+# reach this threshold -- it turns out the CDX API doesn't always return all
+# pages when using domain/prefix queries (some indexes are excluded from those
+# queries, but it also looks like there are some bugs preventing other mementos
+# from being included), so until that gets resolved (maybe never?), this makes
+# sure we query for ever page individually.
+MAX_QUERY_URLS_PER_DOMAIN = 30_000
 
 
 # These functions lump together library code into monolithic operations for the


### PR DESCRIPTION
When we have lots of pages at a given domain, we used to issue a single CDX query for everything at that domain, rather than a separate query for each URL we are tracking. However, it turns out this doesn't actually work:
- Some indexes are excluded from prefix queries in CDX, so you won't get URLs included in those indexes.
- Wayback folks think there might also be a bug causing some pages to not get included in prefix queries when they should.

So in order to make sure we are actually getting data about *all* the pages we track, we can't use the old optimization of querying by domain. For now, just set `MAX_QUERY_URLS_PER_DOMAIN` to an absurdly high number that we'll never reach.