### PR TITLE
Update Wayback to v0.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests ~=2.24.0
 toolz ~=0.11.1
 tornado ~=6.0.4
 tqdm ~=4.50.0
-wayback ~=0.2.4
+wayback ~=0.2.5


### PR DESCRIPTION
This fixes a bug with fetching mementos for redirects. For more, see: https://github.com/edgi-govdata-archiving/wayback/pull/53