### PR TITLE
Don't show progress bars if no TTY, take 2

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -649,7 +649,10 @@ def import_ia_urls(urls, *, from_date=None, to_date=None,
         memento_data_queue = utils.FiniteQueue()
         progress_thread = threading.Thread(target=lambda: utils.iterate_into_queue(
             memento_data_queue,
-            tqdm(versions_queue, desc='Processing', unit=' CDX Records')))
+            tqdm(versions_queue,
+                 desc='Processing',
+                 unit=' CDX Records',
+                 disable=None)))
         progress_thread.start()
 
         # Filter out errors and summarize


### PR DESCRIPTION
This is a follow-on to #850, which I botched. I thought I remembered TQDM not showing progress bars in non-TTY environments by default, but it turns out that is not true (or it's changed). Instead, you have to explicitly tell it to choose based on the environment with `disable=None` (instead of giving it a boolean value). This should actually remove the progress bars in production. (Also, this time I tested with Docker locally.)