### PR TITLE
Switch from PyPDF2 to pypdf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cchardet ==2.1.7
 python-dateutil ~=2.8.2
 docopt ~=0.6.2
 lxml ~=4.9.2
-PyPDF2[crypto] ~=3.0.1
+pypdf[crypto] ~=3.2.0
 sentry-sdk ~=1.12.1
 requests ~=2.28.1
 toolz ~=0.12.0

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -66,7 +66,7 @@ def test_extract_pdf_title_encrypted_no_password():
 
 
 @pytest.mark.skip("""
-    PyPDF2 has maintainers again, and we no longer have any examples of
+    pypdf has maintainers again, and we no longer have any examples of
     unsupported encryption schemes! Bring this test back if we
     encounter new, unencryptable PDFs.
 """)

--- a/web_monitoring/tests/test_utils.py
+++ b/web_monitoring/tests/test_utils.py
@@ -68,7 +68,7 @@ def test_extract_pdf_title_encrypted_no_password():
 @pytest.mark.skip("""
     pypdf has maintainers again, and we no longer have any examples of
     unsupported encryption schemes! Bring this test back if we
-    encounter new, unencryptable PDFs.
+    encounter new, undecryptable PDFs.
 """)
 def test_extract_pdf_title_encrypted_unsupported_algorithm():
     """

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -5,8 +5,8 @@ import io
 import logging
 import lxml.html
 import os
-from PyPDF2 import PdfReader
-from PyPDF2.errors import PyPdfError
+from pypdf import PdfReader
+from pypdf.errors import PyPdfError
 import queue
 import re
 import signal


### PR DESCRIPTION
This isn't actually a change in libraries; PyPDF2 has been renamed to pypdf and won't be releasing new updates under the old name (see https://pypdf2.readthedocs.io/en/latest/meta/CHANGELOG.html#version-3-1-0-2022-12-23).