### PR TITLE
Limit the size of HTTP responses that can be diffed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ export DIFFING_SERVER_DEBUG="False"
 # `ACCESS_CONTROL_ALLOW_ORIGIN` header in HTTP responses.
 export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
 
+# Maximum diffable body size, in bytes.
+export DIFFER_MAX_BODY_SIZE='10485760' # 10 MB
+
 # The diff server does not normally validate SSL certificates when requesting
 # pages to diff. If this is set to "true", diff requests will fail if upstream
 # https:// requests have invalid certificates.


### PR DESCRIPTION
You can now set the `DIFFER_MAX_BODY_SIZE` environment variable to a number of bytes in order to limit the size of responses to be diffed by the diffing server. If more bytes are received, the HTTP client in the diffing server will stop immediately. This should help ensure we can’t accidentally slam the diffing server with something too big to handle.

Fixes #154.

NOTE: This leverages a built-in feature of Tornado’s *Simple* HTTP client, even though it’s much slower and less reliable than the cURL-based client. We’d eventually like to switch to the cURL one, but haven’t because we wanted to be able to implement this. It would still be *great* to figure out how to implement this with the cURL client in the future.