### PR TITLE
Clean up logs for Kube/CloudWatch

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -57,7 +57,6 @@ from pathlib import Path
 import re
 import requests
 import signal
-import sys
 import threading
 import time
 from tqdm import tqdm

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -999,7 +999,10 @@ Options:
             return
 
         unplaybackable_path = _parse_path(arguments.get('--unplaybackable'))
-        validate_db_credentials()
+        if not arguments.get('--dry-run'):
+            validate_db_credentials()
+
+        start_time = datetime.now(tz=timezone.utc)
         if arguments['ia']:
             import_ia_urls(
                 urls=[arguments['<url>']],
@@ -1022,6 +1025,10 @@ Options:
                 unplaybackable_path=unplaybackable_path,
                 dry_run=arguments.get('--dry-run'),
                 precheck_versions=arguments.get('--precheck'))
+
+        end_time = datetime.now(tz=timezone.utc)
+        print(f'Completed at {end_time.isoformat()}')
+        print(f'Duration: {end_time - start_time}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Normally, TQDM does not do anything if the output is not an interactive terminal (TTY), since the way it prints doesn't work very well in that context. However, we had some funky customizations that made it output in those environments anyway (albeit at a lower rate), because we were so often investigating weird behavior over very long timespans in production, and having it output some kind of "heartbeat" was helpful. We haven't done that in a long time, and it's always made non-interactive logs messy. But now that those logs are going through Kubernetes to CloudWatch, it makes the logs basically unusable. This hack has long outlived its purpose.

I’ve also added logging for a final job timing/duration for convenience in archived logs.