### PR TITLE
Specify language for Sphinx docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,7 +79,7 @@ release = web_monitoring.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
We gave up for now on upgrading to Sphinx 5, but one lesson from it is that setting the `language` will be required, because it really is the right thing to do.