### PR TITLE
Warcs have useful content too

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-dateutil ~=2.9.0
 docopt ~=0.6.2
 lxml ~=5.3.0
 pypdf[crypto] ~=5.1.0
+PyYAML ~=6.0.2
 sentry-sdk ~=1.14.0
 requests ~=2.32.3
 # We need to specify urllib3 to make sure everyone is using the same version;

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ requests ~=2.32.3
 urllib3 ~=2.3.0
 toolz ~=1.0.0
 tqdm ~=4.67.1
-warcio ~=1.7.5
+warcio[all] ~=1.7.5
 wayback ~=0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ requests ~=2.32.3
 urllib3 ~=2.3.0
 toolz ~=1.0.0
 tqdm ~=4.67.1
+warcio ~=1.7.5
 wayback ~=0.4.5

--- a/scripts/warc_import
+++ b/scripts/warc_import
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+from web_monitoring.cli.warc_import import main
+
+
+if __name__ == '__main__':
+    main()

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -58,7 +58,6 @@ from pathlib import Path
 import re
 import requests
 import sentry_sdk
-import signal
 import threading
 import time
 from tqdm import tqdm

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -667,7 +667,7 @@ def import_ia_urls(urls, *, from_date=None, to_date=None,
     worker_count = worker_count if worker_count > 0 else PARALLEL_REQUESTS
     unplaybackable = load_unplaybackable_mementos(unplaybackable_path)
 
-    with utils.QuitSignal((signal.SIGINT, signal.SIGTERM)) as stop_event:
+    with utils.QuitSignal() as stop_event:
         cdx_records = utils.FiniteQueue()
         cdx_thread = threading.Thread(target=lambda: utils.iterate_into_queue(
             cdx_records,

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -381,8 +381,9 @@ def main():
     seeds = set(read_seeds_file(args.seeds))
     total = min(len(seeds), args.limit or float('inf'))
 
-    chains = islice(each_redirect_chain(args.warc_path, seeds=seeds),
-                    args.limit)
+    chains = each_redirect_chain(args.warc_path, seeds=seeds)
+    chains = utils.QuitSignal().stop_iteration(islice(chains, args.limit))
+
     versions = ((format_version(c), c.requests[-1].response_body)
                 for c in chains)
     versions = (preupload(storage, version, body)

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -166,6 +166,12 @@ class RequestRecords:
             location = self.response.http_headers.get_header('location')
             if status.startswith('3') and location:
                 return urljoin(self.url, location)
+            # Amazon WAF browser challenge works reloading the same URL with a
+            # cookie. Treat this like a redirect; we should have captured the
+            # second request to the same URL.
+            elif status == '202' and self.response.http_headers.get_header('x-amzn-waf-action') == 'challenge':
+                logger.warning(f'Handling Amazon WAF challenge: "{self.url}"')
+                return self.url
 
         return ''
 

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import dateutil.parser
 from functools import lru_cache
 import gzip

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -296,7 +296,6 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
 
             request_set = RequestRecords(request.uri, warc_info=warc_info)
             response_record, body = extract_record(warc_path, request.response.offset)
-            logger.warning(f'Adding {response_record.rec_type} for "{next_url}" (seed "{seed}")')
             request_set.add(
                 response_record,
                 index=0,

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -550,7 +550,7 @@ def format_version(chain: RedirectChain) -> dict:
         body_url=None,
         body_hash=utils.hash_content(final.response_body),
         status=int(final.response.http_headers.get_statuscode()),
-        headers=dict(final.response.http_headers.headers),
+        headers={k.lower(): v for k, v in final.response.http_headers.headers},
         source_type='edgi_crawl_v0',
         source_metadata=metadata,
         media_type=media_type or None,

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -295,6 +295,10 @@ def each_redirect_chain(warcs: list[str], seeds: set[str]) -> Generator[Redirect
 
     logger.info('Yielding matching records for seeds...')
     for seed in seeds:
+        # FIXME: This approach expects each seed will only be requested once in
+        # the collection of WARCs being examined, which is not necessarily
+        # accurate. It's good enough for WARCs we create with Browsertrix, but
+        # not other sources that may have been collected differently.
         chain = RedirectChain()
         next_url = seed
         next_timestamp = datetime(1, 1, 1, tzinfo=timezone.utc)

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -349,7 +349,11 @@ def main():
                 print(json.dumps(version))
         else:
             import_ids = db_client.add_versions(
-                progress,
+                # HACK: this generator expression comprehension is here to make
+                # sure the sequence of versions has no known length. (tqdm's
+                # iterator has a length, which causes problems for batching).
+                # https://github.com/pytoolz/toolz/issues/602
+                (version for version in progress),
                 create_pages=False,
                 skip_unchanged_versions=False
             )

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -280,7 +280,7 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
                             else:
                                 break
 
-                        if not chain.requests[-1].redirect_target:
+                        if chain.requests[-1].response and not chain.requests[-1].redirect_target:
                             for request in chain.requests:
                                 del open_redirects[request.url]
 

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -287,7 +287,9 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
                     logger.warning(f'No WARC records for seed: "{seed}"')
                 else:
                     logger.error(f'Incomplete redirect chain for seed: "{seed}" (no records for "{next_url}")')
-                continue
+                chain = None
+                next_url = None
+                break
 
             request = next((r for r in requests if r.timestamp > next_timestamp), requests[-1])
             assert request.response, f'Request index entry missing response record for "{request.uri}" at {request.timestamp}'
@@ -315,7 +317,8 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
             next_url = request_set.redirect_target
             next_timestamp = request.timestamp + timedelta(minutes=1)
 
-        yield chain
+        if chain:
+            yield chain
 
 
 # def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, None, None]:

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -189,6 +189,7 @@ def parse_warc_fields(record: ArcWarcRecord) -> StatusAndHeaders:
 @lru_cache(maxsize=256)
 def extract_record(warc: str, offset: int) -> tuple[ArcWarcRecord, bytes]:
     with open(warc, 'rb') as file:
+        file.seek(offset)
         record = next(iter(ArchiveIterator(file)))
         return record, record.content_stream().read()
 

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -208,7 +208,7 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
     seen_seeds: set[str] = set()
     warc_info: dict[str, Any] = {}
 
-    response_index = {}
+    response_index: dict[str, int] = {}
 
     warc_path = Path(warc).absolute()
     warc_info['warc_name'] = warc_path.name
@@ -271,7 +271,8 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
                                 offset = response_index.get(redirect)
                                 if offset:
                                     target_record, body = extract_record(warc_path, offset)
-                                    request = RequestRecords(redirect)
+                                    assert target_record.rec_type == 'response', f'Record should be response, but was "{target_record.rec_type}" (in middle)'
+                                    request = RequestRecords(redirect, warc_info=warc_info)
                                     request.add(target_record, last.last_index, offset=offset, length=0, body=body)
                                     chain.add(request)
                                     if request.redirect_target:
@@ -294,7 +295,8 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
                     offset = response_index.get(redirect)
                     if offset:
                         target_record, body = extract_record(warc_path, offset)
-                        request = RequestRecords(redirect)
+                        assert target_record.rec_type == 'response', f'Record should be response, but was "{target_record.rec_type}" (after end)'
+                        request = RequestRecords(redirect, warc_info=warc_info)
                         request.add(target_record, last.last_index, offset=offset, length=0, body=body)
                         chain.add(request)
                     else:

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -212,6 +212,8 @@ def each_redirect_chain(warc: str, seeds: set[str]) -> Generator[RedirectChain, 
         reader = ArchiveIterator(warc_file)
         for index, record in enumerate(reader):
             if record.rec_type == 'warcinfo':
+                # TODO: There might be other stuff we want to read in WARCs
+                # generated from non-Browsertrix sources.
                 info = parse_warc_fields(record)
                 if 'software' in info:
                     warc_info['crawler'] = info['software']
@@ -361,6 +363,8 @@ def main():
                         help='Update existing records in DB instead of skipping')
     args = parser.parse_args()
 
+    # TODO: we'll probably eventually want to support WARCs from IA or maybe
+    # other sources. This will need
     if not args.seeds:
         print('For now, you *must* supply a Browsertrix `pages.jsonl` file as the `--seeds` option')
         sys.exit(1)

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -357,6 +357,8 @@ def main():
     parser.add_argument('--archive-s3', help='S3 bucket to upload raw response bodies to.', required=True)
     parser.add_argument('--dry-run', action='store_true', help='Do not actually upload results')
     parser.add_argument('--limit', type=int, help='Stop after this many records')
+    parser.add_argument('--update', action='store_const', default='skip', const='replace',
+                        help='Update existing records in DB instead of skipping')
     args = parser.parse_args()
 
     if not args.seeds:
@@ -391,7 +393,8 @@ def main():
             import_ids = db_client.add_versions(
                 (version for version, _ in progress),
                 create_pages=False,
-                skip_unchanged_versions=False
+                skip_unchanged_versions=False,
+                update=args.update
             )
 
     if import_ids:

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -501,10 +501,11 @@ def format_version(chain: RedirectChain) -> dict:
 
     metadata = {
         **final.warc_info,
-        'warc_page_id': final.response.rec_headers.get('WARC-Page-ID'),
+        # 'warc_page_id': final.response.rec_headers.get('WARC-Page-ID'),
         'warc_records': [meta
                          for requests in chain.requests
-                         for meta in requests.metadata],
+                         for meta in requests.metadata
+                         if meta['type'] == 'response'],
     }
 
     record_metadata = final.response.rec_headers.get('WARC-JSON-Metadata')

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -359,7 +359,7 @@ def main():
             )
 
     if len(import_ids):
-        print('Wiating for import jobs to complete...', file=sys.stderr)
+        print('Waiting for import jobs to complete...', file=sys.stderr)
         errors = db_client.monitor_import_statuses(import_ids)
         total = sum(len(job_errors) for job_errors in errors.values())
         if total > 0:

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -13,6 +13,7 @@ import re
 import sys
 import threading
 from typing import Any, Generator
+from urllib.parse import urljoin
 from cloudpathlib import S3Client, S3Path
 import sentry_sdk
 from tqdm.contrib.logging import tqdm_logging_redirect
@@ -132,7 +133,7 @@ class RequestRecords:
             status = self.response.http_headers.get_statuscode()
             location = self.response.http_headers.get_header('location')
             if status.startswith('3') and location:
-                return location
+                return urljoin(self.url, location)
 
         return ''
 

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -326,9 +326,12 @@ def main():
 
     db_client = db.Client.from_env()
 
-    storage = S3HashStore(args.archive_s3, gzip=True, dry_run=True, extra_args={
-        'ACL': 'public-read'
-    })
+    storage = S3HashStore(
+        args.archive_s3,
+        gzip=True,
+        dry_run=args.dry_run,
+        extra_args={'ACL': 'public-read'}
+    )
 
     seeds = set(read_seeds_file(args.seeds))
     total = len(seeds)

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -375,7 +375,7 @@ def main():
     )
 
     seeds = set(read_seeds_file(args.seeds))
-    total = min(len(seeds), args.limit or 0)
+    total = min(len(seeds), args.limit or float('inf'))
 
     chains = islice(each_redirect_chain(args.warc_path, seeds=seeds),
                     args.limit)

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -1,0 +1,354 @@
+from argparse import ArgumentParser
+from dataclasses import dataclass, field
+import gzip
+from itertools import islice
+import json
+import logging
+from pathlib import Path
+import re
+import sys
+import threading
+from typing import Generator, Iterable
+from cloudpathlib import S3Client, S3Path
+import sentry_sdk
+from tqdm.contrib.logging import tqdm_logging_redirect
+from warcio import ArchiveIterator
+from warcio.recordloader import ArcWarcRecord, StatusAndHeadersParser, StatusAndHeaders
+from .. import db
+from .. import utils
+from ..utils import detect_encoding, sniff_media_type
+
+
+logger = logging.getLogger(__name__)
+
+
+# FIXME: share with `cli.py`
+# We do some parsing of HTML and PDF documents to extract the title before
+# importing the document. These media types are used to determine whether and
+# how to parse the document.
+HTML_MEDIA_TYPES = frozenset((
+    'application/html',
+    'application/xhtml',
+    'application/xhtml+xml',
+    'application/xml',
+    'application/xml+html',
+    'application/xml+xhtml',
+    'text/webviewhtml',
+    'text/html',
+    'text/x-server-parsed-html',
+    'text/xhtml',
+))
+PDF_MEDIA_TYPES = frozenset((
+    'application/pdf',
+    'application/x-pdf',
+))
+# These media types are so meaningless that it's worth sniffing the content to
+# see if we can determine an actual media type.
+SNIFF_MEDIA_TYPES = frozenset((
+    'application/octet-stream',
+    'application/x-download',
+    'binary/octet-stream',
+))
+# Identifies a bare media type (that is, one without parameters)
+MEDIA_TYPE_EXPRESSION = re.compile(r'^\w+/\w[\w+_\-.]+$')
+
+
+# FIXME: share with `cli.py`
+class S3HashStore:
+    """
+    Store and track content-addressed data in S3.
+    """
+
+    def __init__(self, bucket: str, gzip: bool = False, extra_args: dict = {}, dry_run: bool = False) -> None:
+        self.bucket = bucket
+        self.extra_args = extra_args
+        self.gzip = gzip
+        if gzip:
+            self.extra_args['ContentEncoding'] = 'gzip'
+        self.seen_hashes = set()
+        self.lock = threading.Lock()
+        self.dry_run = dry_run
+
+    def store(self, data: bytes, hash: str = '', content_type: str = '') -> str:
+        if not hash:
+            hash = utils.hash_content(data)
+
+        if not content_type:
+            content_type = 'application/octet-stream'
+
+        archive = S3Path(f's3://{self.bucket}', client=S3Client(extra_args={
+            **self.extra_args,
+            'ContentType': content_type
+        }))
+        path = archive / hash
+
+        upload = False
+        with self.lock:
+            if hash not in self.seen_hashes:
+                self.seen_hashes.add(hash)
+                upload = True
+
+        if upload and not path.exists():
+            logger.info(f'Uploading to S3 (hash={hash})')
+            if self.gzip:
+                data = gzip.compress(data)
+            if not self.dry_run:
+                path.write_bytes(data)
+
+        return path.as_url()
+
+
+def read_seeds_file(seeds_path: str) -> list[str]:
+    with open(seeds_path, 'r') as file:
+        try:
+            first = json.loads(file.readline())
+            if first['format'] != 'json-pages-1.0':
+                raise ValueError(f'Incorrect format: {first["format"]}')
+        except Exception:
+            raise ValueError('Seeds file is not a Browsertrix "json-pages-1.0" file.')
+
+        pages = (json.loads(line) for line in file if line != '')
+        return [page['url'] for page in pages if page['seed']]
+
+
+@dataclass
+class RequestRecords:
+    url: str
+    records: list[ArcWarcRecord] = field(default_factory=list)
+    request: ArcWarcRecord | None = None
+    response: ArcWarcRecord | None = None
+    response_body: bytes = b''
+    last_index: int = 0
+    warc_info: dict | None = None
+
+    @property
+    def redirect_target(self) -> str:
+        if self.response:
+            status = self.response.http_headers.get_statuscode()
+            location = self.response.http_headers.get_header('location')
+            if status.startswith('3') and location:
+                return location
+
+        return ''
+
+    def add(self, record: ArcWarcRecord, index: int) -> None:
+        self.records.append(record)
+        self.last_index = index
+        if record.rec_type == 'response':
+            self.response = record
+            self.response_body = record.content_stream().read()
+        elif record.rec_type == 'request':
+            self.request = record
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __eq__(self, other) -> bool:
+        return self is other
+
+
+@dataclass
+class RedirectChain:
+    requests: list[RequestRecords] = field(default_factory=list)
+
+    def add(self, request: RequestRecords) -> None:
+        if request not in self.requests:
+            self.requests.append(request)
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __eq__(self, other) -> bool:
+        return self is other
+
+
+def parse_warc_fields(record: ArcWarcRecord) -> StatusAndHeaders:
+    if record.rec_headers.get('content-type') != 'application/warc-fields':
+        raise ValueError('Record does not have "application/warc-fields" content')
+
+    parser = StatusAndHeadersParser([], verify=False)
+    return parser.parse(record.content_stream(), 'WARC/1.1').headers
+
+
+def each_redirect_chain(warc_path: str, seeds: set[str]) -> Generator[RedirectChain, None, None]:
+    max_open_request_age = 250
+    open_requests: dict[str, RequestRecords] = {}
+    open_redirects: dict[str, RedirectChain] = {}
+
+    warc_info = {'warc_name': Path(warc_path).name}
+
+    with open(warc_path, 'rb') as warc_file:
+        for index, record in enumerate(ArchiveIterator(warc_file)):
+            if record.rec_type == 'warcinfo':
+                info = parse_warc_fields(record)
+                if 'software' in info:
+                    warc_info['crawler'] = info['software']
+                continue
+
+            target = record.rec_headers.get_header('WARC-Target-URI')
+            request = open_requests.get(target)
+            if request is None and target not in seeds and target not in open_redirects:
+                continue
+
+            if not request:
+                request = RequestRecords(target, warc_info=warc_info)
+                open_requests[target] = request
+
+            request.add(record, index)
+
+            chain = open_redirects.get(target)
+            if not chain:
+                chain = RedirectChain()
+                open_redirects[target] = chain
+            chain.add(request)
+
+            if request.redirect_target:
+                open_redirects[request.redirect_target] = chain
+
+            if index >= max_open_request_age:
+                for chain in set(open_redirects.values()):
+                    last = chain.requests[-1]
+                    if last.last_index + max_open_request_age < index and not last.redirect_target:
+                        for request in chain.requests:
+                            del open_redirects[request.url]
+
+                        yield chain
+
+        for chain in set(open_redirects.values()):
+            yield chain
+
+
+def get_response_media(response: ArcWarcRecord) -> tuple[str, str]:
+    """Extract media type and media type parameters from a memento."""
+    media, *parameters = response.http_headers.get('Content-Type', '').split(';')
+
+    # Clean up media type
+    media = media.strip().lower()
+    if not MEDIA_TYPE_EXPRESSION.match(media):
+        url = response.rec_headers.get('WARC-Target-URI')
+        logger.info('Unknown media type "%s" for "%s"', media, url)
+        media = ''
+
+    # Clean up whitespace, remove empty parameters, etc.
+    clean_parameters = (param.strip() for param in parameters)
+    parameters = [param for param in clean_parameters if param]
+    parameter_string = '; '.join(parameters)
+
+    return media, parameter_string
+
+
+def format_version(chain: RedirectChain) -> dict:
+    final = chain.requests[-1]
+    final_response = final.response
+    assert final_response
+
+    iso_date = chain.requests[0].response.rec_headers.get_header('WARC-Date')
+    assert len(iso_date) >= 20 and iso_date.endswith('Z')
+
+    metadata = {
+        **final.warc_info,
+        'warc_page_id': final.response.rec_headers.get('WARC-Page-ID'),
+        'warc_record_ids': [r.rec_headers.get('WARC-Record-ID')
+                            for requests in chain.requests
+                            for r in requests.records],
+    }
+
+    record_metadata = final.response.rec_headers.get('WARC-JSON-Metadata')
+    if record_metadata:
+        try:
+            metadata['warc_record_meta'] = json.loads(record_metadata)
+        except Exception as error:
+            logger.warning(f'Error parsing WARC-JSON-Metadata: {error}')
+
+    for request in chain.requests:
+        if request.request:
+            metadata['user_agent'] = request.request.http_headers.get_header('user-agent')
+            break
+
+    # If there were redirects, list every URL in the chain of requests.
+    if len(chain.requests) > 1:
+        metadata['redirected_url'] = final.url
+        metadata['redirects'] = [r.url for r in chain.requests]
+        metadata['statuses'] = [r.response.http_headers.get_statuscode() for r in chain.requests]
+
+    media_type, media_type_parameters = get_response_media(final_response)
+    if not media_type or media_type in SNIFF_MEDIA_TYPES:
+        media_type = sniff_media_type(final_response.content_stream().read(), media_type)
+
+    title = ''
+    if media_type in HTML_MEDIA_TYPES:
+        encoding = detect_encoding(final.response_body, final.response.http_headers)
+        title = utils.extract_title(final.response_body, encoding)
+    elif media_type in PDF_MEDIA_TYPES or final.response_body.startswith(b'%PDF-'):
+        title = utils.extract_pdf_title(final.response_body) or title
+
+    return dict(
+        url=chain.requests[0].url,
+        capture_time=iso_date,
+        body_url=None,
+        body_hash=utils.hash_content(final.response_body),
+        status=int(final.response.http_headers.get_statuscode()),
+        headers=dict(final.response.http_headers.headers),
+        source_type='edgi_crawl_v0',
+        source_metadata=metadata,
+        media_type=media_type or None,
+        content_length=len(final.response_body),
+        title=title,
+    )
+
+
+def format_and_preupload(redirect_chains: Iterable[RedirectChain], storage: S3HashStore) -> Generator[dict, None, None]:
+    for chain in redirect_chains:
+        version = format_version(chain)
+        url = storage.store(
+            chain.requests[-1].response_body,
+            hash=version['body_hash'],
+            content_type=version['media_type']
+        )
+        version['body_url'] = url
+        yield version
+
+
+def main():
+    sentry_sdk.init()
+
+    parser = ArgumentParser()
+    parser.add_argument('warc_path', help='Path to WARC file to extract data from')
+    parser.add_argument('--seeds', help='List of seed URLs to extract from WARC.')
+    parser.add_argument('--archive-s3', help='S3 bucket to upload raw response bodies to.', required=True)
+    parser.add_argument('--dry-run', action='store_true', help='Do not actually upload results')
+    parser.add_argument('--limit', type=int, help='Stop after this many records')
+    args = parser.parse_args()
+
+    if not args.seeds:
+        print('For now, you *must* supply a Browsertrix `pages.jsonl` file as the `--seeds` option')
+        sys.exit(1)
+
+    storage = S3HashStore(args.archive_s3, gzip=True, dry_run=True, extra_args={
+        'ACL': 'public-read'
+    })
+
+    seeds = set(read_seeds_file(args.seeds))
+    total = len(seeds)
+
+    records = each_redirect_chain(args.warc_path, seeds=seeds)
+    versions = format_and_preupload(records, storage)
+    if args.limit:
+        versions = islice(versions, args.limit)
+        total = args.limit
+
+    with tqdm_logging_redirect(versions, total=total) as progress:
+        if args.dry_run:
+            for version in progress:
+                print(json.dumps(version))
+        else:
+            db_client = db.Client.from_env()
+            db_client.add_versions(
+                versions,
+                create_pages=False,
+                skip_unchanged_versions=False
+            )
+
+
+if __name__ == '__main__':
+    main()

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -346,7 +346,7 @@ def main():
                 print(json.dumps(version))
         else:
             import_ids = db_client.add_versions(
-                versions,
+                progress,
                 create_pages=False,
                 skip_unchanged_versions=False
             )

--- a/web_monitoring/media.py
+++ b/web_monitoring/media.py
@@ -1,0 +1,142 @@
+import logging
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+# We do some parsing of HTML and PDF documents to extract the title before
+# importing the document. These media types are used to determine whether and
+# how to parse the document.
+HTML_MEDIA_TYPES = frozenset((
+    'application/html',
+    'application/xhtml',
+    'application/xhtml+xml',
+    'application/xml',
+    'application/xml+html',
+    'application/xml+xhtml',
+    'text/webviewhtml',
+    'text/html',
+    'text/x-server-parsed-html',
+    'text/xhtml',
+))
+PDF_MEDIA_TYPES = frozenset((
+    'application/pdf',
+    'application/x-pdf',
+))
+
+# These media types are so meaningless that it's worth sniffing the content to
+# see if we can determine an actual media type.
+SNIFF_MEDIA_TYPES = frozenset((
+    'application/octet-stream',
+    'application/x-download',
+    'binary/octet-stream',
+))
+
+# Identifies a bare media type (that is, one without parameters)
+MEDIA_TYPE_EXPRESSION = re.compile(r'^\w+/\w[\w+_\-.]+$')
+
+# Patterns used to sniff various media types. Based on:
+# - https://dev.w3.org/html5/cts/html5-type-sniffing.html
+# - https://mimesniff.spec.whatwg.org/#rules-for-identifying-an-unknown-mime-type
+#
+# NOTE: a "verbose" regex would be nice here, but they don't seem to work with
+# binary strings.
+SNIFF_HTML_HINTS = (
+    rb'<!DOCTYPE HTML',
+    rb'<HTML',
+    rb'<HEAD',
+    rb'<SCRIPT',
+    rb'<IFRAME',
+    rb'<H1',
+    rb'<DIV',
+    rb'<FONT',
+    rb'<TABLE',
+    rb'<A',
+    rb'<STYLE',
+    rb'<TITLE',
+    rb'<B',
+    rb'<BODY',
+    rb'<BR',
+    rb'<P',
+    rb'<!--',
+)
+
+SNIFF_HTML_PATTERN = re.compile(
+    rb'^[\s\n\r]*(%s)[\s\n\r>]' % b'|'.join(SNIFF_HTML_HINTS),
+    re.IGNORECASE
+)
+
+SNIFF_MEDIA_TYPE_PATTERNS = {
+    SNIFF_HTML_PATTERN: 'text/html',
+    re.compile(rb'^[\s\n\r]*<?xml'): 'text/xml',
+    re.compile(rb'^%PDF-'): 'application/pdf',
+    re.compile(rb'^%!PS-Adobe-'): 'application/postscript',
+    re.compile(rb'^(GIF87a|GIF89a)'): 'image/gif',
+    re.compile(rb'^\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'): 'image/png',
+    re.compile(rb'^\xFF\xD8\xFF'): 'image/jpeg',
+    re.compile(rb'^BM'): 'image/bmp',
+}
+
+
+def sniff_media_type(content, default='application/octet-stream'):
+    """
+    Detect the media type of some content. If the media type can't be detected,
+    the value of the ``default`` parameter will be returned.
+
+    This is similar to how browsers do it and is based on:
+    - https://dev.w3.org/html5/cts/html5-type-sniffing.html
+    - https://mimesniff.spec.whatwg.org/#rules-for-identifying-an-unknown-mime-type
+
+    Parameters
+    ----------
+    content : bytes
+    default : str or None
+
+    Returns
+    -------
+    str
+        The detected media type of the content.
+    """
+    for pattern, media_type in SNIFF_MEDIA_TYPE_PATTERNS.items():
+        if pattern.match(content):
+            return media_type
+
+    return default
+
+
+def read_media_type(headers: dict[str, str], url: str = '') -> tuple[str, str]:
+    """
+    Read media type and media type parameters from a set of HTTP headers. Pass
+    an optional URL for better debug logging.
+    """
+    media, *parameters = headers.get('Content-Type', '').split(';')
+
+    # Clean up media type
+    media = media.strip().lower()
+    if not MEDIA_TYPE_EXPRESSION.match(media):
+        url_info = f' for "{url}"' if url else ''
+        logger.info('Unknown media type "%s"%s', media, url_info)
+        media = ''
+
+    # Clean up whitespace, remove empty parameters, etc.
+    clean_parameters = (param.strip() for param in parameters)
+    parameters = [param for param in clean_parameters if param]
+    parameter_string = '; '.join(parameters)
+
+    return media, parameter_string
+
+
+def find_media_type(headers: dict[str, str], content: bytes = b'', url: str = '') -> tuple[str, str]:
+    """
+    Determine the media type of an HTTP response. This will attempt to read an
+    expicitly set media type from the headers, but will fall back to sniffing
+    if necessary.
+
+    This may return empty strings if a media type cannot be found.
+    """
+    media_type, media_type_parameters = read_media_type(headers, url)
+    if not media_type or media_type in SNIFF_MEDIA_TYPES:
+        media_type = sniff_media_type(content, media_type)
+
+    return media_type, media_type_parameters

--- a/web_monitoring/tests/support.py
+++ b/web_monitoring/tests/support.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def get_fixture_bytes(filename):
+    filepath = Path(__file__).parent / 'fixtures' / filename
+    with filepath.open('rb') as file:
+        return file.read()

--- a/web_monitoring/tests/test_media.py
+++ b/web_monitoring/tests/test_media.py
@@ -1,0 +1,29 @@
+from support import get_fixture_bytes
+from web_monitoring.media import sniff_media_type
+
+
+class TestSniffMediaType:
+    def test_sniff_media_type_detects_html(self):
+        raw_bytes = b'''
+            <!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+            <html>
+            <head>
+                <title>Test Page</title>
+            </head>
+            <body>
+                Test
+            </body>
+            </html>
+        '''
+        media = sniff_media_type(raw_bytes)
+        assert media == 'text/html'
+
+    def test_sniff_media_type_detects_pdf(self):
+        raw_bytes = get_fixture_bytes('basic_title.pdf')
+        media = sniff_media_type(raw_bytes)
+        assert media == 'application/pdf'
+
+    def test_sniff_media_type_uses_default_parameter_as_fallback(self):
+        raw_bytes = b'This is just a random string'
+        media = sniff_media_type(raw_bytes, 'my/default')
+        assert media == 'my/default'

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -1,7 +1,9 @@
 import cchardet
+from cloudpathlib import S3Client, S3Path
 import codecs
 from datetime import datetime, timedelta, timezone
 import dateutil.parser
+import gzip
 import hashlib
 import io
 import logging
@@ -98,76 +100,7 @@ def detect_encoding(content, headers, default='utf-8'):
     return encoding
 
 
-# Patterns used to sniff various media types. Based on:
-# - https://dev.w3.org/html5/cts/html5-type-sniffing.html
-# - https://mimesniff.spec.whatwg.org/#rules-for-identifying-an-unknown-mime-type
-#
-# NOTE: a "verbose" regex would be nice here, but they don't seem to work with
-# binary strings.
-SNIFF_HTML_HINTS = (
-    rb'<!DOCTYPE HTML',
-    rb'<HTML',
-    rb'<HEAD',
-    rb'<SCRIPT',
-    rb'<IFRAME',
-    rb'<H1',
-    rb'<DIV',
-    rb'<FONT',
-    rb'<TABLE',
-    rb'<A',
-    rb'<STYLE',
-    rb'<TITLE',
-    rb'<B',
-    rb'<BODY',
-    rb'<BR',
-    rb'<P',
-    rb'<!--',
-)
-
-SNIFF_HTML_PATTERN = re.compile(
-    rb'^[\s\n\r]*(%s)[\s\n\r>]' % b'|'.join(SNIFF_HTML_HINTS),
-    re.IGNORECASE
-)
-
-SNIFF_MEDIA_TYPE_PATTERNS = {
-    SNIFF_HTML_PATTERN: 'text/html',
-    re.compile(rb'^[\s\n\r]*<?xml'): 'text/xml',
-    re.compile(rb'^%PDF-'): 'application/pdf',
-    re.compile(rb'^%!PS-Adobe-'): 'application/postscript',
-    re.compile(rb'^(GIF87a|GIF89a)'): 'image/gif',
-    re.compile(rb'^\x89\x50\x4E\x47\x0D\x0A\x1A\x0A'): 'image/png',
-    re.compile(rb'^\xFF\xD8\xFF'): 'image/jpeg',
-    re.compile(rb'^BM'): 'image/bmp',
-}
-
-
-def sniff_media_type(content, default='application/octet-stream'):
-    """
-    Detect the media type of some content. If the media type can't be detected,
-    the value of the ``default`` parameter will be returned.
-
-    This is similar to how browsers do it and is based on:
-    - https://dev.w3.org/html5/cts/html5-type-sniffing.html
-    - https://mimesniff.spec.whatwg.org/#rules-for-identifying-an-unknown-mime-type
-
-    Parameters
-    ----------
-    content : bytes
-    default : str or None
-
-    Returns
-    -------
-    str
-        The detected media type of the content.
-    """
-    for pattern, media_type in SNIFF_MEDIA_TYPE_PATTERNS.items():
-        if pattern.match(content):
-            return media_type
-
-    return default
-
-
-def extract_title(content_bytes, encoding='utf-8'):
+def extract_html_title(content_bytes, encoding='utf-8'):
     "Return content of <title> tag as string. On failure return empty string."
     content_str = content_bytes.decode(encoding=encoding, errors='ignore')
     # The parser expects a file-like, so we mock one.
@@ -446,6 +379,64 @@ class QuitSignal(Signal):
     def __enter__(self):
         super().__enter__()
         return self.event
+
+
+class S3HashStore:
+    """
+    Store and track content-addressed data in S3. This relies on standard
+    AWS environment variables or configuration files for authentication.
+
+    Parameters
+    ----------
+    bucket : str
+        The name of the S3 bucket to store content in.
+    gzip : bool, default=False
+        Whether to gzip data before storing it.
+    extra_args : dict, optional
+        Boto3 "extra args" that are used with various operations as applicable.
+        For more info, see: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer
+    dry_run : bool, default=False
+        If true, calls to ``store`` do not actually upload. Allows this to be
+        used in test/debug workflows without significantly altering logic.
+    """
+
+    def __init__(self, bucket: str, gzip: bool = False, extra_args: dict = {}, dry_run: bool = False) -> None:
+        self.bucket = bucket
+        self.extra_args = extra_args
+        self.gzip = gzip
+        if gzip:
+            self.extra_args['ContentEncoding'] = 'gzip'
+        self.seen_hashes = set()
+        self.lock = threading.Lock()
+        self.dry_run = dry_run
+
+    def store(self, data: bytes, hash: str = '', content_type: str = '') -> str:
+        if not hash:
+            hash = hash_content(data)
+
+        if not content_type:
+            content_type = 'application/octet-stream'
+
+        archive = S3Path(f's3://{self.bucket}', client=S3Client(extra_args={
+            **self.extra_args,
+            'ContentType': content_type
+        }))
+        path = archive / hash
+
+        upload = False
+        with self.lock:
+            if hash not in self.seen_hashes:
+                self.seen_hashes.add(hash)
+                upload = True
+
+        if upload and not self.dry_run and not path.exists():
+            logger.info(f'Uploading to S3 (hash={hash})')
+            if self.gzip:
+                data = gzip.compress(data)
+            if not self.dry_run:
+                path.write_bytes(data)
+
+        return path.as_url()
 
 
 # Values correspond to `timedelta` keyword arguments.


### PR DESCRIPTION
We now have some of our own crawls, and need to import data from the resulting WARCs. This scripts runs through a WARC file and uploads the bodies to our hash storage and the creates an import job with the resulting "versions".

This is a little biased towards WARCs output by Browsertrix.crawler, because that's what we're using right now. It will probably need some adapting to work with other WARCs, if and when we encounter them (hopefully from IA soon!).

While I was at it, I updated the import code to use the “new” import format (from several years ago!) that we never updated to before. It makes things much clearer.