### PR TITLE
Drop docopt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: "web-monitoring-processing"
 dependencies:
 - beautifulsoup4
 - python-dateutil
-- docopt
 - lxml
 - requests
 - toolz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "charset_normalizer ~=3.4.1",
     "cloudpathlib[s3] ~=0.20.0",
     "python-dateutil ~=2.9.0",
-    "docopt ~=0.6.2",
     "lxml ~=5.3.0",
     "pypdf[crypto] ~=5.1.0",
     "PyYAML ~=6.0.2",


### PR DESCRIPTION
Docopt was a neat tool, but it imposed some weird constraints and edge cases on argument parsing and ordering, and extracting and parsing the values from it was often overcomplicated (even with argparse’s more verbose syntax, this is fewer lines overall because it does more parsing for us). The built-in argparse module doesn't have those issues and being built-in is nice.

This is mostly just some cleanup work I’ve been meaning to do for a while.