### PR TITLE
Don't fail on malformed/encrypted/unreadable PDFs

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -374,7 +374,7 @@ class WaybackRecordsWorker(threading.Thread):
         if media_type in HTML_MEDIA_TYPES:
             title = utils.extract_title(memento.content, memento.encoding or 'utf-8')
         elif media_type in PDF_MEDIA_TYPES or memento.content.startswith(b'%PDF-'):
-            title = utils.extract_pdf_title(memento.content)
+            title = utils.extract_pdf_title(memento.content) or title
 
         return dict(
             # Page-level info

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -36,9 +36,20 @@ def extract_title(content_bytes, encoding='utf-8'):
     return WHITESPACE_PATTERN.sub(' ', title.text.strip())
 
 
-def extract_pdf_title(content_bytes):
+def extract_pdf_title(content_bytes, password=''):
     pdf = PdfFileReader(io.BytesIO(content_bytes))
-    info = pdf.getDocumentInfo()
+    # Lots of PDFs turn out to be encrypted with an empty password. ¯\_(ツ)_/¯
+    if pdf.isEncrypted:
+        try:
+            pdf.decrypt(password)
+        except Exception:
+            return None
+
+    try:
+        info = pdf.getDocumentInfo()
+    except Exception:
+        return None
+
     return info.title
 
 


### PR DESCRIPTION
It turns out the PyPDF2 code we added in #622 was not especially safe — there are a variety of ways PDF parsing could fail (the file could use a newer format PyPDF2 does not understand, or it could simply be malformed). It also turns out quite a few PDFs out there are encrypted with an empty password (weird, but common enough that most PDF readers simply try it automatically for it if the file is encrypted). Finally, PyPDF2 only supports 2 of the standard PDF encryption algorithms, so decryption could also fail on a perfectly legitimate file.

This previously caused us to completely fail at saving the memento for PDFs that couldn’t parse because of any of the above cirumstances! The changes here attempt to handle these gracefully, and simply set no title instead of raising an exception if the PDF could not be read.