### PR TITLE
Sentry metrics cleanup

### DIFF
--- a/web_monitoring/cli/cli.py
+++ b/web_monitoring/cli/cli.py
@@ -369,9 +369,10 @@ class WaybackRecordsWorker(threading.Thread):
         """
         memento = self.wayback.get_memento(record, exact_redirects=False)
         with memento:
-            with sentry_sdk.start_span(op='memento.format'):
+            with sentry_sdk.start_span(op='memento.format') as span:
                 version = self.format_memento(memento, record, self.maintainers,
                                               self.tags)
+                span.set_data('memento.url', version['url'])
 
             quality = utils.estimate_version_quality(version)
             if quality < MINIMUM_QUALITY:

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -215,11 +215,11 @@ def each_redirect_chain(warcs: list[str], seeds: set[str]) -> Generator[Redirect
     # This only supports one warcinfo record per WARC; not technically correct.
     warc_infos: dict[str, dict[str, Any]] = {}
 
-    with sentry_sdk.start_transaction(op='warc.index_all') as index_span:
+    with sentry_sdk.start_transaction(op='warc.index_all', name='Index WARC files') as index_span:
         index_bytes = 0
 
         for warc in warcs:
-            with sentry_sdk.start_span(op='warc.index') as span:
+            with sentry_sdk.start_span(op='warc.index', name='Index single WARC file') as span:
                 warc_path = Path(warc).absolute()
                 warc_info: dict[str, Any] = {'warc_name': warc_path.name}
                 warc_infos[warc] = warc_info
@@ -391,7 +391,6 @@ def each_redirect_chain(warcs: list[str], seeds: set[str]) -> Generator[Redirect
                 yield chain
 
     for result, count in seed_results.items():
-        # sentry_sdk.metrics.count(f'warc_seeds.{result}', count)
         sentry_sdk.metrics.count('warc.seeds', count, unit='count', attributes={'result': result})
         logger.info(f'warc.seeds: {count}, result: {result}')
 

--- a/web_monitoring/cli/warc_import.py
+++ b/web_monitoring/cli/warc_import.py
@@ -329,7 +329,9 @@ def each_redirect_chain(warcs: list[str], seeds: set[str]) -> Generator[Redirect
             # not other sources that may have been collected differently.
             chain = RedirectChain()
 
-            with sentry_sdk.start_span(op='warc.load_seed'):
+            with sentry_sdk.start_span(op='warc.load_seed') as span:
+                span.set_data('seed.url', seed)
+
                 next_url = seed
                 next_timestamp = datetime(1, 1, 1, tzinfo=timezone.utc)
                 seen_entries = []
@@ -396,7 +398,8 @@ def each_redirect_chain(warcs: list[str], seeds: set[str]) -> Generator[Redirect
 
 
 def format_version(chain: RedirectChain) -> dict:
-    with sentry_sdk.start_span(op='warc.format'):
+    with sentry_sdk.start_span(op='warc.format') as span:
+        span.set_data('seed.url', chain.requests[0].url)
         return format_version_impl(chain)
 
 

--- a/web_monitoring/utils.py
+++ b/web_monitoring/utils.py
@@ -514,6 +514,10 @@ class S3HashStore:
         self.dry_run = dry_run
 
     def store(self, data: bytes, hash: str = '', content_type: str = '') -> str:
+        with sentry_sdk.start_span(op='hash_store.store', name='Store data in hash store'):
+            return self._store(data, hash, content_type)
+
+    def _store(self, data: bytes, hash: str = '', content_type: str = '') -> str:
         if not hash:
             hash = hash_content(data)
 


### PR DESCRIPTION
This is a bit of cleanup following #963.

- Ensure all transactions have names. I thought missing names would just fall back to the `op` name in the Sentry UI, but that's only the case in some places. In others (like notification e-mails) you just get `<unlabeled transaction>`. Not helpful!
- Add more attributes to the various spans to help with more detailed sorting.
- Instrument `S3HashStore`.

Part of https://github.com/edgi-govdata-archiving/web-monitoring/issues/204.