### PR TITLE
Make LOG_LEVEL only apply to loggers in this codebase

### DIFF
--- a/web_monitoring/__init__.py
+++ b/web_monitoring/__init__.py
@@ -1,11 +1,5 @@
-import logging
-import os
 from ._version import __version__, __version_tuple__  # noqa: F401
 
 # Satisfy pyflakes
 assert __version__
 assert __version_tuple__
-
-
-if os.environ.get('LOG_LEVEL'):
-    logging.basicConfig(level=os.environ['LOG_LEVEL'].upper())

--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -398,9 +398,9 @@ class AuthorNameMapper:
 
 def main():
     from argparse import ArgumentParser
+    from ..logging import configure_logging
 
-    log_level = os.getenv('LOG_LEVEL', 'INFO')
-    logging.basicConfig(level=log_level)
+    configure_logging()
 
     parser = ArgumentParser(description='Add analyst annotations from a csv file to the Web Monitoring db.')
     parser.add_argument('csv_path', help='Path to CSV to read annotations from.')

--- a/web_monitoring/cli/annotations_import.py
+++ b/web_monitoring/cli/annotations_import.py
@@ -4,7 +4,6 @@ from dataclasses import asdict, dataclass
 import json
 import logging
 import math
-import os
 import re
 from time import sleep
 from tqdm import tqdm

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -570,7 +570,7 @@ def _load_known_versions(client, start_date, end_date):
     limited_versions = islice(versions, 500_000)
     cache = set(_version_cache_key(v["capture_time"], v.get("url", v.get("capture_url")))
                 for v in limited_versions)
-    logger.debug(f'  Found {len(cache)} known versions')
+    logger.info(f'  Found {len(cache)} known versions')
     return cache
 
 

--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -62,6 +62,7 @@ import threading
 from typing import Generator, Iterable
 import time
 from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
 from urllib.parse import urlsplit
 from web_monitoring import db
 import wayback
@@ -1038,6 +1039,9 @@ def validate_db_credentials():
 
 def main():
     from argparse import ArgumentParser
+    from ..logging import configure_logging
+
+    configure_logging()
 
     sentry_sdk.init()
     # This script does a lot of iterative, async processing across threads,
@@ -1108,30 +1112,31 @@ def main():
             }, dry_run=args.dry_run)
 
         start_time = datetime.now(tz=timezone.utc)
-        if args.url == 'active-pages':
-            import_ia_db_urls(
-                from_date=args._from,
-                to_date=args.to,
-                maintainers=args.maintainer,
-                tags=args.tag,
-                skip_unchanged=args.skip_unchanged,
-                url_pattern=args.pattern,
-                worker_count=args.parallel,
-                unplaybackable_path=unplaybackable_path,
-                dry_run=args.dry_run,
-                precheck_versions=args.precheck,
-                archive_storage=archive_storage)
-        else:
-            import_ia_urls(
-                urls=[args.url],
-                maintainers=args.maintainer,
-                tags=args.tag,
-                from_date=args._from,
-                to_date=args.to,
-                skip_unchanged=args.skip_unchanged,
-                unplaybackable_path=unplaybackable_path,
-                dry_run=args.dry_run,
-                archive_storage=archive_storage)
+        with logging_redirect_tqdm():
+            if args.url == 'active-pages':
+                import_ia_db_urls(
+                    from_date=args._from,
+                    to_date=args.to,
+                    maintainers=args.maintainer,
+                    tags=args.tag,
+                    skip_unchanged=args.skip_unchanged,
+                    url_pattern=args.pattern,
+                    worker_count=args.parallel,
+                    unplaybackable_path=unplaybackable_path,
+                    dry_run=args.dry_run,
+                    precheck_versions=args.precheck,
+                    archive_storage=archive_storage)
+            else:
+                import_ia_urls(
+                    urls=[args.url],
+                    maintainers=args.maintainer,
+                    tags=args.tag,
+                    from_date=args._from,
+                    to_date=args.to,
+                    skip_unchanged=args.skip_unchanged,
+                    unplaybackable_path=unplaybackable_path,
+                    dry_run=args.dry_run,
+                    archive_storage=archive_storage)
 
         end_time = datetime.now(tz=timezone.utc)
         print_info(f'Completed at {end_time.isoformat()}')

--- a/web_monitoring/cli/ia_healthcheck.py
+++ b/web_monitoring/cli/ia_healthcheck.py
@@ -11,6 +11,7 @@ import sentry_sdk
 import sys
 from wayback import WaybackClient
 from .. import db
+from ..logging import configure_logging
 from ..utils import cli_datetime
 
 
@@ -96,6 +97,7 @@ def output_results(statuses):
 
 
 def main():
+    configure_logging()
     sentry_sdk.init()
     parser = ArgumentParser()
     parser.add_argument('--from', type=cli_datetime,

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -18,6 +18,7 @@ from warcio.recordloader import ArcWarcRecord, StatusAndHeadersParser, StatusAnd
 import yaml
 from .. import db
 from .. import utils
+from ..logging import configure_logging
 from ..media import HTML_MEDIA_TYPES, PDF_MEDIA_TYPES, find_media_type
 from ..utils import S3HashStore, detect_encoding, matchable_url, normalize_url
 
@@ -432,6 +433,7 @@ def preupload(storage: S3HashStore, version: dict, body: bytes) -> tuple[dict, b
 
 
 def main():
+    configure_logging()
     sentry_sdk.init()
 
     parser = ArgumentParser()

--- a/web_monitoring/logging.py
+++ b/web_monitoring/logging.py
@@ -1,0 +1,17 @@
+import logging
+import os
+
+
+def configure_logging():
+    # Keep config simple by using basicConfig for the root logger and adding a
+    # special level for *our* logs. In the future we may need something more
+    # complex like dictConfig.
+    level = (os.environ.get('LOG_LEVEL') or 'WARNING').upper()
+    root_level = level if level in ('WARNING', 'ERROR', 'CRITICAL') else 'WARNING'
+
+    logging.basicConfig(
+        level=root_level,
+        style='{',
+        format='{asctime} {levelname} [{name}] {message}',
+    )
+    logging.getLogger('web_monitoring').setLevel(level)


### PR DESCRIPTION
Setting `LOG_LEVEL` previously applied to all loggers from all loaded modules, including third-party packages. That was ok for some, but excessive for most. This changes logging to only apply to loggers from our own application code.

It also adjusts the logging to use a more logfile-friendly (rather than interactive output-friendly) format with more metadata, and to work a little more nicely with TQDM.

There is a probably a bunch more to be improved and cleaned up with how logs are done in this app, but this is already a hugely useful improvement.