### PR TITLE
HOTFIX: new `print_info()` cannot flush

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -558,7 +558,7 @@ def _version_cache_key(time, url):
 
 
 def _load_known_versions(client, start_date, end_date):
-    print_info('Pre-checking known versions...', flush=True)
+    print_info('Pre-checking known versions...')
 
     versions = client.get_versions(start_date=start_date,
                                    end_date=end_date,


### PR DESCRIPTION
I recently added a `print_info()` function to the IA import script to control the logging of "normal" informational output, so it goes to the right output stream and also coordinates with tqdm. But I forgot that one of these calls includes an explicit flush. I don't think that was ever actually needed, and was more an issue with general Python output buffering on non-TTY streams. So I've simply removed it.