### PR TITLE
Add Brotli support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+brotli ~=1.1.0
 cchardet ==2.1.7
 cloudpathlib[s3] ~=0.20.0
 python-dateutil ~=2.9.0


### PR DESCRIPTION
It turns out that the Wayback Machine is serving us some content with Brotli encoding, even if we don't say we support it, leading to us storing and trying to analyze comprssed data as if it was already decompressed. Requests will use Brotli as long as it is installed, so installing it is all we need to do here.