### PR TITLE
Ask for less data from Wayback during healthcheck

### DIFF
--- a/web_monitoring/cli/ia_healthcheck.py
+++ b/web_monitoring/cli/ia_healthcheck.py
@@ -63,7 +63,7 @@ def wayback_has_captures(url, from_date=None):
     list of JSON
     """
     with WaybackClient() as wayback:
-        versions = wayback.search(url, from_date=from_date)
+        versions = wayback.search(url, from_date=from_date, limit=1)
         try:
             next(versions)
         except StopIteration:


### PR DESCRIPTION
This is a pretty tiny performance update to the healthcheck script, but helpful. Just happened to notice it today.