### PR TITLE
Clean up child processes in `QuitSignal`

### DIFF
--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import logging
 import lxml.html
+import multiprocessing
 import os
 from pypdf import PdfReader
 from pypdf.errors import PyPdfError
@@ -409,9 +410,9 @@ class QuitSignal(Signal):
             self.event.set()
         else:
             print(self.final_message, file=sys.stderr, flush=True)
-            # Clean up any child processes, otherwise they might be left alive.
             for child in multiprocessing.active_children():
                 child.terminate()
+
             os._exit(128 + signal_type)
 
     def stop_iteration(self, iterable: Iterable[T]) -> Generator[T, None, None]:


### PR DESCRIPTION
Things upstreams some (very old!) [signal handling improvements from the task-sheets project](https://github.com/edgi-govdata-archiving/web-monitoring-task-sheets/blob/bd77d9dbfb07188bbb2a10cfae91022f5485e74b/analyst_sheets/tools.py#L311-L362). Not sure why that took so long.

Also includes a separate, old lesson-learned about correct return codes for signal handling failures.