### PR TITLE
Add deprecation notices for diffs/diff-server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: ~/web-monitoring-processing
@@ -83,16 +83,22 @@ jobs:
             docker push envirodgi/processing:latest
 
 workflows:
-  version: 2
   build:
     jobs:
       - build
-      - build_docker
-      - publish_docker:
-          requires:
-            - build
-            - build_docker
-          filters:
-            branches:
-              only:
-                - release
+      # The docker image is currently focused on the diff server, which now
+      # lives in the web-monitoring-diff project and will be published there.
+      # The current docker image should be considered deprecated and will no
+      # longer be updated.
+      #
+      # We're keeping this code around for future images based around the other
+      # scripts here for possible use with things like AWS Batch.
+      # - build_docker
+      # - publish_docker:
+      #     requires:
+      #       - build
+      #       - build_docker
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ This component is intended to hold various backend tools serving different tasks
 1. Query external sources of captured web pages (e.g. Internet Archive, Page
    Freezer, Sentry), and formulate a request for importing their version and
    page metadata into web-monitoring-db.
-2. Provide a web service that computes the "diff" between two versions of a page
-   in response to a query from web-monitoring-db.
-3. Query web-monitoring-db for new Changes, analyze them in an automated
+2. Query web-monitoring-db for new Changes, analyze them in an automated
    pipeline to assign priority and/or filter out uninteresting ones, and submit
    this information back to web-monitoring-db.
 
@@ -26,8 +24,6 @@ Working and Under Active Development:
 * A Python API to the web-monitoring-db Rails app in ``web_monitoring.db``
 * Python functions and a command-line tool for importing snapshots from the
   Internet Archive into web-monitoring-db.
