### PR TITLE
Bump wayback to v0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ sentry-sdk ~=0.20.3
 requests ~=2.25.1
 toolz ~=0.11.1
 tqdm ~=4.58.0
-wayback ~=0.3.0b1
+wayback ~=0.3.0


### PR DESCRIPTION
There's a final, non-beta release of Wayback v0.3.0! Upgrade to that, and get rid of the timeout hacks.

Also reduce the `get_memento()` timeout to 45 seconds. The default 60 second timeout works and gives us a low error rate (0.15%-1.0%), but leads to import runs as long as 18 hours. Let's see whether reducing the timeout a bit shortens the runs without dramatically increasing errors.