### PR TITLE
Sniff media types when content-type is meaningless

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -43,7 +43,7 @@ and results between them.
 
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from web_monitoring.utils import detect_encoding
+from web_monitoring.utils import detect_encoding, sniff_media_type
 import dateutil.parser
 from docopt import docopt
 from itertools import islice
@@ -153,6 +153,13 @@ HTML_MEDIA_TYPES = frozenset((
 PDF_MEDIA_TYPES = frozenset((
     'application/pdf',
     'application/x-pdf',
+))
+
+# These media types are so meaningless that it's worth sniffing the content to
+# see if we can determine an actual media type.
+SNIFF_MEDIA_TYPES = frozenset((
+    'application/octet-stream',
+    'application/x-download',
 ))
 
 # Identifies a bare media type (that is, one without parameters)
@@ -404,6 +411,8 @@ class WaybackRecordsWorker(threading.Thread):
             ]
 
         media_type, media_type_parameters = self.get_memento_media(memento)
+        if not media_type or media_type in SNIFF_MEDIA_TYPES:
+            media_type = sniff_media_type(memento.content, media_type)
 
         title = ''
         if media_type in HTML_MEDIA_TYPES:

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -88,7 +88,17 @@ def test_extract_pdf_title_no_eof():
 
 class TestSniffMediaType:
     def test_sniff_media_type_detects_html(self):
-        raw_bytes = get_fixture_bytes('unknown_encoding.html')
+        raw_bytes = b'''
+            <!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+            <html>
+            <head>
+                <title>Test Page</title>
+            </head>
+            <body>
+                Test
+            </body>
+            </html>
+        '''
         media = sniff_media_type(raw_bytes)
         assert media == 'text/html'
 

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -92,7 +92,7 @@ class TestSniffMediaType:
         media = sniff_media_type(raw_bytes)
         assert media == 'text/html'
 
-    def test_sniff_media_type_detects_html(self):
+    def test_sniff_media_type_detects_pdf(self):
         raw_bytes = get_fixture_bytes('basic_title.pdf')
         media = sniff_media_type(raw_bytes)
         assert media == 'application/pdf'

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -4,7 +4,7 @@ import queue
 from pathlib import Path
 import threading
 from web_monitoring.utils import (extract_title, extract_pdf_title, RateLimit,
-                                  FiniteQueue)
+                                  FiniteQueue, sniff_media_type)
 
 
 def get_fixture_bytes(filename):
@@ -84,6 +84,23 @@ def test_extract_pdf_title_no_eof():
     pdf_bytes = get_fixture_bytes('no_eof_marker.pdf')
     title = extract_pdf_title(pdf_bytes)
     assert title is None
+
+
+class TestSniffMediaType:
+    def test_sniff_media_type_detects_html(self):
+        raw_bytes = get_fixture_bytes('unknown_encoding.html')
+        media = sniff_media_type(raw_bytes)
+        assert media == 'text/html'
+
+    def test_sniff_media_type_detects_html(self):
+        raw_bytes = get_fixture_bytes('basic_title.pdf')
+        media = sniff_media_type(raw_bytes)
+        assert media == 'application/pdf'
+
+    def test_sniff_media_type_uses_default_parameter_as_fallback(self):
+        raw_bytes = b'This is just a random string'
+        media = sniff_media_type(raw_bytes, 'my/default')
+        assert media == 'my/default'
 
 
 class TestRateLimit:

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -98,27 +98,33 @@ def detect_encoding(content, headers, default='utf-8'):
 # Patterns used to sniff various media types. Based on:
 # - https://dev.w3.org/html5/cts/html5-type-sniffing.html
 # - https://mimesniff.spec.whatwg.org/#rules-for-identifying-an-unknown-mime-type
-SNIFF_HTML_PATTERN = re.compile(rb'''
-    ^[\s\n\r]*(
-        <!DOCTYPE HTML|
-        <HTML|
-        <HEAD|
-        <SCRIPT|
-        <IFRAME|
-        <H1|
-        <DIV|
-        <FONT|
-        <TABLE|
-        <A|
-        <STYLE|
-        <TITLE|
-        <B|
-        <BODY|
-        <BR|
-        <P|
-        <!--
-    )[\s>]
-''', re.VERBOSE & re.IGNORECASE)
+#
+# NOTE: a "verbose" regex would be nice here, but they don't seem to work with
+# binary strings.
+SNIFF_HTML_HINTS = (
+    rb'<!DOCTYPE HTML',
+    rb'<HTML',
+    rb'<HEAD',
+    rb'<SCRIPT',
+    rb'<IFRAME',
+    rb'<H1',
+    rb'<DIV',
+    rb'<FONT',
+    rb'<TABLE',
+    rb'<A',
+    rb'<STYLE',
+    rb'<TITLE',
+    rb'<B',
+    rb'<BODY',
+    rb'<BR',
+    rb'<P',
+    rb'<!--',
+)
+
+SNIFF_HTML_PATTERN = re.compile(
+    rb'^[\s\n\r]*(%s)[\s\n\r>]' % b'|'.join(SNIFF_HTML_HINTS),
+    re.IGNORECASE
+)
 
 SNIFF_MEDIA_TYPE_PATTERNS = {
     SNIFF_HTML_PATTERN: 'text/html',


### PR DESCRIPTION
When importing, we occasionally hit meaningless `Content-Type` headers like `application/octet-stream` or `application/x-download`, which servers often set in order to force a browser to download a file instead of display it. For these responses, we now sniff the media type according to a standard W3C/WHATWG approach. Note that the original `Content-Type` header is still stored in the `headers` field of the imported version, and we are only changing what winds up in the `media_type` field.