-* An HTTP API for diffing two documents according to a variety of algorithms.
-  (Uses the Tornado web framework.)
 
 Legacy projects that may be revisited:
 * [Example HTML](https://github.com/edgi-govdata-archiving/web-monitoring-processing/tree/main/archives) providing useful test cases.
@@ -112,24 +108,15 @@ Legacy projects that may be revisited:
    Any additional arguments are passed through to `py.test`.
 
 
-## Docker
-
-The Dockerfile runs ``wm-diffing-server`` on port 80 in the container. To build
-and run:
-
-```
-docker build -t processing .
-docker run -p 4000:80 processing
-```
-
-Point your browser or ``curl`` at ``http://localhost:4000``.
-
-
 ## Releases
 
-New releases of the diffing server are published automatically as Docker images by CircleCI when someone pushes to the `release` branch. They are availble at https://hub.docker.com/r/envirodgi/ui. See [web-monitoring-ops](https://github.com/edgi-govdata-archiving/web-monitoring-ops) for how we deploy releases to actual web servers. We do not yet publish releases of the library-style tools in this repo (e.g. `db.py`).
+We try to make sure the code in this repo’s `main` branch is always in a stable, usable state, but occasionally coordinated functionality may be written across multiple commits. If you are depending on this package from another Python program, you may wish to install from the `release` branch instead:
 
-Images are tagged with the SHA-1 of the git commit they were built from. For example, the image `envirodgi/processing:446ae83e121ec8c2207b2bca563364cafbdf8ce0` was built from [commit `446ae83e121ec8c2207b2bca563364cafbdf8ce0`](https://github.com/edgi-govdata-archiving/web-monitoring-processing/commit/446ae83e121ec8c2207b2bca563364cafbdf8ce0) in web-monitoring-processing.
+```sh
+$ pip install git+https://github.com/edgi-govdata-archiving/web-monitoring-processing@release
+```
+
+You can also list the `git+https:` URL above in a pip *requirements* file.
 
 We usually create *merge commits* on the `release` branch that note the PRs included in the release or any other relevant notes (e.g. [`Release #302 and #313.`](https://github.com/edgi-govdata-archiving/web-monitoring-processing/commit/446ae83e121ec8c2207b2bca563364cafbdf8ce0)).
 

--- a/web_monitoring/diff/content_type.py
+++ b/web_monitoring/diff/content_type.py
@@ -1,3 +1,14 @@
+# -------- DEPRECATED -----------
+#
+# This package has been deprecated and will be removed soon. Everything in it
+# is now part of web-monitoring-diff.
+#
+#   https://github.com/edgi-govdata-archiving/web-monitoring-diff
+#   https://pypi.org/project/web-monitoring-diff/
+#
+# See also: https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/638
+#
+
 # Tools for checking the type of content and making sure it's acceptable for
 # a given diffing algorithm
 

--- a/web_monitoring/diff/deprecation.py
+++ b/web_monitoring/diff/deprecation.py
@@ -1,0 +1,10 @@
+import warnings
+
+
+def warn_deprecation():
+    warnings.warn('The web_monitoring.diff package has been deprecated and '
+                  'will no longer be updated! Please switch to the new '
+                  '`web-monitoring-diff` package at: '
+                  'https://pypi.org/project/web-monitoring-diff/',
+                  DeprecationWarning,
+                  stacklevel=2)

--- a/web_monitoring/diff/diff_errors.py
+++ b/web_monitoring/diff/diff_errors.py
@@ -1,3 +1,14 @@
+# -------- DEPRECATED -----------
+#
+# This package has been deprecated and will be removed soon. Everything in it
+# is now part of web-monitoring-diff.
+#
+#   https://github.com/edgi-govdata-archiving/web-monitoring-diff
+#   https://pypi.org/project/web-monitoring-diff/
+#
+# See also: https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/638
+#
+
 class UndiffableContentError(ValueError):
     """
     Raised when the content provided to a differ is incompatible with the

--- a/web_monitoring/diff/differs.py
+++ b/web_monitoring/diff/differs.py
@@ -1,4 +1,16 @@
+# -------- DEPRECATED -----------
+#
+# This package has been deprecated and will be removed soon. Everything in it
+# is now part of web-monitoring-diff.
+#
+#   https://github.com/edgi-govdata-archiving/web-monitoring-diff
+#   https://pypi.org/project/web-monitoring-diff/
+#
+# See also: https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/638
+#
+
 from bs4 import Comment
+from .deprecation import warn_deprecation
 from diff_match_patch import diff, diff_bytes
 from ..utils import get_color_palette
 from htmldiffer.diff import HTMLDiffer
@@ -19,11 +31,13 @@ REPEATED_BLANK_LINES = re.compile(r'([^\S\n]*\n\s*){2,}')
 
 def compare_length(a_body, b_body):
     "Compute difference in response body lengths. (Does not compare contents.)"
+    warn_deprecation()
     return {'diff': len(b_body) - len(a_body)}
 
 
 def identical_bytes(a_body, b_body):
     "Compute whether response bodies are exactly identical."
+    warn_deprecation()
     return {'diff': a_body == b_body}
 
 
@@ -56,6 +70,7 @@ def _get_visible_text(html):
 
 def side_by_side_text(a_text, b_text):
     "Extract the visible text from both response bodies."
+    warn_deprecation()
     return {'diff': {'a_text': _get_visible_text(a_text),
                      'b_text': _get_visible_text(b_text)}}
 
@@ -83,6 +98,7 @@ def html_text_diff(a_text, b_text):
     ...                '<p>Added</p><p>Unchanged</p>')
     [[-1, 'Delet'], [1, 'Add'], [0, 'ed Unchanged']]
     """
+    warn_deprecation()
 
     t1 = _get_visible_text(a_text)
     t2 = _get_visible_text(b_text)
@@ -103,6 +119,7 @@ def html_source_diff(a_text, b_text):
     ...                  '<p>Added</p><p>Unchanged</p>')
     [[0, '<p>'], [-1, 'Delet'], [1, 'Add'], [0, 'ed</p><p>Unchanged</p>']]
     """
+    warn_deprecation()
     TIMELIMIT = 2  # seconds
     res = compute_dmp_diff(a_text, b_text, timelimit=TIMELIMIT)
     count = len([[type_, string_] for type_, string_ in res if type_])
@@ -137,6 +154,7 @@ def insert_style(html, css):
 
 
 def html_tree_diff(a_text, b_text):
+    warn_deprecation()
     color_palette = get_color_palette()
     css = f'''
 diffins {{text-decoration : none; background-color:
@@ -156,6 +174,7 @@ diffdel * {{text-decoration : none; background-color:
 
 
 def html_differ(a_text, b_text):
+    warn_deprecation()
     color_palette = get_color_palette()
     css = f'''
 .htmldiffer_insert {{text-decoration : none; background-color:

--- a/web_monitoring/diff/html_diff_render.py
+++ b/web_monitoring/diff/html_diff_render.py
@@ -1,3 +1,14 @@
+# -------- DEPRECATED -----------
+#
+# This package has been deprecated and will be removed soon. Everything in it
+# is now part of web-monitoring-diff.
+#
+#   https://github.com/edgi-govdata-archiving/web-monitoring-diff
+#   https://pypi.org/project/web-monitoring-diff/
+#
+# See also: https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/638
+#
+
 """
 This HTML-diffing implementation is based on LXML’s `html.diff` module. It is
 meant to create HTML documents that can be viewed in a browser to highlight
@@ -26,6 +37,7 @@ import html5_parser
 import logging
 import re
 from .content_type import raise_if_not_diffable_html
+from .deprecation import warn_deprecation
 from .differs import compute_dmp_diff
 
 # Imports only used in forked tokenization code; may be ripe for removal:
@@ -362,6 +374,8 @@ def html_diff_render(a_text, b_text, a_headers=None, b_headers=None,
     text2 = '<!DOCTYPE html><html><head></head><body><h1>Header</h1></body></html>'
     test_diff_render = html_diff_render(text1,text2)
     """
+    warn_deprecation()
+
     raise_if_not_diffable_html(
         a_text,
         b_text,

--- a/web_monitoring/diff/links_diff.py
+++ b/web_monitoring/diff/links_diff.py
@@ -1,5 +1,16 @@
+# -------- DEPRECATED -----------
+#
+# This package has been deprecated and will be removed soon. Everything in it
+# is now part of web-monitoring-diff.
+#
+#   https://github.com/edgi-govdata-archiving/web-monitoring-diff
+#   https://pypi.org/project/web-monitoring-diff/
+#
+# See also: https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/638
+#
 import html5_parser
 from .content_type import raise_if_not_diffable_html
+from .deprecation import warn_deprecation
 from .differs import compute_dmp_diff
 from ..utils import get_color_palette
 from difflib import SequenceMatcher
@@ -22,6 +33,7 @@ def links_diff(a_text, b_text, a_headers=None, b_headers=None,
     as an internal link, but not:
         <a href="http://this.domain.com/this/page#anchor-in-this-page">Text</a>
     """
+    warn_deprecation()
     raise_if_not_diffable_html(
         a_text,
         b_text,
@@ -57,6 +69,7 @@ def links_diff_json(a_text, b_text, a_headers=None, b_headers=None,
     Generate a diff of all outgoing links (see `links_diff()`) where the `diff`
     property is formatted as a list of change codes and values.
     """
+    warn_deprecation()
     diff = links_diff(a_text, b_text, a_headers, b_headers,
                       content_type_options)
     return {
@@ -71,6 +84,7 @@ def links_diff_html(a_text, b_text, a_headers=None, b_headers=None,
     Generate a diff of all outgoing links (see `links_diff()`) where the `diff`
     property is an HTML string. Note the actual return type is still JSON.
     """
+    warn_deprecation()
     diff = links_diff(a_text, b_text, a_headers, b_headers,
                       content_type_options)
     soup = _render_html_diff(diff['diff'])

--- a/web_monitoring/diff_server/server.py
+++ b/web_monitoring/diff_server/server.py
@@ -1,3 +1,13 @@
+# -------- DEPRECATED -----------
+#
+# This package has been deprecated and will be removed soon. Everything in it
+# is now part of web-monitoring-diff.
+#
+#   https://github.com/edgi-govdata-archiving/web-monitoring-diff
+#   https://pypi.org/project/web-monitoring-diff/
+#
+# See also: https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/638
+#
 import asyncio
 import codecs
 import concurrent.futures
@@ -20,6 +30,7 @@ import tornado.httpclient
 import tornado.ioloop
 import tornado.web
 import traceback
+import warnings
 import web_monitoring
 from ..diff import differs, html_diff_render, links_diff
 from ..diff.diff_errors import UndiffableContentError, UndecodableContentError
@@ -704,6 +715,10 @@ class HealthCheckHandler(BaseHandler):
 
 
 def make_app():
+    warnings.warn('The web_monitoring.diff_server package has been '
+                  'deprecated! Please switch to the new `web-monitoring-diff` '
+                  'package at: https://pypi.org/project/web-monitoring-diff/',
+                  DeprecationWarning)
     class BoundDiffHandler(DiffHandler):
         differs = DIFF_ROUTES
 
@@ -724,6 +739,17 @@ def start_app(port):
 
 
 def cli():
+    print("""
+**** WARNING: this diff server has been deprecated! ****
+
+No new versions of this server will be released, and it will eventually be
+removed entirely. You should switch to the new `web-monitoring-diff` package,
+which includes a similar server and improved diffing functionality.
+
+    https://pypi.org/project/web-monitoring-diff/
+    https://github.com/edgi-govdata-archiving/web-monitoring-diff
+    """, file=sys.stderr)
+
     doc = """Start a diffing server.
 
 Usage:


### PR DESCRIPTION
All the diff functionality and the diff server has been moved to https://github.com/edgi-govdata-archiving/web-monitoring-diff. New development will happen there, not here, and adding these deprecation notices should help clarify that for anybody we don’t know about who is making use of this.

Fixes #638.