### PR TITLE
Use cURL-based HTTP client in diff server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ export ACCESS_CONTROL_ALLOW_ORIGIN_HEADER="*"
 # Maximum diffable body size, in bytes.
 export DIFFER_MAX_BODY_SIZE='10485760' # 10 MB
 
+# Use Tornado's "simple" HTTP client to get diffable content. By default, the
+# diff server uses a cURL-based client, which is faster and more robust.
+# export USE_SIMPLE_HTTP_CLIENT='true'
+
 # The diff server does not normally validate SSL certificates when requesting
 # pages to diff. If this is set to "true", diff requests will fail if upstream
 # https:// requests have invalid certificates.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
   include:
     - python: 3.7
 
+addons:
+  apt:
+    # Required for pycurl and shamelessly stolen from their Travis config.
+    packages: [libssh2-1, libgnutls28-dev]
+
 install:
     - pip install -r requirements.txt
     - pip install -r dev-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.7-slim
 LABEL maintainer="enviroDGI@gmail.com"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git gcc g++ pkg-config libxml2-dev libxslt-dev libz-dev
+    git gcc g++ pkg-config libxml2-dev libxslt-dev libz-dev \
+    libssl-dev openssl libcurl4-openssl-dev
 
 # Set the working directory to /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -41,19 +41,20 @@ Legacy projects that may be revisited:
    privileges to install or use it, and it won't interfere with any other
    installations of Python already on your system.)
 
-2. Install libxml2 and libxslt. (This package uses lxml, which requires your system to have the libxml2 and libxslt libraries.)
+2. Install libxml2, libxslt, and openssl. (This package uses lxml, which requires your system to have the libxml2 and libxslt libraries, and pycurl, which requires libcurl [built-in on MacOS] and openssl.)
 
     On MacOS, use Homebrew:
 
     ```sh
     brew install libxml2
     brew install libxslt
+    brew install openssl
     ```
 
     On Debian Linux:
 
     ```sh
-    apt-get install libxml2-dev libxslt-dev
+    apt-get install libxml2-dev libxslt-dev libssl-dev openssl libcurl4-openssl-dev
     ```
 
     On other systems, the packages might have slightly different names.
