### PR TITLE
Allow using IA "timemap" API for CDX search

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -1050,6 +1050,13 @@ def main():
     ))
     args = parser.parse_args()
 
+    # HACK: Allow testing out performance/stability of old CDX vs. "new"
+    # timemap CDX APIs. They *should* got to the same service, but anecdotally
+    # appear to perform differently.
+    if os.getenv('WAYBACK_USE_TIMEMAP_CDX', '').lower() in ('true', 't', '1'):
+        wayback._client.CDX_SEARCH_URL = 'https://web.archive.org/web/timemap/cdx'
+        logger.warning('Using /web/timemap/cdx API for Wayback searches')
+
     if args.command == 'import-ia':
         unplaybackable_path = _parse_path(args.unplaybackable)
         if not args.dry_run:


### PR DESCRIPTION
It turns out that the v2 rewrite of CDX search was finally completed a while ago, and it replaced the old CDX search. At this point, `/cdx/search/cdx` and `/web/timemap/cdx` are supposed to be pointing to the same service behind the scenes. However, the `/web/timemap/cdx` anecdotally feels more reliable and faster whenever I try it, so this makes it possible to switch over to it on an ad-hoc basis for trialing things. Sort of a follow-on to #940.