### PR TITLE
Upgrade Wayback to v0.3.0a1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests ~=2.24.0
 toolz ~=0.11.1
 tornado ~=6.0.4
 tqdm ~=4.50.0
-wayback ~=0.2.5
+wayback ~=0.3.0a1

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -349,37 +349,22 @@ class WaybackRecordsWorker(threading.Thread):
         """
         iso_date = cdx_record.timestamp.isoformat()
         # Use compact representation for UTC
-        if cdx_record.timestamp.tzinfo is None:
-            iso_date += 'Z'
-        elif iso_date.endswith('+00:00'):
+        if iso_date.endswith('+00:00'):
             no_tz_date = iso_date.split("+", 1)[0]
             iso_date = f'{no_tz_date}Z'
 
-        # Get all headers from the original response.
-        prefix = 'X-Archive-Orig-'
-        original_headers = {
-            k[len(prefix):]: v for k, v in memento.headers.items()
-            if k.startswith(prefix)
-        }
-
         metadata = {
-            'headers': original_headers,
+            'headers': memento.headers,
             'view_url': cdx_record.view_url
         }
 
-        if memento.status_code >= 400:
-            metadata['error_code'] = memento.status_code
-
         # If there were redirects, list every URL in the chain of requests.
-        if memento.url != cdx_record.raw_url:
-            redirects = list(map(
-                lambda response: wayback.memento_url_data(response.url)[0],
-                memento.history))
-            redirected_url = wayback.memento_url_data(memento.url)[0]
-            redirects.append(redirected_url)
-            metadata['redirected_url'] = redirected_url
-            metadata['redirects'] = [url for i, url in enumerate(redirects)
-                                     if url not in redirects[:i]]
+        if memento.url != cdx_record.url:
+            metadata['redirected_url'] = memento.url
+            metadata['redirects'] = [
+                *map(lambda item: item.url, memento.history),
+                memento.url
+            ]
 
         media_type, media_type_parameters = self.get_memento_media(memento)
 
@@ -409,7 +394,7 @@ class WaybackRecordsWorker(threading.Thread):
 
     def get_memento_media(self, memento):
         """Extract media type and media type parameters from a memento."""
-        media, *parameters = memento.headers.get('content-type', '').split(';')
+        media, *parameters = memento.headers.get('Content-Type', '').split(';')
 
         # Clean up whitespace, remove empty parameters, etc.
         clean_parameters = (param.strip() for param in parameters)

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -337,8 +337,7 @@ class WaybackRecordsWorker(threading.Thread):
         Load the actual Wayback memento for a CDX record and transform it to
         a Web Monitoring DB import record.
         """
-        memento = self.wayback.get_memento(record.raw_url,
-                                           exact_redirects=False)
+        memento = self.wayback.get_memento(record, exact_redirects=False)
         with memento:
             return self.format_memento(memento, record, self.maintainers,
                                        self.tags)

--- a/web_monitoring/tests/test_cli.py
+++ b/web_monitoring/tests/test_cli.py
@@ -86,6 +86,7 @@ def test_format_memento():
         assert version['media_type'] == 'text/html'
         assert version['source_metadata'] == {
             'headers': {
+                'Content-Type': 'text/html',
                 'Date': 'Fri, 24 Nov 2017 15:13:14 GMT',
                 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
                 'Transfer-Encoding': 'chunked'
@@ -144,6 +145,7 @@ def test_format_memento_pdf():
                 'Cache-Control': 'max-age=572',
                 'Connection': 'close',
                 'Content-Length': '375909',
+                'Content-Type': 'application/pdf',
                 'Date': 'Thu, 30 Apr 2020 02:42:32 GMT',
                 'ETag': '"12c958e520c9ff580f52ee11446c5e0c:1579909999.298098"',
                 'Expires': 'Thu, 30 Apr 2020 02:52:04 GMT',


### PR DESCRIPTION
The first alpha version of Wayback v0.3.0 is out, and as its primary users (and biggest scale users AFAIK), we should get this running so we find out about any issues quickly. It would be good to have this running for our imports before really certifying a final version of Wayback v0.3 anyway.