### PR TITLE
Don't use `resolve_revisits` in CDX search

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -791,7 +791,8 @@ def _list_ia_versions_for_urls(url_patterns, from_date, to_date,
                 break
 
             ia_versions = client.search(url, from_date=from_date,
-                                        to_date=to_date, limit=1000)
+                                        to_date=to_date, limit=1000,
+                                        resolve_revisits=False)
             try:
                 for version in ia_versions:
                     if stop and stop.is_set():

--- a/web_monitoring/cli/ia_healthcheck.py
+++ b/web_monitoring/cli/ia_healthcheck.py
@@ -47,7 +47,8 @@ def wayback_has_captures(url, from_date=None):
     list of JSON
     """
     with WaybackClient() as wayback:
-        versions = wayback.search(url, from_date=from_date, limit=1)
+        versions = wayback.search(url, from_date=from_date, limit=1,
+                                  resolve_revisits=False)
         try:
             next(versions)
         except StopIteration:


### PR DESCRIPTION
I had a *hugely* useful discussion with some folks over at Internet Archive today about changes to the CDX & timemap APIs, and one lesson learned in there is that `resolve_revisits` can be a bit of a problem. We don't *really* need it for our use cases, but it gets set to `True` by default. This turns it off for hopefully better and more stable performance and behavior.

As a separate matter, I need to summarize those notes and post some updates over in https://github.com/edgi-govdata-archiving/wayback. Obviously the next release over there with breaking changes needs to switch this default!