### PR TITLE
Drop references to removed `media_type_parameters`

### DIFF
--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -76,8 +76,7 @@ def _time_range_string(start_date, end_date):
 
 
 def _build_version(*, page_id, uuid, capture_time, uri, hash, source_type,
-                   title, source_metadata=None, media_type=None,
-                   media_type_parameters=None):
+                   title, source_metadata=None, media_type=None):
     """
     Build a Version dict from parameters, performing some validation.
     """
@@ -93,8 +92,7 @@ def _build_version(*, page_id, uuid, capture_time, uri, hash, source_type,
                'source_type': str(source_type),
                'title': str(title),
                'source_metadata': source_metadata,
-               'media_type': media_type,
-               'media_type_parameters': media_type_parameters}
+               'media_type': media_type}
     return version
 
 
@@ -102,7 +100,7 @@ def _build_importable_version(*, page_url, uuid=None, capture_time, uri,
                               version_hash, source_type, title,
                               page_maintainers=None, page_tags=None,
                               source_metadata=None, status=None,
-                              media_type=None, media_type_parameters=None):
+                              media_type=None):
     """
     Build a Version dict from parameters, performing some validation.
 
@@ -124,8 +122,7 @@ def _build_importable_version(*, page_url, uuid=None, capture_time, uri,
                'status': str(status),
                'page_maintainers': page_maintainers,
                'page_tags': page_tags,
-               'media_type': media_type,
-               'media_type_parameters': media_type_parameters}
+               'media_type': media_type}
     return version
 
 


### PR DESCRIPTION
We removed this functionality from the database in edgi-govdata-archiving/web-monitoring-db#752, so it should be pulled from here.