### PR TITLE
Add default timeout to db client

### DIFF
--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -160,7 +160,7 @@ class Client:
     url : string, optional
         Default is ``https://api.monitoring.envirodatagov.org``.
     timeout: float, optional
-        A connection timeout in seconds to be used for all requests. 0 indcates 
+        A connection timeout in seconds to be used for all requests. `0` indcates 
         no timeout. Individual method calls may override this value if `timeout`
         can be provided as an argument. The default value is 30.5 seconds.
     """

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -160,9 +160,9 @@ class Client:
     url : string, optional
         Default is ``https://api.monitoring.envirodatagov.org``.
     timeout: float, optional
-        A connection timeout in seconds to be used for all requests. `0` indcates 
-        no timeout. Individual method calls may override this value if `timeout`
-        can be provided as an argument. The default value is 30.5 seconds.
+        A connection timeout in seconds to be used for all requests. `0` indicates 
+        no timeout should be used. Individual method calls may override this value
+        if `timeout` can be provided as an argument. The default value is 30.5 seconds.
     """
     def __init__(self, email, password, url=DEFAULT_URL, timeout=DEFAULT_TIMEOUT):
         self._api_url = f'{url}/api/v0'

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -131,7 +131,7 @@ def _build_importable_version(*, page_url, uuid=None, capture_time, uri,
 def _validate_timeout(timeout, default=None):
     if timeout is None:
         return default
-    elif timeout is not None and timeout < 0:
+    elif timeout < 0:
         raise ValueError(f'Timeout must be non-negative. "{timeout}" was provided.')
     elif timeout == 0:
         return None

--- a/web_monitoring/tests/test_db.py
+++ b/web_monitoring/tests/test_db.py
@@ -295,9 +295,39 @@ def test_validate_credentials_should_raise():
         cli.validate_credentials()
 
 
+@patch.dict('os.environ', clear=True)
 @patch('web_monitoring.db.requests.Session')
-def test_default_timeout(mock_session):
-    cli = Client(**AUTH)
+def test_from_env_with_default_timeout(mock_session):
+    os.environ.update({'WEB_MONITORING_DB_URL': AUTH['url'],
+                       'WEB_MONITORING_DB_EMAIL': AUTH['email'],
+                       'WEB_MONITORING_DB_PASSWORD': AUTH['password']})
+    cli = Client.from_env()
     cli.get_user_session()
     mock_session.return_value.request.assert_called_with(
         method='GET', url=f'{AUTH["url"]}/users/session', timeout=DEFAULT_TIMEOUT)
+
+
+@patch.dict('os.environ', clear=True)
+@patch('web_monitoring.db.requests.Session')
+def test_from_env_with_custom_timeout(mock_session):
+    os.environ.update({'WEB_MONITORING_DB_URL': AUTH['url'],
+                       'WEB_MONITORING_DB_EMAIL': AUTH['email'],
+                       'WEB_MONITORING_DB_PASSWORD': AUTH['password'],
+                       'WEB_MONITORING_DB_TIMEOUT': '7.5'})
+    cli = Client.from_env()
+    cli.get_user_session()
+    mock_session.return_value.request.assert_called_with(
+        method='GET', url=f'{AUTH["url"]}/users/session', timeout=7.5)
+
+
+@patch.dict('os.environ', clear=True)
+@patch('web_monitoring.db.requests.Session')
+def test_from_env_with_no_timeout(mock_session):
+    os.environ.update({'WEB_MONITORING_DB_URL': AUTH['url'],
+                       'WEB_MONITORING_DB_EMAIL': AUTH['email'],
+                       'WEB_MONITORING_DB_PASSWORD': AUTH['password'],
+                       'WEB_MONITORING_DB_TIMEOUT': '0'})
+    cli = Client.from_env()
+    cli.get_user_session()
+    mock_session.return_value.request.assert_called_with(
+        method='GET', url=f'{AUTH["url"]}/users/session', timeout=None)

--- a/web_monitoring/tests/test_db.py
+++ b/web_monitoring/tests/test_db.py
@@ -36,7 +36,7 @@ VERSIONISTA_ID = '13708349'
 TIME = datetime(2017, 11, 15, tzinfo=timezone.utc)
 NEW_VERSION_ID = '06620776-d347-4abd-a423-a871620299a9'
 
-# The only matters when re-recording the tests for vcr.
+# This only matters when re-recording the tests for vcr.
 AUTH = {'url': "http://localhost:3000",
         'email': "seed-admin@example.com",
         'password': "PASSWORD"}
@@ -295,39 +295,25 @@ def test_validate_credentials_should_raise():
         cli.validate_credentials()
 
 
-@patch.dict('os.environ', clear=True)
 @patch('web_monitoring.db.requests.Session')
-def test_from_env_with_default_timeout(mock_session):
-    os.environ.update({'WEB_MONITORING_DB_URL': AUTH['url'],
-                       'WEB_MONITORING_DB_EMAIL': AUTH['email'],
-                       'WEB_MONITORING_DB_PASSWORD': AUTH['password']})
-    cli = Client.from_env()
+def test_client_with_default_timeout(mock_session):
+    cli = Client(**AUTH)
     cli.get_user_session()
     mock_session.return_value.request.assert_called_with(
         method='GET', url=f'{AUTH["url"]}/users/session', timeout=DEFAULT_TIMEOUT)
 
 
-@patch.dict('os.environ', clear=True)
 @patch('web_monitoring.db.requests.Session')
-def test_from_env_with_custom_timeout(mock_session):
-    os.environ.update({'WEB_MONITORING_DB_URL': AUTH['url'],
-                       'WEB_MONITORING_DB_EMAIL': AUTH['email'],
-                       'WEB_MONITORING_DB_PASSWORD': AUTH['password'],
-                       'WEB_MONITORING_DB_TIMEOUT': '7.5'})
-    cli = Client.from_env()
+def test_client_with_custom_timeout(mock_session):
+    cli = Client(**AUTH, timeout=7.5)
     cli.get_user_session()
     mock_session.return_value.request.assert_called_with(
         method='GET', url=f'{AUTH["url"]}/users/session', timeout=7.5)
 
 
-@patch.dict('os.environ', clear=True)
 @patch('web_monitoring.db.requests.Session')
-def test_from_env_with_no_timeout(mock_session):
-    os.environ.update({'WEB_MONITORING_DB_URL': AUTH['url'],
-                       'WEB_MONITORING_DB_EMAIL': AUTH['email'],
-                       'WEB_MONITORING_DB_PASSWORD': AUTH['password'],
-                       'WEB_MONITORING_DB_TIMEOUT': '0'})
-    cli = Client.from_env()
+def test_client_with_no_timeout(mock_session):
+    cli = Client(**AUTH, timeout=0)
     cli.get_user_session()
     mock_session.return_value.request.assert_called_with(
         method='GET', url=f'{AUTH["url"]}/users/session', timeout=None)

--- a/web_monitoring/tests/test_db.py
+++ b/web_monitoring/tests/test_db.py
@@ -7,7 +7,8 @@ from datetime import datetime, timedelta, timezone
 import os
 from pathlib import Path
 import pytest
-from web_monitoring.db import Client, MissingCredentials, UnauthorizedCredentials
+from unittest.mock import patch
+from web_monitoring.db import Client, MissingCredentials, UnauthorizedCredentials, DEFAULT_TIMEOUT
 import vcr
 
 
@@ -292,3 +293,11 @@ def test_validate_credentials_should_raise():
     cli = Client(**bad_auth)
     with pytest.raises(UnauthorizedCredentials):
         cli.validate_credentials()
+
+
+@patch('web_monitoring.db.requests.Session')
+def test_default_timeout(mock_session):
+    cli = Client(**AUTH)
+    cli.get_user_session()
+    mock_session.return_value.request.assert_called_with(
+        method='GET', url=f'{AUTH["url"]}/users/session', timeout=DEFAULT_TIMEOUT)


### PR DESCRIPTION
I didn't add `timeout` as an optional parameter to any of the client methods because I wasn't sure if it's needed anywhere yet. Let me know if it is, and I can add it wherever. This one looked like it could be a candidate: [monitor_import_statuses](https://github.com/edgi-govdata-archiving/web-monitoring-processing/blob/a05fd623f5b983db84d4f2370197a61bd4276153/web_monitoring/db.py#L522)