### PR TITLE
Use a shared HTTPAdapter across all threads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ toolz ~=0.10.0
 tornado ~=6.0.3
 tqdm ~=4.42.0
 tzlocal ~=2.0
-wayback ~=0.2.1
+wayback ~=0.2.2

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -214,6 +214,7 @@ class WaybackRecordsWorker(threading.Thread):
         self.maintainers = maintainers
         self.tags = tags
         self.unplaybackable = unplaybackable
+        self.adapter = adapter
         session_options = session_options or dict(retries=3, backoff=2,
                                                   timeout=(30.5, 2))
         # session = wayback.WaybackSession(user_agent=USER_AGENT, **session_options)
@@ -240,7 +241,10 @@ class WaybackRecordsWorker(threading.Thread):
 
             self.handle_record(record, retry_connection_failures=True)
 
-        # self.wayback.close()
+        # Only close the client if it's using an adapter we created, instead of
+        # one some other piece of code owns.
+        if not self.adapter:
+            self.wayback.close()
         return self.summary
 
     def handle_record(self, record, retry_connection_failures=False):

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -41,36 +41,56 @@ def hash_content(content_bytes):
     return hashlib.sha256(content_bytes).hexdigest()
 
 
-_last_call_by_group = defaultdict(int)
-_rate_limit_lock = threading.Lock()
-
-
-@contextmanager
-def rate_limited(calls_per_second=2, group='default'):
+class RateLimit:
     """
-    A context manager that restricts entries to its body to occur only N times
-    per second (N can be a float). The current thread will be put to sleep in
-    order to delay calls.
+    RateLimit is a simple locking mechanism that can be used to enforce rate
+    limits and is safe to use across multiple threads. It can also be used as
+    a context manager.
+
+    Calling `rate_limit_instance.wait()` blocks until a minimum time has passed
+    since the last call. Using `with rate_limit_instance:` blocks entries to
+    the context until a minimum time since the last context entry.
 
     Parameters
     ----------
-    calls_per_second : float or int, optional
-        Maximum number of calls into this context allowed per second
-    group : string, optional
-        Unique name to scope rate limiting. If two contexts have different
-        `group` values, their timings will be tracked separately.
+    per_second : int or float
+        The maximum number of calls per second that are allowed. If 0, a call
+        to `wait()` will never block.
+
+    Examples
+    --------
+    Slow down a tight loop to only occur twice per second:
+
+    >>> limit = RateLimit(per_second=2)
+    >>> for x in range(10):
+    >>>     with limit:
+    >>>         print(x)
     """
-    if calls_per_second <= 0:
-        yield
-    else:
-        with _rate_limit_lock:
-            last_call = _last_call_by_group[group]
-            minimum_wait = 1.0 / calls_per_second
+    def __init__(self, per_second=10):
+        self._lock = threading.RLock()
+        self._last_call_time = 0
+        if per_second <= 0:
+            self._minimum_wait = 0
+        else:
+            self._minimum_wait = 1.0 / per_second
+
+    def wait(self):
+        if self._minimum_wait == 0:
+            return
+
+        with self._lock:
             current_time = time.time()
-            if current_time - last_call < minimum_wait:
-                time.sleep(minimum_wait - (current_time - last_call))
-            _last_call_by_group[group] = time.time()
-        yield
+            idle_time = current_time - self._last_call_time
+            if idle_time < self._minimum_wait:
+                time.sleep(self._minimum_wait - idle_time)
+
+            self._last_call_time = time.time()
+
+    def __enter__(self):
+        self.wait()
+
+    def __exit__(self, type, value, traceback):
+        pass
 
 
 def get_color_palette():

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-from contextlib import contextmanager
 import hashlib
 import io
 import logging
@@ -162,12 +160,19 @@ class FiniteQueue(queue.SimpleQueue):
     def __iter__(self):
         return self
 
-    def __next__(self):
+    def __next__(self, timeout=None):
         item = self.get()
         if item is self.QUEUE_END:
             raise StopIteration
 
         return item
+
+    def iterate_with_timeout(self, timeout):
+        while True:
+            try:
+                yield self.__next__(timeout)
+            except StopIteration:
+                return
 
 
 class DepthCountedContext:


### PR DESCRIPTION
I spent an absurd amount of time over the last few days trying different approaches to better managing connections and errors with Wayback. Part of that was prompted by #525 and #507 

This basically rigs up a situation where we create a single `HTTPAdapter` for use across all our sessions (one session per thread). We then set the maximum number of connections in the adapter to the number of threads we are using, and tell it to block (if you don’t tell it to block, it’ll just go ahead and make more connections than the max anyway, which, ??? is kinda weird but hey). This has a huge impact on error rate and performance:

**Before:**
- Takes roughly 13-16 minutes to download 500 mementos from Wayback.
- Has an error rate of 20-30% (we see lower error rates at the end of the day because we go back and retry everything several times).

**After:**
- Takes roughly 8-9 minutes to download 500 mementos from Wayback
- Has an error rate of 0.0-1.2%

(Tested on my local machine at the office with a pretty speedy connection, alternating between different approaches to hopefully ensure they all got tested under similar load conditions at the Internet Archive.)

Why not just share a single Session or Client? Requests is apparently not thread-safe, and it seems like its authors have been struggling with small, niggling issues around thread-safety for a while. It’s not great to be sharing an [`HTTPAdapter`](https://github.com/psf/requests/blob/master/requests/adapters.py) across threads, but it’s a small interface and doesn’t interact much with the rest of requests. This *seems* OK, and I haven’t run into any issues yet. Going any lower means wrapping parts of urllib3, which makes me feel like “why are we even using requests?” So I figured this is the sweet spot for now.

Along the way, I also implemented an AIMD (Additive Increase/Multiplicative Decrease) sizing algorithm for pools (this is the algorithm typically used for [managing TCP window sizes](https://en.wikipedia.org/wiki/TCP_congestion_control) to optimize network congestion). It turns out that it didn’t seem to perform a whole lot better than what I ultimately did here, and it’s much more complicated to implement, so I left it out for now. Maybe it’ll come back someday! ¯\\\_(ツ)\_/¯


**There’s still a little cleanup to do to make this final, so this is not yet ready to merge.** (See all the commented out bits.)