### PR TITLE
Upgrade Wayback to v0.3.0b1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests ~=2.25.1
 toolz ~=0.11.1
 tornado ~=6.1
 tqdm ~=4.58.0
-wayback ~=0.3.0a3
+wayback ~=0.3.0b1


### PR DESCRIPTION
Wayback v0.3.0b1 no longer raises `HTTPError` from requests, and instead we have now have `NoMementoError` which covers the one specific `HTTPError` case we were testing for. This also pretty much gets rid of everywhere we touch requests that is not some low-level hackery around thread-safety (hopefully Wayback v0.4 will fix that).

If this works well for the next few days, we’ll ship the final Wayback v0.3.0.