### PR TITLE
Handle PDFs with no title

### DIFF
--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -47,10 +47,9 @@ def extract_pdf_title(content_bytes, password=''):
 
     try:
         info = pdf.getDocumentInfo()
+        return info.title
     except Exception:
         return None
-
-    return info.title
 
 
 def hash_content(content_bytes):


### PR DESCRIPTION
It turns out PyPDF2 does not set the document's `title` attribute to `None` when there's no title. It simply doesn't have the attribute at all. Which was causing us to throw exceptions.