### PR TITLE
Add `--from` and `--sample` opts to healthcheck

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -44,7 +44,8 @@ and results between them.
 from cloudpathlib import CloudPath, S3Client, S3Path
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from web_monitoring.utils import detect_encoding, sniff_media_type
+from web_monitoring.utils import (cli_datetime, detect_encoding,
+                                  sniff_media_type)
 import dateutil.parser
 from docopt import docopt
 from itertools import islice
@@ -942,25 +943,6 @@ def _is_page(version):
             splitext(urlparse(version.url).path)[1] not in SUBRESOURCE_EXTENSIONS)
 
 
-def _parse_date_argument(date_string):
-    """Parse a CLI argument that should represent a date into a datetime"""
-    if not date_string:
-        return None
-
-    try:
-        hours = float(date_string)
-        return datetime.utcnow() - timedelta(hours=hours)
-    except ValueError:
-        pass
-
-    try:
-        return dateutil.parser.parse(date_string)
-    except ValueError:
-        pass
-
-    return None
-
-
 def _parse_path(path_string):
     if path_string is None:
         return None
@@ -1075,16 +1057,16 @@ Options:
                 urls=[arguments['<url>']],
                 maintainers=arguments.get('--maintainer'),
                 tags=arguments.get('--tag'),
-                from_date=_parse_date_argument(arguments['<from_date>']),
-                to_date=_parse_date_argument(arguments['<to_date>']),
+                from_date=cli_datetime(arguments['<from_date>']),
+                to_date=cli_datetime(arguments['<to_date>']) if arguments['<to_date>'] else None,
                 skip_unchanged=skip_unchanged,
                 unplaybackable_path=unplaybackable_path,
                 dry_run=arguments.get('--dry-run'),
                 archive_storage=archive_storage)
         elif arguments['ia-known-pages']:
             import_ia_db_urls(
-                from_date=_parse_date_argument(arguments['<from_date>']),
-                to_date=_parse_date_argument(arguments['<to_date>']),
+                from_date=cli_datetime(arguments['<from_date>']),
+                to_date=cli_datetime(arguments['<to_date>']) if arguments['<to_date>'] else None,
                 maintainers=arguments.get('--maintainer'),
                 tags=arguments.get('--tag'),
                 skip_unchanged=skip_unchanged,

--- a/web_monitoring/cli/ia_healthcheck.py
+++ b/web_monitoring/cli/ia_healthcheck.py
@@ -6,13 +6,12 @@
 # to check that each has been captured at least once in the last few days.
 
 from argparse import ArgumentParser
-from datetime import datetime, timedelta, timezone
-import dateutil.parser
 import random
 import sentry_sdk
 import sys
 from wayback import WaybackClient
 from .. import db
+from ..utils import cli_datetime
 
 
 # The current Sentry client truncates string values at 512 characters. It
@@ -106,27 +105,11 @@ def output_results(statuses):
             sentry_sdk.capture_message(f'{message}\n{log_string}')
 
 
-def cli_time(date_string) -> datetime:
-    """
-    Parse a CLI argument that should represent a date/time or time delta from
-    now into a datetime
-    """
-    try:
-        # TODO: handle a unit specifier, e.g. "3d" for 3 days.
-        hours = float(date_string)
-        return datetime.now(timezone.utc) - timedelta(hours=hours)
-    except ValueError:
-        pass
-
-    return dateutil.parser.parse(date_string)
-
-
 def main():
     sentry_sdk.init()
-    default_from = datetime.now() - timedelta(days=3)
     parser = ArgumentParser()
-    parser.add_argument('--from', type=cli_time, default=default_from,
-                        dest='from_time',
+    parser.add_argument('--from', type=cli_datetime,
+                        default=cli_datetime('3d'), dest='from_time',
                         help='Check for captures later than this time.')
     parser.add_argument('--sample', type=int, default=10,
                         help='Sample this many URLs for captures.')


### PR DESCRIPTION
I frequently find myself making little tweaks to the constants in the healthcheck script when running it. This adds proper CLI options to let you specify a different sample size and timeframe so you don't have to change the code.