### PR TITLE
Validate URLs in CLI importer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": "/Users/julianmclain/miniconda3/envs/web-monitoring-processing/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "python.pythonPath": "/Users/julianmclain/miniconda3/envs/web-monitoring-processing/bin/python"
-}

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -493,6 +493,9 @@ def import_ia_urls(urls, *, from_date=None, to_date=None,
                    version_filter=None, worker_count=0,
                    create_pages=True, unplaybackable_path=None,
                    dry_run=False):
+    if not _all_urls_valid(urls):
+        raise ValueError("Invalid URL Provided")
+
     worker_count = worker_count if worker_count > 0 else PARALLEL_REQUESTS
     unplaybackable = load_unplaybackable_mementos(unplaybackable_path)
 
@@ -758,6 +761,20 @@ def _parse_date_argument(date_string):
         pass
 
     return None
+
+def _all_urls_valid(urls):
+    """
+    Validate that all URLs are formatted correctly. This function assumes that
+    a URL is valid if it has a valid addressing scheme and network location.
+    """
+    def _is_valid(url):
+        try:
+            result = urlparse(url)
+            return all([result.scheme, result.netloc])
+        except:
+            return False
+    
+    return False not in [_is_valid(url) for url in urls]
 
 
 def main():

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -493,8 +493,8 @@ def import_ia_urls(urls, *, from_date=None, to_date=None,
                    version_filter=None, worker_count=0,
                    create_pages=True, unplaybackable_path=None,
                    dry_run=False):
-    if not _all_urls_valid(urls):
-        raise ValueError("Invalid URL Provided")
+    if not all(_is_valid(url) for url in urls):
+        raise ValueError("Invalid URL provided")
 
     worker_count = worker_count if worker_count > 0 else PARALLEL_REQUESTS
     unplaybackable = load_unplaybackable_mementos(unplaybackable_path)
@@ -762,19 +762,17 @@ def _parse_date_argument(date_string):
 
     return None
 
-def _all_urls_valid(urls):
+
+def _is_valid(url):
     """
     Validate that all URLs are formatted correctly. This function assumes that
     a URL is valid if it has a valid addressing scheme and network location.
     """
-    def _is_valid(url):
-        try:
-            result = urlparse(url)
-            return all([result.scheme, result.netloc])
-        except:
-            return False
-    
-    return False not in [_is_valid(url) for url in urls]
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except:
+        return False
 
 
 def main():

--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -6,7 +6,7 @@ import vcr
 from wayback import WaybackClient
 from web_monitoring.cli.cli import (_filter_unchanged_versions,
                                     WaybackRecordsWorker, import_ia_db_urls,
-                                    _all_urls_valid)
+                                    _is_valid)
 
 
 # The only matters when re-recording the tests for vcr.
@@ -48,18 +48,20 @@ def test_filter_unchanged_versions():
         {'page_url': 'http://other.com',   'version_hash': 'b'},
     ]
 
-def test_all_valid_urls():
+
+def test_is_valid():
     valid_single_url = ['https://example.com']
     valid_urls = ['https://example.com', 'http://example.com/interesting/path', 'https://subdomain.example.com']
     valid_url_missing_domain = ['https://google']
     invalid_single_url = ['asldkfje']
     invalid_and_valid_urls = ['https://exmaple.com', 'http:badprotocol.com']
 
-    assert _all_urls_valid(valid_urls)
-    assert _all_urls_valid(valid_single_url)
-    assert _all_urls_valid(valid_url_missing_domain)
-    assert not _all_urls_valid(invalid_single_url)
-    assert not _all_urls_valid(invalid_and_valid_urls)
+    assert all(_is_valid(url) for url in valid_single_url)
+    assert all(_is_valid(url) for url in valid_urls)
+    assert all(_is_valid(url) for url in valid_url_missing_domain)
+    assert not all(_is_valid(url) for url in invalid_single_url)
+    assert not all(_is_valid(url) for url in invalid_and_valid_urls)
+
 
 @ia_vcr.use_cassette()
 def test_format_memento():

--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 import vcr
 from wayback import WaybackClient
 from web_monitoring.cli.cli import (_filter_unchanged_versions,
-                                    WaybackRecordsWorker, import_ia_db_urls)
+                                    WaybackRecordsWorker, import_ia_db_urls,
+                                    _all_urls_valid)
 
 
 # The only matters when re-recording the tests for vcr.
@@ -47,6 +48,18 @@ def test_filter_unchanged_versions():
         {'page_url': 'http://other.com',   'version_hash': 'b'},
     ]
 
+def test_all_valid_urls():
+    valid_single_url = ['https://example.com']
+    valid_urls = ['https://example.com', 'http://example.com/interesting/path', 'https://subdomain.example.com']
+    valid_url_missing_domain = ['https://google']
+    invalid_single_url = ['asldkfje']
+    invalid_and_valid_urls = ['https://exmaple.com', 'http:badprotocol.com']
+
+    assert _all_urls_valid(valid_urls)
+    assert _all_urls_valid(valid_single_url)
+    assert _all_urls_valid(valid_url_missing_domain)
+    assert not _all_urls_valid(invalid_single_url)
+    assert not _all_urls_valid(invalid_and_valid_urls)
 
 @ia_vcr.use_cassette()
 def test_format_memento():

--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -50,17 +50,13 @@ def test_filter_unchanged_versions():
 
 
 def test_is_valid():
-    valid_single_url = ['https://example.com']
-    valid_urls = ['https://example.com', 'http://example.com/interesting/path', 'https://subdomain.example.com']
-    valid_url_missing_domain = ['https://google']
-    invalid_single_url = ['asldkfje']
-    invalid_and_valid_urls = ['https://exmaple.com', 'http:badprotocol.com']
+    valid_url = 'https://example.com'
+    valid_url_without_tld = 'https://google'
+    invalid_url = 'asldkfje'
 
-    assert all(_is_valid(url) for url in valid_single_url)
-    assert all(_is_valid(url) for url in valid_urls)
-    assert all(_is_valid(url) for url in valid_url_missing_domain)
-    assert not all(_is_valid(url) for url in invalid_single_url)
-    assert not all(_is_valid(url) for url in invalid_and_valid_urls)
+    assert _is_valid(valid_url)
+    assert _is_valid(valid_url_without_tld)
+    assert not _is_valid(invalid_url)
 
 
 @ia_vcr.use_cassette()


### PR DESCRIPTION
This looked like a good first issue, so I took a shot at it. Let me know what you think.

In terms of validation, I wasn't sure exactly what you need. For example, are you only looking at specific TLDs? Is protocol required? etc... 

I decided to use `urlparse` and just confirm that the url has a valid protocol and network location (which apparently doesn't require a TLD being present as I learned). 