### PR TITLE
Reactivate Dependabot for Pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+
+  - package-ecosystem: pip
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Since this stuff is more actively maintained again, it’s probably time to turn Dependabot back on.