### PR TITLE
Fix test for Content-Length header vs. actual body size mismatch

### DIFF
--- a/web_monitoring/diff_server/server.py
+++ b/web_monitoring/diff_server/server.py
@@ -365,15 +365,15 @@ class DiffHandler(BaseHandler):
                 # Unfortunately we get pretty ambiguous info if the connection
                 # was closed because we exceeded the max size. :(
                 message = f'The connection was closed while fetching "{url}"'
-                if MAX_BODY_SIZE:
+                if client.max_body_size:
                     message += (f' -- this may have been caused by a large '
                                 f'response (the maximum diffable response is '
-                                f'{MAX_BODY_SIZE} bytes)')
+                                f'{client.max_body_size} bytes)')
                 raise PublicError(502,
                                   message,
                                   'Connection closed while fetching upstream',
                                   extra={'url': url,
-                                         'max_size': MAX_BODY_SIZE})
+                                         'max_size': client.max_body_size})
             except tornado.httpclient.HTTPError as error:
                 # If the response is actually coming from a web archive,
                 # allow error codes. The Memento-Datetime header indicates


### PR DESCRIPTION
We had a test for the situation where a server responds with more bytes than it said it would with the `Content-Length` header, but it was implemented incorrectly! It turns out Tornado has a helpful feature that stops you if you try to send more bytes than you said you would in the `Content-Length` header, and we were running afoul of that. The only reason we saw an error in this case was because we hit this situation before flushing the headers, which means Tornado caught us and stopped the response before sending anything -- so from the client end, it looked like our test server was hanging up early rather than sending too much.

Note the test now expects the diff to *succeed* in this case instead of fail. That's not a change in behavior; instead, the test is now reflecting the server's actual existing behavior. It turns out `SimpleAsyncHTTPClient` (and pretty much all major HTTP clients I tested, from cURL to requests, to several web browsers) just stop reading the response data after hitting `Content-Length` (I didn't realize that at all!) even if there's more being sent. So in practice, we actually succeed in diffing here -- it's just that we only diff the first `<Content-Length>` bytes the server sent.

This also fixes how we messaged the error about maximum content length in cases where an environment variable wasn't used for configuration (e.g. our tests).

Found while attempting to bring #293 back from the dead.