### PR TITLE
Upgrade VCR to v8.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
 dependencies = [
-    # HACK: Warcio depends on aiohttp (any version), but VCR is not yet
-    # compatible with v3.14.x. This is just a hack to make sure we have a
-    # working setup for tests.
-    # https://github.com/kevin1024/vcrpy/pull/996
-    "aiohttp ~=3.13.0",
     "brotli ~=1.2.0",
     "charset_normalizer ~=3.4.1",
     "cloudpathlib[s3] >=0.23,<0.25",
@@ -62,7 +57,7 @@ test = [
     "coverage >=7.13.1,<7.15.0",
     "pyflakes ~=3.4.0",
     "pytest ~=9.0.1",
-    "vcrpy ~=8.1.0",
+    "vcrpy ~=8.2.0",
     "requests-mock ~=1.12.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "coverage >=7.13.1,<7.15.0",
     "pyflakes ~=3.4.0",
     "pytest ~=9.0.1",
-    "vcrpy ~=8.2.0",
+    "vcrpy ~=8.2.1",
     "requests-mock ~=1.12.1",
 ]
 


### PR DESCRIPTION
This speculatively upgrades the version of VCR we use to v8.2.0, which should fix the aiohttp incompatibility we previously had a hack for (this also removes the hack).

Release notes: https://github.com/kevin1024/vcrpy/releases/tag/v8.2.0