### PR TITLE
Use explicit python version for Docker and Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,21 @@
 version: 2.1
+
+parameters:
+  python-version:
+    type: string
+    default: "3.7.13"
+
 jobs:
   build:
     working_directory: ~/web-monitoring-processing
     docker:
-      - image: cimg/python:3.7.13
+      - image: cimg/python:<< pipeline.parameters.python-version >>
     steps:
       - checkout
       - restore_cache:
           keys:
-            - processing-{{ arch }}-v3-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - processing-{{ arch }}-v3-
+            - processing-{{ arch }}-<< pipeline.parameters.python-version >>-v1-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - processing-{{ arch }}-<< pipeline.parameters.python-version >>-v1-
 
       # Bundle install dependencies
       - run:
@@ -25,7 +31,7 @@ jobs:
 
       # Store bundle cache
       - save_cache:
-          key: processing-{{ arch }}-v3-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: processing-{{ arch }}-<< pipeline.parameters.python-version >>-v1-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - venv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ jobs:
   build:
     working_directory: ~/web-monitoring-processing
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.7.13
     steps:
       - checkout
       - restore_cache:
           keys:
-            - processing-{{ arch }}-v2-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            - processing-{{ arch }}-v2-
+            - processing-{{ arch }}-v3-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - processing-{{ arch }}-v3-
 
       # Bundle install dependencies
       - run:
@@ -25,7 +25,7 @@ jobs:
 
       # Store bundle cache
       - save_cache:
-          key: processing-{{ arch }}-v2-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: processing-{{ arch }}-v3-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.7-slim
+FROM python:3.7.13-slim
 LABEL maintainer="enviroDGI@gmail.com"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -31,11 +31,8 @@ Legacy projects that may be revisited:
 
 ## Installation Instructions
 
-1. Get Python 3.7. This packages makes use of modern Python features and
-   requires Python 3.7+.  If you don't have Python 3.7, we recommend using
-   [conda](https://conda.io/miniconda.html) to install it. (You don't need admin
-   privileges to install or use it, and it won't interfere with any other
-   installations of Python already on your system.)
+1. Get Python 3.7 or later. If you don't have the right version, we recommend using
+   [conda](https://conda.io/miniconda.html) or [pyenv](https://github.com/pyenv/pyenv) to install it. (You don't need admin privileges to install or use them, and they won't interfere with any other installations of Python already on your system.)
 
 2. Install libxml2 and libxslt. (This package uses lxml, which requires your system to have the libxml2 and libxslt libraries.)
 


### PR DESCRIPTION
We cache a virtualenv on CircleCI, and when there are new patch releases of Python and Circle upgrades, we have problems, because the cache's symlink for Python starts pointing to nowhere. This will help prevent that problem.

I figured it makes sense to lock down a specific version of Python in the Dockerfile while we’re at it.