### PR TITLE
Be more careful writing to S3 hash store

### DIFF
--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -502,10 +502,13 @@ class S3HashStore:
         if not content_type:
             content_type = 'application/octet-stream'
 
-        archive = S3Path(f's3://{self.bucket}', client=S3Client(extra_args={
-            **self.extra_args,
-            'ContentType': content_type
-        }))
+        archive = S3Path(f's3://{self.bucket}', client=S3Client(
+            file_cache_mode='close_file',
+            extra_args={
+                **self.extra_args,
+                'ContentType': content_type
+            },
+        ))
         path = archive / hash
 
         upload = False

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -520,6 +520,11 @@ class S3HashStore:
                 data = gzip.compress(data)
             if not self.dry_run:
                 written = path.write_bytes(data)
+                # Double-check that we wrote everything we tried to. This might
+                # be an unnecessary check, but it's possible it might save us
+                # from some weird edge-cases related to how cloudpathlib uses
+                # the local disk as an intermediary cache:
+                # https://github.com/edgi-govdata-archiving/web-monitoring-processing/issues/929
                 if written != len(data):
                     raise RuntimeError(
                         f'S3 write failure: only wrote {written} of '

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -519,7 +519,12 @@ class S3HashStore:
             if self.gzip:
                 data = gzip.compress(data)
             if not self.dry_run:
-                path.write_bytes(data)
+                written = path.write_bytes(data)
+                if written != len(data):
+                    raise RuntimeError(
+                        f'S3 write failure: only wrote {written} of '
+                        f'{len(data)} bytes to S3'
+                    )
 
         return path.as_url()
 


### PR DESCRIPTION
In #929, we had some mysterious issues around response bodies silently failing to write to the S3 hash store for a few weeks. I’m not entirely sure of the cause (no good logs or telemetry, no exceptions), but I suspect it was a resource starvation issue, since it seemed to be alleviated around the time we deployed a new release, and I vaguely recall killing the import job that was in process and letting a new one start automatically a few hours later with the new code.

This does two things to try and better handle resource issues, although both are a little speculative:

1. Tell cloudpathlib to automatically clear its on-disk cache immediately after writing. We don’t really need that cache for our use cases, and it’s very possible the cache could be filling the disk.

2. Double-check that the number bytes written to the S3 buffer (i.e. the on-disk cache) before uploading matched the number of bytes we tried to write, and raise an exception if they don’t match.
 
    I thought Python would have already raised an exception in this circumstance,, but it’s also possible that on a full disk it does not, and just returns zero. This is really speculative, and I’m not *entirely* sure it’s doing anything useful, but don’t really have time for deeper or more extensive testing. This code is more CYA than anything else.

For now, I’m treating this as fixing #929.