### PR TITLE
Don't assume credentials are present in CLI

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -952,7 +952,7 @@ def validate_db_credentials():
             Check the following environment variables:
 
                 WEB_MONITORING_DB_URL
-                WEB_MONITORING_DB_EMAIL {os.environ['WEB_MONITORING_DB_EMAIL']}
+                WEB_MONITORING_DB_EMAIL {os.environ.get('WEB_MONITORING_DB_EMAIL')}
                 WEB_MONITORING_DB_PASSWORD
                 """)
 


### PR DESCRIPTION
This is a quick follow-up to #845 -- the CLI formats an error message with the assumption that credentials will be present in the environment, and that's no longer true.