### PR TITLE
Get the Dockerfile working again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,12 @@ jobs:
             cd docs && make html
 
   build_docker:
-    machine: true
+    machine:
+      image: ubuntu-2004:202111-02
     steps:
       - checkout
       - run: |
-          docker build -t envirodgi/processing:$CIRCLE_SHA1 .
+          docker build --target release --tag envirodgi/processing:$CIRCLE_SHA1 .
       - run:
           name: Save Image
           command: |
@@ -120,7 +121,8 @@ jobs:
             - docker-image
 
   publish_docker:
-    machine: true
+    machine:
+      image: ubuntu-2004:202111-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -146,19 +148,13 @@ workflows:
               python-version: ["3.7", "3.8", "3.9", "3.10"]
       - lint
       - docs
-      # The docker image is currently focused on the diff server, which now
-      # lives in the web-monitoring-diff project and will be published there.
-      # The current docker image should be considered deprecated and will no
-      # longer be updated.
-      #
-      # We're keeping this code around for future images based around the other
-      # scripts here for possible use with things like AWS Batch.
-      # - build_docker
-      # - publish_docker:
-      #     requires:
-      #       - build
-      #       - build_docker
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
+      - build_docker
+      - publish_docker:
+          requires:
+            - test
+            - lint
+            - build_docker
+          filters:
+            branches:
+              only:
+                - release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-# Base Image for Building -----------------------------------------------------
-
-FROM python:3.10.10-slim AS build
+# Base Image  -----------------------------------------------------------------
+FROM python:3.10.10-slim AS base
+LABEL org.opencontainers.image.authors="enviroDGI@gmail.com"
 LABEL maintainer="enviroDGI@gmail.com"
 
-# RUN apt-get update && apt-get install -y --no-install-recommends \
-#     git gcc g++ pkg-config libxml2-dev libxslt-dev libz-dev \
-#     libssl-dev openssl libcurl4-openssl-dev
+
+# Building Deps & Native Code -------------------------------------------------
+FROM base AS build
 
 # Need build tools for some dependencies (Cchardet, Lxml)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -29,9 +29,7 @@ RUN pip install --user .
 
 
 # Deployable Image w/out Build-Only Dependencies ------------------------------
-
-FROM python:3.10.10-slim AS release
-LABEL maintainer="enviroDGI@gmail.com"
+FROM base AS release
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libxml2 libxslt1.1 zlib1g


### PR DESCRIPTION
We haven't really maintained the Dockerfile here since we spun off the web-monitoring-diff project (after which we no longer ran anything from this repo as a container). We need containerization for the code here again, and this updates out Dockerfile to build an image that works.

This partially addresses #757 (we still need to actually get it running in production — I think that’ll just be a Kubernetes ConJob rather than trying to set up an ECS cluster in addition to everything else).