### PR TITLE
Allow limiting imports to one version per day

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -702,15 +702,18 @@ def _filter_unchanged_daily_versions(versions):
     for version in versions:
         hash_info = last_hashes.get(version['url'], {
             'hash': '',
-            'date': '2000-01-01'
+            'date': '1900-01-01',
+            'status': 900
         })
         if (
-            hash_info['hash'] != version['body_hash']
-            or hash_info['date'] != version['capture_time'][:10]
+            hash_info['date'] != version['capture_time'][:10]
+            # or hash_info['hash'] != version['body_hash']
+            or version['status'] < hash_info['status']
         ):
             last_hashes[version['url']] = {
                 'hash': version['body_hash'],
-                'date': version['capture_time'][:10]
+                'date': version['capture_time'][:10],
+                'status': version['status'],
             }
             yield version
 

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -724,6 +724,13 @@ def _filter_daily_versions(versions):
 
 
 def _filter_daily_cdx(records):
+    """
+    Filter CDX records to one per day per URL when possible. If all CDX
+    records for a given day have missing or 3xx status codes, we can't
+    meaningfully filter, so in that case this will let all CDX records through
+    for that day. When choosing the best record for the day, this will
+    prioritize the earliest, lowest status code (e.g. 200 instead of 400).
+    """
     url = ''
     day = None
     day_records = []


### PR DESCRIPTION
Some pages get captured a *lot* by the Internet Archive, and it’s not really necessary or valuable for us to import and track every one of those captures. Now you can set `--skip-unchanged day` to import at most one version per day (more-or-less; there are some cases where we might wind up importing more).

I’ve been using this when loading historical data for new URLs we track, but am not using it for our regular nightly imports of all URLs.