### PR TITLE
Update Wayback to v0.3.0a2, improve logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests ~=2.24.0
 toolz ~=0.11.1
 tornado ~=6.1
 tqdm ~=4.51.0
-wayback ~=0.3.0a1
+wayback ~=0.3.0a2

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -640,7 +640,6 @@ def import_ia_urls(urls, *, from_date=None, to_date=None,
         uploader.join()
 
         if not dry_run:
-            print('Saving list of non-playbackable URLs...')
             save_unplaybackable_mementos(unplaybackable_path, unplaybackable)
 
         if summary['success'] == 0:
@@ -724,6 +723,8 @@ def load_unplaybackable_mementos(path):
 def save_unplaybackable_mementos(path, mementos, expiration=7 * 24 * 60 * 60):
     if path is None:
         return
+
+    print('Saving list of non-playbackable URLs...')
 
     threshold = datetime.utcnow() - timedelta(seconds=expiration)
     urls = list(mementos.keys())


### PR DESCRIPTION
Pretty much what it does on the tin. This is a minor bugfix to alleviate issues with some memento imports. A tiny logging fix (only claim to save the unplaybackable cache when that's actually what's happening) came along for the ride.