### PR TITLE
Set an import's media_type instead of metadata

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -338,9 +338,14 @@ class WaybackRecordsWorker(threading.Thread):
             if k.startswith(prefix)
         }
 
+        # Parse media type information.
+        media_type, *media_params = memento.headers.get('content-type', '').split(';')
+        # Clean up whitespace, remove empty parameters, etc.
+        stripped_params = (param.strip() for param in media_params)
+        media_params = [param for param in stripped_params if param]
+        media_type_parameters = '; '.join(media_params)
+
         metadata = {
-            'mime_type': memento.headers.get('content-type', '').split(';', 1)[0],
-            'encoding': memento.encoding,
             'headers': original_headers,
             'view_url': cdx_record.view_url
         }
@@ -369,6 +374,8 @@ class WaybackRecordsWorker(threading.Thread):
             # Version/memento-level info
             capture_time=iso_date,
             uri=cdx_record.raw_url,
+            media_type=media_type or None,
+            media_type_parameters=media_type_parameters or None,
             version_hash=utils.hash_content(memento.content),
             source_type='internet_archive',
             source_metadata=metadata,

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -74,7 +74,8 @@ def _time_range_string(start_date, end_date):
 
 
 def _build_version(*, page_id, uuid, capture_time, uri, hash, source_type,
-                   title, source_metadata=None):
+                   title, source_metadata=None, media_type=None,
+                   media_type_parameters=None):
     """
     Build a Version dict from parameters, performing some validation.
     """
@@ -89,14 +90,17 @@ def _build_version(*, page_id, uuid, capture_time, uri, hash, source_type,
                'hash': str(hash),
                'source_type': str(source_type),
                'title': str(title),
-               'source_metadata': source_metadata}
+               'source_metadata': source_metadata,
+               'media_type': media_type,
+               'media_type_parameters': media_type_parameters}
     return version
 
 
 def _build_importable_version(*, page_url, uuid=None, capture_time, uri,
                               version_hash, source_type, title,
                               page_maintainers=None, page_tags=None,
-                              source_metadata=None, status=None):
+                              source_metadata=None, status=None,
+                              media_type=None, media_type_parameters=None):
     """
     Build a Version dict from parameters, performing some validation.
 
@@ -117,7 +121,9 @@ def _build_importable_version(*, page_url, uuid=None, capture_time, uri,
                'source_metadata': source_metadata,
                'status': str(status),
                'page_maintainers': page_maintainers,
-               'page_tags': page_tags}
+               'page_tags': page_tags,
+               'media_type': media_type,
+               'media_type_parameters': media_type_parameters}
     return version
 
 

--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -82,14 +82,13 @@ def test_format_memento():
         assert version['version_hash'] == 'ae433414499f91630983fc379d9bafae67250061178930b8779ee76c82485491'
         assert version['source_type'] == 'internet_archive'
         assert version['status'] == 200
+        assert version['media_type'] == 'text/html'
         assert version['source_metadata'] == {
-            'encoding': 'ISO-8859-1',
             'headers': {
                 'Date': 'Fri, 24 Nov 2017 15:13:14 GMT',
                 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
                 'Transfer-Encoding': 'chunked'
             },
-            'mime_type': 'text/html',
             'view_url': 'http://web.archive.org/web/20171124151315/https://www.fws.gov/birds/'
         }
 

--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -67,8 +67,9 @@ def test_format_memento():
                                     to_date='20171124151316')
         record = next(cdx_records)
         memento = client.get_memento(record.raw_url, exact_redirects=False)
-        version = WaybackRecordsWorker.format_memento(None, memento, record,
-                                                      ['maintainer'], ['tag'])
+        worker = WaybackRecordsWorker(None, None, None, None, None)
+        version = worker.format_memento(memento, record, ['maintainer'],
+                                        ['tag'])
 
         assert isinstance(version, dict)
 
@@ -103,8 +104,8 @@ def test_format_memento_handles_redirects():
                                     to_date='20180808094145')
         record = next(cdx_records)
         memento = client.get_memento(record.raw_url, exact_redirects=False)
-        version = WaybackRecordsWorker.format_memento(None, memento, record,
-                                                      None, None)
+        worker = WaybackRecordsWorker(None, None, None, None, None)
+        version = worker.format_memento(memento, record, None, None)
 
         assert isinstance(version, dict)
         assert version['source_metadata']['redirected_url'] == final_url


### PR DESCRIPTION
We used to use `source_metadata` to set the media type and encoding information about a version, but web-monitoring-db has long since added top-level support for media type information. This updates the import code to use that, and also makes sure not to set `media_type` to an empty string, which is invalid (we used to do this, and imports would be rejected in some rare cases as a result).

Since we are processing a memento's `Content-Type` header in a more nuanced way now, this also means we might start storing extra media type parameters that we were leaving out before (we previously only captured the `charset` parameter).