### PR TITLE
HOTFIX: Versions with no status

### DIFF
--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -742,7 +742,7 @@ def estimate_version_quality(version: dict[str, Any]) -> float:
     return estimate_snapshot_quality(
         url=version['url'],
         timestamp=timestamp,
-        status=version['status'] or (600 if version['network_error'] else 200),
+        status=version['status'] or (600 if version.get('network_error') else 200),
         headers=version['headers'] or {},
         content_length=version['content_length'],
         media_type=version['media_type'],

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -742,7 +742,7 @@ def estimate_version_quality(version: dict[str, Any]) -> float:
     return estimate_snapshot_quality(
         url=version['url'],
         timestamp=timestamp,
-        status=version['status'],
+        status=version['status'] or (600 if version['network_error'] else 200),
         headers=version['headers'] or {},
         content_length=version['content_length'],
         media_type=version['media_type'],


### PR DESCRIPTION
Make sure we can handle versions with no status code. These days, that’s usually because they are a network error, but on much older versions, that was because we didn’t have or didn’t record exact status codes from some sources.