### PR TITLE
Add v1 schema support to annotations import script

### DIFF
--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -9,9 +9,7 @@ import re
 from tqdm import tqdm
 from web_monitoring import db
 
-logger = logging.getLogger(__name__)
-log_level = os.getenv('LOG_LEVEL', 'WARNING')
-logger.setLevel(logging.__dict__[log_level])
+logger = logging.getLogger('annotations_import')
 
 IMPORTANCE_SIGNIFICANCE_MAP = {
     'low': 0.5,
@@ -399,6 +397,9 @@ class AuthorNameMapper:
 
 
 def main():
+    log_level = os.getenv('LOG_LEVEL', 'WARNING')
+    logging.basicConfig(level=log_level)
+
     doc = """Add analyst annotations from a csv file to the Web Monitoring db.
 
 Usage:

--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -213,7 +213,7 @@ class AnalystSheet:
             change_ids = self.get_change_ids(row)
             try:
                 annotation = self.create_annotation(row, index)
-                id = annotation['analyst_sheet_id']
+                id = annotation['sheet_change_id']
                 if id in ids:
                     logger.warn(f"DUPLICATE ID: {id}")
             except Exception as error:
@@ -247,7 +247,7 @@ class V1ChangesSheet(AnalystSheet):
         # Useful info for analysts, but mostly duplicative of data in DB.
         ('Checked (2-significant)', None),
         ('Index', None),
-        ('Unique ID', 'analyst_sheet_id', sheet_str),
+        ('Unique ID', 'sheet_change_id', sheet_str),
         ('Output Date/Time', None),
         ('Agency', None),
         ('Site Name', None),
@@ -329,7 +329,7 @@ class V2ChangesSheet(AnalystSheet):
 
     schema = (
         ('Index', None, sheet_str),
-        ('Unique ID', 'analyst_sheet_id', sheet_str),
+        ('Unique ID', 'sheet_change_id', sheet_str),
         ('Output Date/Time', None, sheet_str),
         ('Agency', None, sheet_str),
         ('Site Name', None, sheet_str),

--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -350,8 +350,7 @@ class V2ChangesSheet(AnalystSheet):
         ('Importance?', None, sheet_str),
 
         ('Language alteration', 'language_alteration', sheet_bool),
-        # FIXME: missing?
-        ('Content change/addition/removal', None, sheet_bool),
+        ('Content change/addition/removal', 'content_change', sheet_bool),
         ('Link change/addition/removal', 'link_change', sheet_bool),
         ('Repeated Change across many pages or a domain', 'repeated_change', sheet_bool),
         ('Alteration within sections of a webpage', 'alteration_within_sections', sheet_bool),

--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -229,6 +229,9 @@ class AnalystSheet:
     def create_annotation(self, csv_row, row_index):
         annotation = {
             'annotation_schema': self.schema_name,
+            'significance': (self.get_row_significance(csv_row, row_index)
+                             if self.is_important
+                             else 0.0)
         }
         for index, field in enumerate(self.schema):
             value = csv_row[index]
@@ -302,14 +305,9 @@ class V1ChangesSheet(AnalystSheet):
         del annotation['notes_2_a']
         del annotation['notes_2_b']
 
-        significance = 0.0
-        if self.is_important:
-            significance = self.get_row_significance(row_index)
-        annotation['significance'] = significance
-
         return annotation
 
-    def get_row_significance(self, row_number):
+    def get_row_significance(self, _row, row_number):
         value = 'medium'
         offset = self.row_offset + 1
         for candidate in V1_SIGNIFICANT_ROWS:
@@ -376,17 +374,7 @@ class V2ChangesSheet(AnalystSheet):
         ('Ask/tell other working groups?', None, sheet_str),
     )
 
-    def create_annotation(self, csv_row, row_index):
-        annotation = super().create_annotation(csv_row, row_index)
-
-        significance = 0.0
-        if self.is_important:
-            significance = self.get_row_significance(csv_row)
-        annotation['significance'] = significance
-
-        return annotation
-
-    def get_row_significance(self, row):
+    def get_row_significance(self, row, _row_index):
         row_importance = self.get('Importance?', row).lower().strip()
         return IMPORTANCE_SIGNIFICANCE_MAP.get(row_importance, 0.0)
 

--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -6,15 +6,123 @@ import os
 import re
 from tqdm import tqdm
 from web_monitoring import db
+from time import sleep
 
 logger = logging.getLogger(__name__)
 log_level = os.getenv('LOG_LEVEL', 'WARNING')
 logger.setLevel(logging.__dict__[log_level])
 
+# These were set in the original sheet by color coding, so we've just kept an
+# index here. Not great. 2 types of data in this list:
+#   1. (row_number, significance)
+#   2. (start_row_number_inclusive, end_row_number_exclusive, significance)
+#
+# Row numbers are from the original sheet, which has 5 header rows and is
+# 1-based. So subtract 6 from these to get the indexes used in this script.
+V1_SIGNIFICANT_ROWS = [
+    (6, 'low'),
+    (8, 'low'),
+    (14, 'high'),
+    (37, 'low'),
+    (41, 'high'),
+    (45, 'low'),
+    (47, 'low'),
+    (48, 'low'),
+    (49, 'low'),
+    (51, 'low'),
+    (55, 'high'),
+    (58, 'low'),
+    (61, 'low'),
+    (68, 'low'),
+    (83, 'low'),
+    (89, 'high'),
+    (93, 'low'),
+    (94, 'low'),
+    (95, 'low'),
+    (96, 'low'),
+    (98, 'low'),
+    (99, 'low'),
+    (100, 'low'),
+    (101, 'low'),
+    (105, 'low'),
+    (106, 'low'),
+    (107, 'low'),
+    (108, 'low'),
+    (109, 'low'),
+    (110, 'low'),
+    (111, 'low'),
+    (112, 'low'),
+    (113, 'low'),
+    (114, 'low'),
+    (115, 'low'),
+    (116, 'low'),
+    (117, 'low'),
+    (118, 'low'),
+    (119, 'low'),
+    (120, 'low'),
+    (121, 'low'),
+    (122, 'low'),
+    (123, 'low'),
+    (124, 'low'),
+    (125, 'low'),
+    (126, 'low'),
+    (127, 'low'),
+    (128, 'low'),
+    (129, 'low'),
+    (130, 'low'),
+    (131, 'low'),
+    (132, 'low'),
+    (133, 'low'),
+    (134, 'low'),
+    (135, 'low'),
+    (136, 'low'),
+    (137, 'low'),
+    (141, 'high'),
+    (145, 193, 'low'),
+    (195, 'low'),
+    (201, 'high'),
+    (218, 238, 'low'),
+    (263, 'high'),
+    (266, 'high'),
+    (271, 'low'),
+    (273, 'low'),
+    (274, 'low'),
+    (276, 'low'),
+    (277, 'low'),
+    (279, 'low'),
+    (283, 288, 'low'),
+    (291, 'low'),
+    (353, 'high'),
+    (359, 'high'),
+    (367, 'high'),
+    (369, 372, 'high'),
+    (416, 'high'),
+    (428, 'high'),
+    (432, 'low'),
+    (447, 'high'),
+    (451, 'high'),
+    (469, 473, 'low'),
+    (492, 'high'),
+    (511, 'high'),
+    (537, 542, 'high'),
+    (549, 'high'),
+    (552, 'low'),
+    (553, 556, 'high'),
+    (565, 570, 'high'),
+    (572, 'low'),
+    (573, 'low'),
+    (666, 'low'),
+    (683, 'low'),
+    (684, 'low'),
+    (1322, 'high'),
+]
+
+
 class DictReaderStrip(csv.DictReader):
     @property
     def fieldnames(self):
         return [name.strip() for name in super().fieldnames]
+
 
 def read_csv(csv_path):
     with open(csv_path, newline='') as csvfile:
@@ -22,9 +130,11 @@ def read_csv(csv_path):
         for row in reader:
             yield row
 
+
 DIFF_URL_REGEX = re.compile(r'^.*/page/(.*)/(.*)\.\.(.*)')
-def find_change_ids(csv_row):
-    diff_url = csv_row['Last Two - Side by Side']
+
+
+def find_change_ids(diff_url):
     regex_result = DIFF_URL_REGEX.match(diff_url)
     if regex_result:
         (page_id, from_version_id, to_version_id) = regex_result.groups()
@@ -34,13 +144,174 @@ def find_change_ids(csv_row):
     else:
         return None
 
+
+def sheet_str(raw):
+    return raw.strip()
+
+
+def sheet_bool(raw):
+    value = raw.lower().strip()
+    if value == '1' or value == 'y' or value == 'yes' or value == 'x':
+        return True
+    elif value == '' or value == '0' or value == 'n' or value == 'no':
+        return False
+    else:
+        raise TypeError(f'Bad value for boolean column: "{raw}"')
+
+
+class AnalystSheet:
+    row_offset = 0
+
+    def __init__(self, csv_path, is_important = False) -> None:
+        self.path = csv_path
+        self.is_important = is_important
+
+
+class V1ChangesSheet(AnalystSheet):
+    schema = (
+        # Useful info for analysts, but mostly duplicative of data in DB.
+        ('Checked (2-significant)', None),
+        ('Index', None),
+        ('Unique ID', 'analyst_sheet_id', sheet_str),
+        ('Output Date/Time', None),
+        ('Agency', None),
+        ('Site Name', None),
+        ('Page Name', None),
+        ('URL', None),
+        ('Page View URL', None),
+        ('Last Two - Side by Side', None),
+        ('Latest to Base - Side by Side', None),
+        ('Date Found - Latest', None),
+        ('Date Found - Base', None),
+        ('Diff length', None),
+        ('Diff hash', None),
+        ('Text diff length', None),
+        ('Text diff hash', None),
+        ('Who Found This?', None),
+
+        ('1', 'page_date_time_change_only', sheet_bool),  # Individual page: Date and time change only
+        ('2', 'page_text_or_numeric_content_change', sheet_bool),  # Individual page: Text or numeric content removal or change
+        ('3', 'page_image_content_change', sheet_bool),  # Individual page: Image content removal or change
+        ('4', 'page_hyperlink_change', sheet_bool),  # Individual page: Hyperlink removal or change
+        ('5', 'page_form_or_interactive_component_change', sheet_bool),  # Individual page: Text-box, entry field, or interactive component removal or change
+        ('6', 'page_page_removal', sheet_bool),  # Individual page: Page removal (whether it has happened in the past or is currently removed)
+        ('7', 'repeat_header_menu_change', sheet_bool),  # Repeated change: Header menu removal or change
+        ('8', 'repeat_template_text_page_format_or_comment_change', sheet_bool),  # Repeated change: Template text, page format, or comment field removal or change
+        ('9', 'repeat_footer_or_site_map_change', sheet_bool),  # Repeated change: Footer or site map removal or change
+        ('10', 'repeat_sidebar_change', sheet_bool),  # Repeated change: Sidebar removal or change
+        ('11', 'repeat_banner_or_ad_change', sheet_bool),  # Repeated change: Banner/advertisement removal or change
+        ('12', 'repeat_scrolling_news', sheet_bool),  # Repeated change: Scrolling news/reports
+        ('1', 'significance_energy_environment_climate', sheet_bool),  # Significant: Change related to energy, environment, or climate
+        ('2', 'significance_language', sheet_bool),  # Significant: Language is significantly altered
+        ('3', 'significance_content_removed', sheet_bool),  # Significant: Content is removed
+        ('4', 'significance_page_removed', sheet_bool),  # Significant: Page is removed
+        ('5', 'significance_not_significant', sheet_bool),  # Significant: Insignificant
+        ('6', 'significance_repeated_insignificant_change', sheet_bool),  # Significant: Repeated Insignificant
+        ('Further Notes', 'notes', sheet_str),
+        ('Choose from drop down menu', 'broad_topic', sheet_str),  # Broad Topic
+        ('', 'keywords', str),  # Keywords
+
+        # There are extra notes in the second of these two columns. Sometimes
+        # they are accidentally put in the first one, so they should be merged.
+        ('Leave blank (used on Patterns sheet)', 'notes_2_a', sheet_str),
+        ('', 'notes_2_b', sheet_str),
+
+        # Ignore this column
+        ('', None),
+    )
+
+    row_offset = 5
+
+    def read_csv(self):
+        with open(self.path, newline='') as csvfile:
+            reader = csv.reader(csvfile)
+            for i in range(self.row_offset):
+                raw_headers = next(reader)
+            expected_headers = [header[0] for header in self.schema]
+            actual_headers = raw_headers[0:len(expected_headers)]
+            if actual_headers != expected_headers:
+                raise CsvSchemaError(f'Sheet did not have expected v1 header row!\n  Expected: {expected_headers}\n    Actual: {raw_headers}')
+            # for row in reader:
+            #     yield {
+            #         header[1] if len(header) > 1 else header[0]: row[index]
+            #         for index, header in enumerate(self.headers)
+            #     }
+            yield from reader
+
+    def parse(self, is_important_changes=False):
+        ids = set()
+        for index, row in enumerate(self.read_csv()):
+            row_number = index + self.row_offset + 1
+            # FIXME: don't use index here
+            change_ids = find_change_ids(row[9])
+            try:
+                annotation = self.create_annotation(row, index, is_important_changes)
+                id = annotation['analyst_sheet_id']
+                if id in ids:
+                    logger.warn(f"DUPLICATE ID: {id}")
+            except Exception as error:
+                raise TypeError(f'Could not parse row {row_number}: {error}')
+
+            if not change_ids:
+                logger.warning(f'failed to extract IDs from row {row_number}')
+            if not annotation:
+                logger.warning(f'failed to extract annotation data from row {row_number}')
+
+            yield {
+                'row': row_number,
+                'change': change_ids,
+                'annotation': annotation
+            }
+
+    def create_annotation(self, csv_row, row_index, is_important_changes=False):
+        annotation = {
+            'annotation_schema': 'edgi_analyst_v1',
+            'annotation_author': csv_row[17],
+        }
+        for index, field in enumerate(self.schema):
+            value = csv_row[index]
+            key = field[1]
+            if key:
+                annotation[key] = field[2](value)
+
+        annotation['notes_2'] = f"{annotation['notes_2_a']} {annotation['notes_2_b']}".strip()
+        del annotation['notes_2_a']
+        del annotation['notes_2_b']
+
+        significance = 0.0
+        if is_important_changes:
+            significance = self.get_row_significance(row_index)
+        annotation['significance'] = significance
+
+        return annotation
+
+    def get_row_significance(self, row_number):
+        value = None
+        offset = self.row_offset + 1
+        for candidate in V1_SIGNIFICANT_ROWS:
+            if row_number == candidate[0] - offset:
+                value = candidate[1] if len(candidate) == 2 else candidate[2]
+                break
+            elif len(candidate) == 3 and row_number > candidate[0] - offset and row_number < candidate[1] - offset:
+                value = candidate[2]
+                break
+        if value == 'low':
+            return 0.5
+        elif value == 'high':
+            return 1.0
+        else:
+            return 0.75
+
+
 class AnnotationAttributeInfo:
     def __init__(self, column_names, json_key):
         self.column_names = column_names
         self.json_key = json_key
 
+
 class CsvSchemaError(Exception):
     ...
+
 
 # If column names ever change while leaving the value semantics intact,
 # add the new  name to the correct list of column names here
@@ -89,13 +360,16 @@ STRING_ANNOTATION_ATTRIBUTES = [AnnotationAttributeInfo(*info) for info in [
      'keywords_to_monitor'),
     (['Further Notes'],
      'further_notes'),
-    (['Ask/tell other working groups?'],
-     'ask_tell_other_working_groups'),
+
+    # Skipping this column; not relevant for archival purposes
+    # (['Ask/tell other working groups?'],
+    #  'ask_tell_other_working_groups'),
 
     # Including this so that we can eventually map it to
     # users in the database
     (['Who Found This?'],
      'annotation_author')]]
+
 
 def get_attribute_value(attribute_info, csv_row):
     for column_name in attribute_info.column_names:
@@ -107,12 +381,13 @@ def get_attribute_value(attribute_info, csv_row):
     raise CsvSchemaError(f'Expected to find one of {attribute_info.column_names} '
                          f'in {csv_row.keys()}')
 
+
 def create_annotation(csv_row, is_important_changes):
     annotation = {}
 
     for attribute_info in BOOL_ANNOTATION_ATTRIBUTES:
         attribute_value = get_attribute_value(attribute_info, csv_row)
-        annotation[attribute_info.json_key] = attribute_value == '1'
+        annotation[attribute_info.json_key] = sheet_bool(attribute_value)
     for attribute_info in STRING_ANNOTATION_ATTRIBUTES:
         attribute_value = get_attribute_value(attribute_info, csv_row)
         annotation[attribute_info.json_key] = attribute_value
@@ -133,33 +408,61 @@ def create_annotation(csv_row, is_important_changes):
 
     return annotation
 
+
 def main():
     doc = """Add analyst annotations from a csv file to the Web Monitoring db.
 
 Usage:
-path/to/annotations_import.py <csv_path> [--is_important_changes]
+path/to/annotations_import.py <csv_path> [options]
 
 Options:
 --is_important_changes  Was this CSV generated from an Important Changes sheet?
+--commit                Send annotatins to DB
+--schema <version>      Should be 'v1' or 'v2'.
 """
     arguments = docopt(doc)
     is_important_changes = arguments['--is_important_changes']
+    commit = arguments['--commit']
+    schema_version = arguments.get('--schema') or 'v2'
     csv_path = arguments['<csv_path>']
+
+    if schema_version == 'v1':
+        sheet = V1ChangesSheet(csv_path)
+        for row in tqdm(sheet.parse(), unit=' rows'):
+            # FIXME: just for testing
+            sleep(0.001)
+            if commit:
+                if row['change'] and row['annotation']:
+                    raise Exception('OH NO')
+                    try:
+                        response = client.add_annotation(**change_ids,
+                                                        annotation=annotation)
+                        logger.debug(response)
+                    except db.WebMonitoringDbError as e:
+                        logger.warning(
+                            f'failed to post annotation for row {row} with error: {e}')
+            else:
+                print(row)
+        return
 
     client = db.Client.from_env()
     # Missing step: Analyze CSV to determine spreadsheet schema version
     for row in tqdm(read_csv(csv_path), unit=' rows'):
-        change_ids = find_change_ids(row)
+        change_ids = find_change_ids(row['Last Two - Side by Side'])
         annotation = create_annotation(row, is_important_changes)
         if not change_ids:
             logger.warning(f'failed to extract IDs from {row}')
         if not annotation:
             logger.warning(f'failed to extract annotation data from {row}')
-        if change_ids and annotation:
-            try:
-                response = client.add_annotation(**change_ids,
-                                                 annotation=annotation)
-                logger.debug(response)
-            except db.WebMonitoringDbError as e:
-                logger.warning(
-                    f'failed to post annotation for row {row} with error: {e}')
+
+        if commit:
+            if change_ids and annotation:
+                try:
+                    response = client.add_annotation(**change_ids,
+                                                    annotation=annotation)
+                    logger.debug(response)
+                except db.WebMonitoringDbError as e:
+                    logger.warning(
+                        f'failed to post annotation for row {row} with error: {e}')
+        else:
+            print(annotation)

--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -265,24 +265,24 @@ class V1ChangesSheet(AnalystSheet):
         ('Text diff hash', None),
         ('Who Found This?', 'annotation_author', sheet_str),
 
-        ('1', 'page_date_time_change_only', sheet_bool),  # Individual page: Date and time change only
-        ('2', 'page_text_or_numeric_content_change', sheet_bool),  # Individual page: Text or numeric content removal or change
-        ('3', 'page_image_content_change', sheet_bool),  # Individual page: Image content removal or change
-        ('4', 'page_hyperlink_change', sheet_bool),  # Individual page: Hyperlink removal or change
-        ('5', 'page_form_or_interactive_component_change', sheet_bool),  # Individual page: Text-box, entry field, or interactive component removal or change
-        ('6', 'page_page_removal', sheet_bool),  # Individual page: Page removal (whether it has happened in the past or is currently removed)
-        ('7', 'repeat_header_menu_change', sheet_bool),  # Repeated change: Header menu removal or change
-        ('8', 'repeat_template_text_page_format_or_comment_change', sheet_bool),  # Repeated change: Template text, page format, or comment field removal or change
-        ('9', 'repeat_footer_or_site_map_change', sheet_bool),  # Repeated change: Footer or site map removal or change
-        ('10', 'repeat_sidebar_change', sheet_bool),  # Repeated change: Sidebar removal or change
-        ('11', 'repeat_banner_or_ad_change', sheet_bool),  # Repeated change: Banner/advertisement removal or change
-        ('12', 'repeat_scrolling_news', sheet_bool),  # Repeated change: Scrolling news/reports
-        ('1', 'significance_energy_environment_climate', sheet_bool),  # Significant: Change related to energy, environment, or climate
-        ('2', 'significance_language', sheet_bool),  # Significant: Language is significantly altered
-        ('3', 'significance_content_removed', sheet_bool),  # Significant: Content is removed
-        ('4', 'significance_page_removed', sheet_bool),  # Significant: Page is removed
-        ('5', 'significance_not_significant', sheet_bool),  # Significant: Insignificant
-        ('6', 'significance_repeated_insignificant_change', sheet_bool),  # Significant: Repeated Insignificant
+        ('1', 'date_time_change_only', sheet_bool),  # Individual page: Date and time change only
+        ('2', 'text_or_numeric_content_change', sheet_bool),  # Individual page: Text or numeric content removal or change
+        ('3', 'image_content_change', sheet_bool),  # Individual page: Image content removal or change
+        ('4', 'hyperlink_change', sheet_bool),  # Individual page: Hyperlink removal or change
+        ('5', 'form_or_interactive_component_change', sheet_bool),  # Individual page: Text-box, entry field, or interactive component removal or change
+        ('6', 'page_removal', sheet_bool),  # Individual page: Page removal (whether it has happened in the past or is currently removed)
+        ('7', 'repeat__header_menu_change', sheet_bool),  # Repeated change: Header menu removal or change
+        ('8', 'repeat__template_text_page_format_or_comment_change', sheet_bool),  # Repeated change: Template text, page format, or comment field removal or change
+        ('9', 'repeat__footer_or_site_map_change', sheet_bool),  # Repeated change: Footer or site map removal or change
+        ('10', 'repeat__sidebar_change', sheet_bool),  # Repeated change: Sidebar removal or change
+        ('11', 'repeat__banner_or_ad_change', sheet_bool),  # Repeated change: Banner/advertisement removal or change
+        ('12', 'repeat__scrolling_news', sheet_bool),  # Repeated change: Scrolling news/reports
+        ('1', 'significance__energy_environment_climate', sheet_bool),  # Significant: Change related to energy, environment, or climate
+        ('2', 'significance__language', sheet_bool),  # Significant: Language is significantly altered
+        ('3', 'significance__content_removed', sheet_bool),  # Significant: Content is removed
+        ('4', 'significance__page_removed', sheet_bool),  # Significant: Page is removed
+        ('5', 'significance__not_significant', sheet_bool),  # Significant: Insignificant
+        ('6', 'significance__repeated_insignificant_change', sheet_bool),  # Significant: Repeated Insignificant
         ('Further Notes', 'notes', sheet_str),
         ('Choose from drop down menu', 'broad_topic', sheet_str),  # Broad Topic
         ('', 'keywords', str),  # Keywords


### PR DESCRIPTION
This project is technically deprecated, but I’m doing some work here to support final shutdown and archival of data (https://github.com/edgi-govdata-archiving/web-monitoring/issues/170).

The main goal here is to import old annotations (different schema than the import script was built to support) and some much newer ones that were never brought into the DB proper. I want them in the DB so we can export a nice SQLite archive that's easy for people to dig through, as opposed to collating data from a variety of sources.

To do:
- [x] Basic support for all schemas
- [x] Support a special file to map author names to e-mails or user IDs (I already made this file; just need to support it here).
- [x] Use this to import annotations
- [x] Manually swap out annotation author foreign key field in DB with user IDs from the `annotation_author` field in the annotations this posts, then remove that field from these annotations (should not have PII in the annotations, but I want to link things correctly and the DB doesn't give us a way to actually do that. Easier to run manual migration on the DB than to change the DB source to support this).