@@ -62,6 +63,14 @@ Legacy projects that may be revisited:
 
     ```sh
     pip install -r requirements.txt
+    python setup.py develop
+    ```
+
+    **On MacOS,** you may need additional configuration to use the Homebrew
+    openssl. Try the following:
+
+    ```sh
+    PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L/usr/local/opt/openssl/lib" CPPFLAGS="-I/usr/local/opt/openssl/include" pip install -r requirements.txt
     python setup.py develop
     ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ git+https://github.com/anastasia/htmldiffer@develop
 git+https://github.com/danielballan/htmltreediff@customize
 html5-parser ~=0.4.9 --no-binary lxml
 lxml ~=4.5.2
+pycurl ~=7.43
 PyPDF2 ~=1.26.0
 sentry-sdk ~=0.17.2
 requests ~=2.24.0

--- a/web_monitoring/diff_server/server.py
+++ b/web_monitoring/diff_server/server.py
@@ -107,9 +107,9 @@ class LimitedCurlAsyncHTTPClient(CurlAsyncHTTPClient):
             curl.setopt(pycurl.MAXFILESIZE, self.max_body_size)
 
 
-# XXX: DO NOT MERGE WITH THIS
 HTTP_CLIENT = LimitedCurlAsyncHTTPClient
-if os.getenv('USE_SIMPLE_HTTP_CLIENT'): HTTP_CLIENT = None
+if os.getenv('USE_SIMPLE_HTTP_CLIENT'):
+    HTTP_CLIENT = None
 tornado.httpclient.AsyncHTTPClient.configure(HTTP_CLIENT,
                                              max_body_size=MAX_BODY_SIZE)
 
@@ -390,6 +390,8 @@ class DiffHandler(BaseHandler):
                                   f'Could not fetch "{url}": {error}',
                                   'Could not fetch upstream content',
                                   extra={'url': url, 'cause': str(error)})
+
+            # --- SIMPLE CLIENT ERRORS ----------------------------------------
             except tornado.simple_httpclient.HTTPTimeoutError:
                 raise PublicError(504,
                                   f'Timed out while fetching "{url}"',
@@ -408,6 +410,8 @@ class DiffHandler(BaseHandler):
                                   'Connection closed while fetching upstream',
                                   extra={'url': url,
                                          'max_size': client.max_body_size})
+
+            # --- CURL CLIENT ERRORS ------------------------------------------
             except CurlError as error:
                 # Documentation for cURL error codes:
                 #   https://curl.haxx.se/libcurl/c/libcurl-errors.html
@@ -444,6 +448,8 @@ class DiffHandler(BaseHandler):
                                       f'Unknown error fetching "{url}"',
                                       f'Unknown error fetching upstream content: {error}',
                                       extra={'url': url})
+
+            # --- COMMON ERRORS SUPPORTED BY ALL CLIENTS ----------------------
             except tornado.httpclient.HTTPError as error:
                 # If the response is actually coming from a web archive,
                 # allow error codes. The Memento-Datetime header indicates

--- a/web_monitoring/diff_server/server.py
+++ b/web_monitoring/diff_server/server.py
@@ -86,7 +86,10 @@ except ValueError:
 # to enforce something like max_body_size with it.
 tornado.httpclient.AsyncHTTPClient.configure(None,
                                              max_body_size=MAX_BODY_SIZE)
-client = tornado.httpclient.AsyncHTTPClient()
+
+
+def get_http_client():
+    return tornado.httpclient.AsyncHTTPClient()
 
 
 class PublicError(tornado.web.HTTPError):
@@ -344,6 +347,7 @@ class DiffHandler(BaseHandler):
                         headers[header_key] = header_value
 
             try:
+                client = get_http_client()
                 response = await client.fetch(url, headers=headers,
                                               validate_cert=VALIDATE_TARGET_CERTIFICATES)
             except ValueError as error:

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 from pathlib import Path
+import pytest
 import re
 import tempfile
 from tornado.testing import AsyncHTTPTestCase, bind_unused_port
@@ -126,6 +127,9 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
             else:
                 os.environ['WEB_MONITORING_APP_ENV'] = original
 
+    # XXX: Need to fix this test (or add tighter URL validation to server)
+    # before merging.
+    @pytest.mark.skip(reason='cURL client supports no protocol on URLs')
     def test_invalid_url_a_format(self):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=example.org&b=https://example.org')
@@ -133,6 +137,9 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         self.assertEqual(response.code, 400)
         self.assertFalse(response.headers.get('Etag'))
 
+    # XXX: Need to fix this test (or add tighter URL validation to server)
+    # before merging.
+    @pytest.mark.skip(reason='cURL client supports no protocol on URLs')
     def test_invalid_url_b_format(self):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=https://example.org&b=example.org')

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -127,9 +127,6 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
             else:
                 os.environ['WEB_MONITORING_APP_ENV'] = original
 
-    # XXX: Need to fix this test (or add tighter URL validation to server)
-    # before merging.
-    @pytest.mark.skip(reason='cURL client supports no protocol on URLs')
     def test_invalid_url_a_format(self):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=example.org&b=https://example.org')
@@ -137,9 +134,6 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         self.assertEqual(response.code, 400)
         self.assertFalse(response.headers.get('Etag'))
 
-    # XXX: Need to fix this test (or add tighter URL validation to server)
-    # before merging.
-    @pytest.mark.skip(reason='cURL client supports no protocol on URLs')
     def test_invalid_url_b_format(self):
         response = self.fetch('/html_token?format=json&include=all&'
                               'a=https://example.org&b=example.org')

--- a/web_monitoring/tests/test_diffing_server_exc_handling.py
+++ b/web_monitoring/tests/test_diffing_server_exc_handling.py
@@ -88,7 +88,7 @@ class DiffingServerFetchTest(DiffingServerTestCase):
 
     def test_pass_headers(self):
         mock = MockAsyncHttpClient()
-        with patch.object(df, 'client', wraps=mock):
+        with patch.object(df, 'get_http_client', return_value=mock):
             mock.respond_to(r'/a$')
             mock.respond_to(r'/b$')
 
@@ -196,7 +196,7 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         we proceed with diffing.
         """
         mock = MockAsyncHttpClient()
-        with patch.object(df, 'client', wraps=mock):
+        with patch.object(df, 'get_http_client', return_value=mock):
             mock.respond_to(r'/error$', code=404, headers={'Memento-Datetime': 'Tue Sep 25 2018 03:38:50'})
             mock.respond_to(r'/success$')
 
@@ -306,35 +306,43 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         assert 'hash' in json.loads(response.body)['error']
 
 
+def patch_http_client(**kwargs):
+    """
+    Create HTTP clients in the diffing server with the specified parameters
+    during this patch. Can be a function decorator or context manager.
+    """
+    def get_client():
+        return tornado.httpclient.AsyncHTTPClient(force_instance=True,
+                                                  **kwargs)
+    return patch.object(df, 'get_http_client', get_client)
+
+
 class DiffingServerResponseSizeTest(DiffingServerTestCase):
+    @patch_http_client(max_body_size=100 * 1024)
     def test_succeeds_if_response_is_small_enough(self):
         async def responder(handler):
             text = (80 * 1024) * 'x'
             handler.write(text.encode('utf-8'))
 
-        client = tornado.httpclient.AsyncHTTPClient(force_instance=True,
-                                                    max_body_size=100 * 1024)
-        with patch.object(df, 'client', client):
-            with SimpleHttpServer(responder) as server:
-                response = self.fetch('/html_source_dmp?'
-                                      f'a={server.url("/whatever1")}&'
-                                      f'b={server.url("/whatever2")}')
-                assert response.code == 200
+        with SimpleHttpServer(responder) as server:
+            response = self.fetch('/html_source_dmp?'
+                                  f'a={server.url("/whatever1")}&'
+                                  f'b={server.url("/whatever2")}')
+            assert response.code == 200
 
+    @patch_http_client(max_body_size=100 * 1024)
     def test_stops_if_response_is_too_big(self):
         async def responder(handler):
             text = (110 * 1024) * 'x'
             handler.write(text.encode('utf-8'))
 
-        client = tornado.httpclient.AsyncHTTPClient(force_instance=True,
-                                                    max_body_size=100 * 1024)
-        with patch.object(df, 'client', client):
-            with SimpleHttpServer(responder) as server:
-                response = self.fetch('/html_source_dmp?'
-                                      f'a={server.url("/whatever1")}&'
-                                      f'b={server.url("/whatever2")}')
-                assert response.code == 502
+        with SimpleHttpServer(responder) as server:
+            response = self.fetch('/html_source_dmp?'
+                                  f'a={server.url("/whatever1")}&'
+                                  f'b={server.url("/whatever2")}')
+            assert response.code == 502
 
+    @patch_http_client(max_body_size=100 * 1024)
     def test_stops_reading_early_when_content_length_is_a_lie(self):
         async def responder(handler):
             # Tornado tries to be careful and prevent us from sending more
@@ -347,26 +355,23 @@ class DiffingServerResponseSizeTest(DiffingServerTestCase):
             text = (110 * 1024) * 'x'
             handler.write(text.encode('utf-8'))
 
-        client = tornado.httpclient.AsyncHTTPClient(force_instance=True,
-                                                    max_body_size=100 * 1024)
-        with patch.object(df, 'client', client):
-            with SimpleHttpServer(responder) as server:
-                response = self.fetch('/html_source_dmp?'
-                                      f'a={server.url("/whatever1")}&'
-                                      f'b={server.url("/whatever2")}')
-                # Even though the response was longer than the max_body_size,
-                # the client should have stopped reading when it hit the number
-                # of bytes set in the Content-Length, header, which is less
-                # than the client's limit. So what should actually happen is a
-                # successful diff of the first <Content-Length> bytes of the
-                # responses.
-                assert response.code == 200
-                # The responses should be the same, and should only be
-                # <Content-Length> bytes long (all our chars are basic ASCII
-                # in this case, so len(bytes) == len(characters)).
-                result = json.loads(response.body)
-                assert result['change_count'] == 0
-                assert len(result['diff'][0][1]) == 1024
+        with SimpleHttpServer(responder) as server:
+            response = self.fetch('/html_source_dmp?'
+                                  f'a={server.url("/whatever1")}&'
+                                  f'b={server.url("/whatever2")}')
+            # Even though the response was longer than the max_body_size,
+            # the client should have stopped reading when it hit the number
+            # of bytes set in the Content-Length, header, which is less
+            # than the client's limit. So what should actually happen is a
+            # successful diff of the first <Content-Length> bytes of the
+            # responses.
+            assert response.code == 200
+            # The responses should be the same, and should only be
+            # <Content-Length> bytes long (all our chars are basic ASCII
+            # in this case, so len(bytes) == len(characters)).
+            result = json.loads(response.body)
+            assert result['change_count'] == 0
+            assert len(result['diff'][0][1]) == 1024
 
 
 def mock_diffing_method(c_body):


### PR DESCRIPTION
This is effectively a revival of #293 (from @vbanos). The cURL HTTP client in Tornado is both faster and supports more funny business various HTTP servers do. I'm hoping this might also improve some of the weird memory & SSL errors we run into in production every so often.

Last time around, we had some concerns about whether `CURLOPT_MAXFILESIZE` would be good enough to restrict the size of responses and mitigate memory issues: https://github.com/edgi-govdata-archiving/web-monitoring-processing/pull/293#issuecomment-431418167 Happily, we now have tests around this and it does (even though I did prototype a more invasive fix).

What still needs doing here:

- [x] Docker support
- [x] TravisCI support
- [x] Installation/setup docs (since this adds new system dependencies that can’t be installed with Pip)
- [x] Error handling (the cURL client raises different errors than the “simple” client, and all our handling is currently tailored for the “simple” client) (clearly we also need better tests around these since they should be failing!)