### PR TITLE
Hide progress bar for WARC import on non-TTY

### DIFF
--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -400,6 +400,9 @@ def main():
     parser.add_argument('--limit', type=int, help='Stop after this many records')
     parser.add_argument('--update', action='store_const', default='skip', const='replace',
                         help='Update existing records in DB instead of skipping')
+    parser.add_argument('--progress', action='store_true',
+                        help='Show progress bar (only for non-interactive '
+                             'sessions; it shows automatically on a TTY).')
     args = parser.parse_args()
 
     # TODO: we'll probably eventually want to support WARCs from IA or maybe
@@ -430,7 +433,8 @@ def main():
                 for version, body in versions)
 
     import_ids = []
-    with tqdm_logging_redirect(versions, total=total) as progress:
+    hide_progress = False if args.progress else None
+    with tqdm_logging_redirect(versions, total=total, disable=hide_progress) as progress:
         if args.dry_run:
             for version, _ in progress:
                 print(json.dumps(version))


### PR DESCRIPTION
The progress bar can be a useful indicator, but when we run this job batched on non-interactive sessions, it makes it hard to see the warnings and errors since they show up in the middle of progress output (on an actual TTY this is no big deal, the progress bar is only one line and warnings move it down instead of showing up in the middle).

We can get it back in cases where we might need it by passing `--progress`.