### PR TITLE
If `WEB_MONITORING_DB_URL` is empty, use default

### DIFF
--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -264,9 +264,9 @@ class Client:
         https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.Retry
         Default: ``(2, 2)``
     """
-    def __init__(self, email=None, password=None, url=DEFAULT_URL, timeout=None,
+    def __init__(self, email=None, password=None, url=None, timeout=None,
                  retries=None):
-        clean_url = url.rstrip('/')
+        clean_url = (url or DEFAULT_URL).rstrip('/')
         self._api_url = f'{clean_url}/api/v0'
         self._base_url = clean_url
         self._session = DbSession(retries=retries, timeout=timeout)


### PR DESCRIPTION
It's pretty common for env vars to be set to the empty string to imply that they are essentially unset, but it turns out we didn't support that for `WEB_MONITORING_DB_URL`. This adds support for it and cleans up our tests around the env vars a bit.

This is currently causing problems for Dependabot PRs downstream in the task-sheets project: https://github.com/edgi-govdata-archiving/web-monitoring-task-sheets/pull/30