### PR TITLE
Remove matplotlib dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,15 +39,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
-    'matplotlib.sphinxext.plot_directive',
     'numpydoc',
 ]
-
-# Configuration options for plot_directive. See:
-# https://github.com/matplotlib/matplotlib/blob/f3ed922d935751e08494e5fb5311d3050a3b637b/lib/matplotlib/sphinxext/plot_directive.py#L81
-plot_html_show_source_link = False
-plot_html_show_formats = False
-plot_pre_code = ()
 
 # Generate the API documentation when building
 autosummary_generate = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ pyflakes ~=2.3.1
 pytest ~=6.2.5
 vcrpy ~=4.1.1
 ipython ~=7.27.0
-matplotlib ~=3.4.3
 numpydoc ~=1.1.0
 requests-mock ~=1.9.3
 sphinx ~=4.1.2


### PR DESCRIPTION
We don't actually use matplotlib. We kept it around because @danielballan had planned to add some plots to the docs, but I don't think that's realistically going to happen anytime soon (if at all), so this drops the dependency. We can always add it back later if needed.