### PR TITLE
Add `--archive-s3 <bucket>` option

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -160,6 +160,7 @@ PDF_MEDIA_TYPES = frozenset((
 SNIFF_MEDIA_TYPES = frozenset((
     'application/octet-stream',
     'application/x-download',
+    'binary/octet-stream',
 ))
 
 # Identifies a bare media type (that is, one without parameters)


### PR DESCRIPTION
This is pretty ugly, but it's a working first cut at the problem and fixes #663. This is suddenly more important since IA seems to be under a lot of load with peopole checking up on Trump-related website changes, and I'm seeing a lot more import-related failures on things that work fine on the processing side and fail to re-download in the DB importer. This will short-circuit that issue.

This ideally would go in a separate worker component, but we just don’t have the right data available from outside `WaybackRecordsWorker` right now. This would also ideally be tested more, but 🤷 