### PR TITLE
Remove tzlocal dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,5 @@ dependencies:
 - tqdm
 - pip:
   - diff_match_patch_python
-  - tzlocal
   - git+https://github.com/anastasia/htmldiffer@develop
   - git+https://github.com/danielballan/htmltreediff@customize

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ requests ~=2.23.0
 toolz ~=0.10.0
 tornado ~=6.0.4
 tqdm ~=4.46.0
-tzlocal ~=2.1
 wayback ~=0.2.3

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -1,13 +1,13 @@
 # Functions for interacting with web-monitoring-db
-from dateutil.parser import parse as parse_timestamp
 from collections.abc import Sequence
+import dateutil.tz
+from dateutil.parser import parse as parse_timestamp
 import json
 import os
 import requests
 import requests.exceptions
 import time
 import toolz
-import tzlocal
 import warnings
 
 
@@ -20,7 +20,7 @@ def _tzaware_isoformat(dt):
     """Express a datetime object in timezone-aware ISO format."""
     if dt.tzinfo is None:
         # This is naive. Assume they mean this time in the local timezone.
-        dt = dt.replace(tzinfo=tzlocal.get_localzone())
+        dt = dt.replace(tzinfo=dateutil.tz.gettz())
     return dt.isoformat()
 
 


### PR DESCRIPTION
When updating tzlocal a couple weeks ago, I noticed we only use it in one place, and we are using it for a feature already supported by another dependency, python-dateutil. In addition, it turns out some authoritative voices recommend moving away from pytz, which tzlocal is designed to work on top of (https://github.com/pganssle/pytz-deprecation-shim).