### PR TITLE
Don't add PRs to project via actions

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,10 +6,10 @@ on:
       - opened
       - reopened
       - transferred
-  pull_request:
-    types:
-      - opened
-      - reopened
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Experimenting with some added project tooling we have now that we are on an officially supported non-profit org account. We may no longer need actions workflows to add to projects.