### PR TITLE
Make cchardet optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ commands:
         description: Install docs dependencies
         type: boolean
         default: false
+      install-extras:
+        type: string
+        default: ''
     steps:
       - checkout
       - restore_cache:
@@ -22,26 +25,22 @@ commands:
             - processing-{{ arch }}-<< parameters.python-version >>-v5-{{ checksum "pyproject.toml" }}
             - processing-{{ arch }}-<< parameters.python-version >>-v5-
 
-      # Bundle install dependencies
       - run:
           name: Install Dependencies
           command: |
+            extras='test'
+            if [[ -n '<< parameters.install-docs >>' ]]; then
+              extras="${extras},docs"
+            fi
+            if [[ -n '<< parameters.install-extras >>' ]]; then
+              extras="${extras},<< parameters.install-extras >>"
+            fi
+
             python -m venv ~/venv
             . ~/venv/bin/activate
             pip install --upgrade pip
-            pip install '.[test]'
+            pip install ".[${extras}]"
 
-      # Docs dependencies are only compatible on Python 3.10+, so only install
-      # them on demand.
-      - when:
-          condition: << parameters.install-docs >>
-          steps:
-            - run:
-                command: |
-                  . ~/venv/bin/activate
-                  pip install '.[test,docs]'
-
-      # Store bundle cache
       - save_cache:
           key: processing-{{ arch }}-<< parameters.python-version >>-v5-{{ checksum "pyproject.toml" }}
           paths:
@@ -52,6 +51,9 @@ jobs:
     parameters:
       python-version:
         type: string
+      extras:
+        type: string
+        default: ''
     working_directory: ~/web-monitoring-processing
     docker:
       - image: cimg/python:<< parameters.python-version >>
@@ -59,6 +61,7 @@ jobs:
       - checkout
       - setup_pip:
           python-version: << parameters.python-version >>
+          install-extras: << parameters.extras >>
       - run:
           name: Tests
           command: |
@@ -141,7 +144,11 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-version: ["3.10"]
+              python-version: ["3.10", "3.11", "3.12", "3.13"]
+              extras: ["", "cchardet"]
+            exclude:
+              - python-version: "3.13"
+                extras: "cchardet"
       - lint
       - docs
       - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
           name: Install Dependencies
           command: |
             extras='test'
-            if [[ -n '<< parameters.install-docs >>' ]]; then
+            if [[ '<< parameters.install-docs >>' == 'true' ]]; then
               extras="${extras},docs"
             fi
             if [[ -n '<< parameters.install-extras >>' ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN pip install --user --trusted-host pypi.python.org .
 ADD . /app
 
 # Install package.
-RUN pip install --user .
+RUN pip install --user '.[cchardet]'
 
 
 # Deployable Image w/out Build-Only Dependencies ------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "brotli ~=1.1.0",
-    "cchardet ==2.1.7",
+    "charset_normalizer ~=3.4.1",
     "cloudpathlib[s3] ~=0.20.0",
     "python-dateutil ~=2.9.0",
     "docopt ~=0.6.2",
@@ -35,6 +35,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cchardet = ["cchardet ==2.2.0a2"]
 # For developing the package (running tests, packaging, etc.) but not needed
 # for _using_ it. Some tooling requires newer Python versions than the package
 # itself (>=3.8). This depends on the `test` extra, which _does_ work on the

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -1,4 +1,3 @@
-import cchardet
 from cloudpathlib import S3Client, S3Path
 import codecs
 from datetime import datetime, timedelta, timezone
@@ -18,6 +17,11 @@ import sys
 import threading
 import time
 from typing import Generator, Iterable, TypeVar
+
+try:
+    from cchardet import detect as detect_charset
+except ImportError:
+    from charset_normalizer import detect as detect_charset
 
 
 logger = logging.getLogger(__name__)
@@ -74,11 +78,9 @@ def detect_encoding(content, headers, default='utf-8'):
 
     # Make an educated guess.
     if not encoding:
-        # try to identify encoding using cchardet. Use up to 18kb of the
-        # content for detection. Its not necessary to use the full content
-        # as it could be huge. Also, if you use too little, detection is not
-        # accurate.
-        detected = cchardet.detect(content[:18432])
+        # Try to identify encoding. Use up to 18kb of the content, since it
+        # could be huge otherwise (this should be enough for accuracy).
+        detected = detect_charset(content[:18432])
         if detected:
             detected_encoding = detected.get('encoding')
             if detected_encoding:


### PR DESCRIPTION
Cchardet is multiple orders of magnitude faster than chardet (and other similar pure Python tools for this purpose), which is why we chose to use it, but it later went unmaintained for several years. This has left us in a situation where we can no longer upgrade Python versions in a lot of our tools, since cchardet only works up to Python 3.10.

This makes cchardet an optional extra and otherwise uses charset_normalizer (which is pure Python, so should always work). This is a huge slowdown, but it appears we don't actually fall back to it very often in actual usage, so it's not the end of the world.

This also upgrades the version of cchardet we use to a pre-release. About a year ago, the maintainer started working on it again and released this preview release that seems to work alright up to Python 3.12. But it doesn't support Python 3.13 and work on it seems to have dropped off. Not sure what the real state of affairs is, so it's still best to keep this optional.