### PR TITLE
Remove deprecated `list_*` methods on DB client

### DIFF
--- a/web_monitoring/cli/ia_healthcheck.py
+++ b/web_monitoring/cli/ia_healthcheck.py
@@ -24,14 +24,14 @@ def sample_monitored_urls(sample_size):
     list of string
     """
     client = db.Client.from_env()
-    page = client.list_pages(chunk=1, chunk_size=1, active=True, include_total=True)
-    url_count = page['meta']['total_results']
+    page = next(client.get_pages(chunk=1, chunk_size=1, active=True, include_total=True))
+    url_count = page['_list_meta']['total_results']
     return (get_page_url(client, index)
             for index in random.sample(range(url_count), sample_size))
 
 
 def get_page_url(client, index):
-    return client.list_pages(chunk=index, chunk_size=1, active=True)['data'][0]['url']
+    return next(client.get_pages(chunk=index, chunk_size=1, active=True))['url']
 
 
 def wayback_has_captures(url, from_date=None):

--- a/web_monitoring/db.py
+++ b/web_monitoring/db.py
@@ -352,70 +352,6 @@ WEB_MONITORING_DB_EMAIL was not. Make sure to neither or both!
 
     ### PAGES ###
 
-    def list_pages(self, *, chunk=None, chunk_size=None, sort=None,
-                   tags=None, maintainers=None, url=None, title=None,
-                   include_versions=None, include_earliest=None,
-                   include_latest=None, source_type=None, hash=None,
-                   start_date=None, end_date=None, active=None,
-                   include_total=False):
-        """
-        List all Pages, optionally filtered by search criteria.
-
-        Parameters
-        ----------
-        chunk : integer, optional
-            pagination parameter
-        chunk_size : integer, optional
-            number of items per chunk
-        sort : list of string, optional
-            fields to sort by in `{field}:{order}` format, e.g. `title:asc`
-        tags : list of string, optional
-        maintainers : list of string, optional
-        url : string, optional
-        title : string, optional
-        include_versions : boolean, optional
-        include_earliest : boolean, optional
-        include_latest : boolean, optional
-        source_type : string, optional
-            such as 'versionista' or 'internet_archive'
-        hash : string, optional
-            SHA256 hash of Version content
-        start_date : datetime, optional
-        end_date : datetime, optional
-        active : boolean, optional
-        include_total : boolean, optional
-            Whether to include a `meta.total_results` field in the response.
-            If not set, `links.last` will usually be empty unless you are on
-            the last chunk. Setting this option runs a pretty expensive query,
-            so use it sparingly. (Default: False)
-
-        Returns
-        -------
-        response : dict
-        """
-        warnings.warn('db.client.list_pages() has been deprecated. Please use '
-                      'db.client.get_pages().',
-                      DeprecationWarning)
-
-        params = {'chunk': chunk,
-                  'chunk_size': chunk_size,
-                  'sort': sort and ','.join(sort) or None,
-                  'tags[]': tags,
-                  'maintainers[]': maintainers,
-                  'url': url,
-                  'title': title,
-                  'include_versions': include_versions,
-                  'include_earliest': include_earliest,
-                  'include_latest': include_latest,
-                  'source_type': source_type,
-                  'hash': hash,
-                  'capture_time': _time_range_string(start_date, end_date),
-                  'active': active,
-                  'include_total': include_total or None}
-        url = '/pages'
-        result = self.request_json(GET, url, params=params)
-        return result
-
     def get_pages(self, *, chunk=None, chunk_size=None, sort=None,
                   tags=None, maintainers=None, url=None, title=None,
                   include_versions=None, include_earliest=None,
@@ -506,82 +442,6 @@ WEB_MONITORING_DB_EMAIL was not. Make sure to neither or both!
 
 
     ### VERSIONS ###
-
-    def list_versions(self, *, page_id=None, chunk=None, chunk_size=None,
-                      sort=None, start_date=None, end_date=None,
-                      source_type=None, hash=None,
-                      source_metadata=None, different=None,
-                      include_change_from_previous=None,
-                      include_change_from_earliest=None, include_total=False):
-        """
-        List Versions, optionally filtered by serach criteria, including Page.
-
-        Parameters
-        ----------
-        page_id : string, optional
-            restricts serach to Versions of a specific Page
-        chunk : integer, optional
-            pagination parameter
-        chunk_size : integer, optional
-            number of items per chunk
-        sort : list of string, optional
-            fields to sort by in `{field}:{order}` format,
-            e.g. `capture_time:asc`
-        start_date : datetime, optional
-        end_date : datetime, optional
-        source_type : string, optional
-            such as 'versionista' or 'internetarchive'
-        hash : string, optional
-            SHA256 hash of Version content
-        source_metadata : dict, optional
-            Examples:
-
-            * ``{'version_id': 12345678}``
-            * ``{'account': 'versionista1', 'has_content': True}``
-        different : boolean, optional
-            If False, include versions that aren't actually different from the
-            previous version of the same page in the response.
-        include_change_from_previous : boolean, optional
-            If True, include a `change_from_previous` field in each version
-            that represents a change object between it and the previous version
-            of the same page.
-        include_change_from_earliest : boolean, optional
-            If True, include a `change_from_earliest` field in each version
-            that represents a change object between it and the earliest version
-            of the same page.
-        include_total : boolean, optional
-            Whether to include a `meta.total_results` field in the response.
-            If not set, `links.last` will usually be empty unless you are on
-            the last chunk. Setting this option runs a pretty expensive query,
-            so use it sparingly. (Default: False)
-
-        Returns
-        -------
-        response : dict
-        """
-        warnings.warn('db.client.list_versions() has been deprecated. Please '
-                      'use db.client.get_versions().',
-                      DeprecationWarning)
-
-        params = {'chunk': chunk,
-                  'chunk_size': chunk_size,
-                  'sort': sort and ','.join(sort) or None,
-                  'capture_time': _time_range_string(start_date, end_date),
-                  'source_type': source_type,
-                  'hash': hash,
-                  'different': different,
-                  'include_change_from_previous': include_change_from_previous,
-                  'include_change_from_earliest': include_change_from_earliest,
-                  'include_total': include_total or None}
-        if source_metadata is not None:
-            for k, v in source_metadata.items():
-                params[f'source_metadata[{k}]'] = v
-        if page_id is None:
-            url = '/versions'
-        else:
-            url = f'/pages/{page_id}/versions'
-        result = self.request_json(GET, url, params=params)
-        return result
 
     def get_versions(self, *, page_id=None, chunk=None, chunk_size=None,
                      sort=None, start_date=None, end_date=None,
@@ -860,32 +720,6 @@ WEB_MONITORING_DB_EMAIL was not. Make sure to neither or both!
 
     ### CHANGES AND ANNOTATIONS ###
 
-    def list_changes(self, page_id, include_total=False):
-        """
-        List Changes between two Versions on a Page.
-
-        Parameters
-        ----------
-        page_id : string
-        include_total : bool, optional
-            Whether to include a `meta.total_results` field in the response.
-            If not set, `links.last` will usually be empty unless you are on
-            the last chunk. Setting this option runs a pretty expensive query,
-            so use it sparingly. (Default: False)
-
-        Returns
-        -------
-        response : dict
-        """
-        warnings.warn('db.client.list_changes() has been deprecated. Please '
-                      'use db.client.get_changes().',
-                      DeprecationWarning)
-
-        url = f'/pages/{page_id}/changes/'
-        result = self.request_json(
-            GET, url, params={'include_total': include_total or None})
-        return result
-
     def get_changes(self, page_id, include_total=False):
         """
         Iterate through a set of changes between any two versions of a page.
