### PR TITLE
Remove duplicate final redirect url from redirects

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -354,7 +354,6 @@ class WaybackRecordsWorker(threading.Thread):
                 lambda response: wayback.memento_url_data(response.url)[0],
                 memento.history))
             redirected_url = wayback.memento_url_data(memento.url)[0]
-            redirects.append(redirected_url)
             metadata['redirected_url'] = redirected_url
             metadata['redirects'] = redirects
 

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -354,8 +354,10 @@ class WaybackRecordsWorker(threading.Thread):
                 lambda response: wayback.memento_url_data(response.url)[0],
                 memento.history))
             redirected_url = wayback.memento_url_data(memento.url)[0]
+            redirects.append(redirected_url)
             metadata['redirected_url'] = redirected_url
-            metadata['redirects'] = redirects
+            metadata['redirects'] = [url for i, url in enumerate(redirects)
+                                     if url not in redirects[:i]]
 
         return dict(
             # Page-level info

--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -109,9 +109,9 @@ def test_format_memento_handles_redirects():
 
         assert isinstance(version, dict)
         assert version['source_metadata']['redirected_url'] == final_url
-        assert len(version['source_metadata']['redirects']) == 3
+        assert len(version['source_metadata']['redirects']) == 2
         assert version['source_metadata']['redirects'][0] == url
-        assert version['source_metadata']['redirects'][2] == final_url
+        assert version['source_metadata']['redirects'][1] == final_url
 
 
 # TODO: this test covers some of the various error cases, but probably not all


### PR DESCRIPTION
Your intuition was right - in `format_memento()` the final url was being added to the list of redirects even though it's already included as the last entry in memento's `history`.