### PR TITLE
Assorted minor import script improvements

### DIFF
--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -13,6 +13,7 @@ import re
 import requests
 import requests.adapters
 import signal
+import sys
 import threading
 import time
 
@@ -467,10 +468,10 @@ class QuitSignal(Signal):
 
     def handle_interrupt(self, signal_type, frame):
         if not self.event.is_set():
-            print(self.graceful_message)
+            print(self.graceful_message, file=sys.stderr, flush=True)
             self.event.set()
         else:
-            print(self.final_message)
+            print(self.final_message, file=sys.stderr, flush=True)
             os._exit(100)
 
     def __enter__(self):


### PR DESCRIPTION
This is a little bit of a grab bag from small tweaks this week:
- Lower the connect timeout for mementos. After a deeper investigation, it turns out waiting for a connection was never a major issue (it was reading) and now that we pool connections properly, this is even less of an issue.
- Increase the read timeout. Now that we are managing connections properly, it became more clear that the timeouts we are most often encountering with IA are in reading. 10s seems much more stable than 2, although this might be too high. We'll see.
- If mementos are missing (CDX has a record of an attempted capture, but when you request it, Wayback reports that the given URL was *never* captured), we shouldn't retry them, so track these as unplaybackable.
- Now that the timeout issues are resolved (above) and we have built in retry at the `wayback` level, stop queueing retries for a whole second round. This is not super valuable. (There's a lot more cleanup that can happen here if we commit to this.)
- Print the `ctrl+c` "quitting gracefully" message to stderr instead of stdout and make sure to flush so that it actually shows up in the output immediately. This is a message that shouldn't get buffered.