@@ -926,38 +760,6 @@ WEB_MONITORING_DB_EMAIL was not. Make sure to neither or both!
         url = (f'/pages/{page_id}/changes/'
                f'{from_version_id}..{to_version_id}')
         result = self.request_json(GET, url)
-        return result
-
-    def list_annotations(self, *, page_id, to_version_id, from_version_id='',
-                         include_total=False):
-        """
-        List Annotations for a Change between two Versions.
-
-        Parameters
-        ----------
-        page_id : string
-        to_version_id : string
-        from_version_id : string, optional
-            If from_version_id is not given, it will be treated as version
-            immediately prior to ``to_version``.
-        include_total : boolean, optional
-            Whether to include a `meta.total_results` field in the response.
-            If not set, `links.last` will usually be empty unless you are on
-            the last chunk. Setting this option runs a pretty expensive query,
-            so use it sparingly. (Default: False)
-
-        Returns
-        -------
-        response : dict
-        """
-        warnings.warn('db.client.list_annotations() has been deprecated. '
-                      'Please use db.client.get_annotations().',
-                      DeprecationWarning)
-
-        url = (f'/pages/{page_id}/changes/'
-               f'{from_version_id}..{to_version_id}/annotations')
-        result = self.request_json(
-            GET, url, params={'include_total': include_total or None})
         return result
 
     def get_annotations(self, *, page_id, to_version_id, from_version_id='',

--- a/web_monitoring/tests/test_db.py
+++ b/web_monitoring/tests/test_db.py
@@ -108,48 +108,6 @@ class TestFromEnv:
         assert client.get_page('x') == {'data': {'uuid': 'x'}}
 
 
-# DEPRECATED
-@db_vcr.use_cassette()
-def test_list_pages():
-    cli = Client(**AUTH)
-    res = cli.list_pages()
-    assert res['data']
-
-    # Test datetimes are parsed correctly.
-    assert isinstance(res['data'][0]['created_at'], datetime)
-    assert isinstance(res['data'][0]['updated_at'], datetime)
-
-    # Test chunk query parameters.
-    res = cli.list_pages(chunk_size=2)
-    assert len(res['data']) == 2
-    res = cli.list_pages(chunk_size=5)
-    assert len(res['data']) == 5
-
-    # Test filtering query parameters.
-    res = cli.list_pages(url='__nonexistent__')
-    assert len(res['data']) == 0
-    res = cli.list_pages(url=URL)
-    assert len(res['data']) > 0
-    res = cli.list_pages(tags=['__nonexistent__'])
-    assert len(res['data']) == 0
-    res = cli.list_pages(tags=[SITE])
-    assert len(res['data']) > 0
-    res = cli.list_pages(maintainers=['__nonexistent__'])
-    assert len(res['data']) == 0
-    res = cli.list_pages(maintainers=[AGENCY])
-    assert len(res['data']) > 0
-
-    # Test relations
-    res = cli.list_pages(include_earliest=True)
-    assert all(['earliest' in page for page in res['data']]) is True
-    assert isinstance(res['data'][0]['earliest']['created_at'], datetime)
-    assert isinstance(res['data'][0]['earliest']['updated_at'], datetime)
-    res = cli.list_pages(include_latest=True)
-    assert all(['latest' in page for page in res['data']]) is True
-    assert isinstance(res['data'][0]['latest']['created_at'], datetime)
-    assert isinstance(res['data'][0]['latest']['updated_at'], datetime)
-
-
 @db_vcr.use_cassette()
 def test_get_pages():
     cli = Client(**AUTH)
@@ -220,33 +178,11 @@ def test_get_page():
     assert res['data']['uuid'] == PAGE_ID
 
 
-# DEPRECATED
-@db_vcr.use_cassette()
-def test_list_page_versions():
-    cli = Client(**AUTH)
-    res = cli.list_versions(page_id=PAGE_ID)
-    assert all([v['page_uuid'] == PAGE_ID for v in res['data']])
-
-
 @db_vcr.use_cassette()
 def test_get_versions_for_page():
     cli = Client(**AUTH)
     versions = cli.get_versions(page_id=PAGE_ID)
     assert all(v['page_uuid'] == PAGE_ID for v in versions)
-
-
-# DEPRECATED
-@db_vcr.use_cassette()
-def test_list_versions():
-    cli = Client(**AUTH)
-    res = cli.list_versions()
-    assert res['data']
-
-    # Test relations
-    res = cli.list_versions(include_change_from_previous=True)
-    assert all(['change_from_previous' in item for item in res['data']]) is True
-    res = cli.list_versions(include_change_from_earliest=True)
-    assert all(['change_from_earliest' in item for item in res['data']]) is True
 
 
 @db_vcr.use_cassette()
@@ -423,14 +359,6 @@ def test_monitor_import_statuses_returns_errors():
                            "not match expected hash (hash_placeholder)"]}
 
 
-# DEPRECATED
-@db_vcr.use_cassette()
-def test_list_changes():
-    cli = Client(**AUTH)
-    # smoke test
-    cli.list_changes(PAGE_ID)
-
-
 @db_vcr.use_cassette()
 def test_get_changes():
     cli = Client(**AUTH)
@@ -447,15 +375,6 @@ def test_get_change():
     # smoke test
     cli.get_change(page_id=PAGE_ID,
                    to_version_id=TO_VERSION_ID)
-
-
-# DEPRECATED
-@db_vcr.use_cassette()
-def test_list_annotations():
-    cli = Client(**AUTH)
-    # smoke test
-    cli.list_annotations(page_id=PAGE_ID,
-                         to_version_id=TO_VERSION_ID)
 
 
 @db_vcr.use_cassette()


### PR DESCRIPTION
These have been deprecated for years; we should stop carrying this baggage around.