### PR TITLE
Clean up syntax in estimate_snapshot_quality

### DIFF
--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -606,10 +606,7 @@ def estimate_snapshot_quality(
     no_cache = False
     if 'cache-control' in headers:
         cache_control = headers['cache-control'].lower()
-        if 'no-cache' in cache_control:
-            no_cache = True
-        elif 'max-age=0' in cache_control:
-            no_cache = True
+        no_cache = 'no-cache' in cache_control or 'max-age=0' in cache_control
     if no_cache is False and 'expires' in headers:
         expires = dateutil.parser.parse(headers['expires'])
         request_time = (


### PR DESCRIPTION
This is just a slight tweak to remove duplicate logic branches. Rubocop tipped me off to this when porting it to Ruby, and I've brough that fix back here.

I’m not really sure if it was just a mistake that I wrote it this way originally, or how exactly it got into this situation, since it seems surprising to have had these two very obvious duplicates right next to each other. 🤷🏻 