### PR TITLE
Disable stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,0 @@
-_extends: .github


### PR DESCRIPTION
The stale issue bot was added many years ago to help manage the influx of a lot of ideas and brainstorming against a small implementation team. Today, the web-monitoring tools mostly just have one maintainer (me) and are not flooded with a lot of issues and ideas. Long-lived issues are more common, and they are helpful for me to keep track of things over the slow pace and timeframe in which I can individually address stuff. Stale bot feels like it is getting more in the way than helping in the current moment (it's also deprecated!). So, I’m disabling it.

Context: Stale bot seems to have been dead for a while (I actually thought we’d disabled it), but it seems to have woken up yesterday and marked a huge pile of issues as stale across a whole lot of repos.