### PR TITLE
Add `--precheck` option to import script

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -607,7 +607,6 @@ def import_ia_db_urls(*, from_date=None, to_date=None, maintainers=None,
     logger.info(f'Found {len(urls)} CDX-queryable URLs')
     logger.debug('\n  '.join(urls))
 
-    # TODO: should probably move most of this to a separate function
     version_cache = None
     if precheck_versions:
         version_cache = _load_known_versions(client,

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -602,9 +602,7 @@ def import_ia_db_urls(*, from_date=None, to_date=None, maintainers=None,
         _filter = version_filter
         def precheck_filter(cdx_record):
             key = memento_key(cdx_record.timestamp, cdx_record.url)
-            logger.info(f'Prechecking {key}')
             if memento_key(cdx_record.timestamp, cdx_record.url) in known_mementos:
-                logger.info(f'  SKIPPING {key}')
                 return False
             return _filter(cdx_record)
 


### PR DESCRIPTION
~**This is a draft for testing, and very much not ready to merge.**~

This adds a new `--precheck` option to the import script, which causes it to load a list of all the versions we have in the database for the given timeframe before trying to import anything from Wayback. The idea here is to reduce duplicate loads and imports: we currently run the import daily, but cover a timeframe of several days so we don’t have huge data loss every time Wayback’s CDX indexing falls behind by a few days (which is frequent — it’s happening as I write this, in fact). That helps things when Wayback is having issues, but when all is well, it results in us loading *a lot* more data from Wayback than is really necessary, and creating imports that frequently consist of data we ultimately ignore because it’s already in the database.

It’s an option because it can be pretty slow or take lots of memory if the import covers a large timeframe. It also can’t be narrowed by URL pattern very easily right now ([there’s no index on the `capture_url` of versions](https://github.com/edgi-govdata-archiving/web-monitoring-db/blob/46561ae6eb52b0d923f7832100d161fc98667d0c/db/schema.rb#L153-L159) and querying pages then versions is complex, even slower, and doesn’t really help our main use case, which is the nightly import for *all* URLs).

I’m starting this as a **very ugly** draft so I can test it running in production for a while and see the impact. It definitely needs some cleanup before merging. :)